### PR TITLE
feat: add Unity CLI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
-# skills
-Public slack channel: [#devs-unity-hub](https://unity.slack.com/messages/C7MKBJ34G/) <br/>
-[View this project in Unity Internal Developer Portal](https://developer.portal.internal.unity.com/catalog/default/component/skills) <br/>
-# Converting to public repository
-Any and all Unity software of any description (including components) (1) whose source is to be made available other than under a Unity source code license or (2) in respect of which a public announcement is to be made concerning its inner workings, may be licensed and released only upon the prior approval of Legal.
+# Unity Skills
+
+A collection of reusable AI agent skills for Unity workflows. Compatible with Claude Code, GitHub Copilot, Cursor, Cline, and [50+ other agents](https://skills.sh).
+
+## Install
+
+```bash
+npx skills add Unity-Technologies/skills
+```
+
+## Available skills
+
+| Skill | Description |
+|---|---|
+| `cli` | Interact with the Unity CLI — install editors, manage projects, run builds, check auth, and more |
+
+## Usage
+
+Once installed, your agent will automatically use the relevant skill when you ask it to perform Unity CLI operations. For example:
+
+> "Install Unity 6000.0.47f1 with the Android module"
+> "List my registered projects"
+> "Run the project in headless mode"
+
+## Contributing
+
+Skills live in the `skills/` directory as Markdown files. Internal contributors: [#devs-unity-hub](https://unity.slack.com/messages/C7MKBJ34G/)

--- a/skills/cli.md
+++ b/skills/cli.md
@@ -58,6 +58,19 @@ These work on every command:
 
 **Always use `--format json` when you need to parse output programmatically.**
 
+## Getting help
+
+If a command fails or you're unsure of the available options, append `-h` or `--help` to any command or subcommand:
+
+```bash
+unity --help
+unity install --help
+unity projects --help
+unity projects create --help
+```
+
+This works at every level of the command hierarchy.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/skills/cli.md
+++ b/skills/cli.md
@@ -1,0 +1,622 @@
+---
+name: cli
+description: Use when interacting with Unity CLI from the terminal — install or uninstall editors, list or open projects, manage modules, check auth status, read logs, browse Unity releases, or run any other Unity CLI operation.
+allowed-tools:
+  - Bash
+---
+
+# Unity CLI
+
+## Step 1: Install the CLI (if not already installed)
+
+First check if the CLI is available:
+
+```bash
+which unity && unity --version
+```
+
+If not found, install it:
+
+**macOS / Linux**
+```bash
+curl -fsSL https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.sh | UNITY_CLI_CHANNEL=beta bash
+```
+
+**Windows (PowerShell)**
+```powershell
+$env:UNITY_CLI_CHANNEL='beta'; irm https://public-cdn.cloud.unity3d.com/hub/prod/cli/install.ps1 | iex
+```
+
+After installing, open a new shell so `unity` is on PATH, then verify:
+
+```bash
+unity --version
+```
+
+If the install script fails or the binary is still not found, tell the user and stop.
+
+## Step 2: Verify it works
+
+```bash
+unity --version
+```
+
+If this fails with a permissions error or crash, the CLI installation may be broken. Suggest re-running the install script.
+
+---
+
+## Global flags
+
+These work on every command:
+
+| Flag | Description |
+|---|---|
+| `--format <fmt>` | Output format: `human` (default), `json`, `tsv`. Also via `UNITY_FORMAT` env var. |
+| `--no-banner` | Suppress the branded header — use in scripts |
+| `--non-interactive` | Disable all interactive prompts — use in CI |
+| `--quiet` | Suppress non-essential output |
+
+**Always use `--format json` when you need to parse output programmatically.**
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error |
+| 2 | Bad arguments |
+| 3 | Authentication failure |
+| 6 | Command-specific failure |
+| 130 | Interrupted (Ctrl+C) |
+
+---
+
+## Commands
+
+### Auth
+
+```bash
+# Check login status
+unity auth status --format json
+
+# Login (opens browser for OAuth)
+unity auth login
+
+# Logout
+unity auth logout
+```
+
+---
+
+### Editors — list, install, uninstall
+
+```bash
+# List all editors (installed + available releases)
+unity editors --format json
+
+# List only installed editors
+unity editors --installed --format json
+
+# List only available releases
+unity editors --releases --format json
+
+# Filter by architecture
+unity editors --installed --architecture arm64 --format json
+
+# Show detailed module info
+unity editors --verbose
+
+# Watch mode — live-updates as editors are installed or removed
+unity editors --watch
+unity editors --installed --watch
+```
+
+#### editors add
+
+Register an existing editor installation by path:
+
+```bash
+unity editors add /path/to/Unity/Editor
+```
+
+#### editors default
+
+```bash
+# Show current default editor
+unity editors default --format json
+
+# Set default by version, alias, or keyword
+unity editors default 6000.0.47f1
+unity editors default latest
+unity editors default lts
+
+# Clear the default
+unity editors default --unset
+```
+
+On a TTY with no arguments, shows an interactive selection prompt.
+
+#### editors install-path
+
+```bash
+# Show current editor install path
+unity editors install-path
+
+# Set a new install path
+unity editors install-path --set /path/to/editors
+```
+
+Also available as the top-level `unity install-path` (with an additional `--get` flag).
+
+#### editors info
+
+```bash
+# Show release details for a specific version
+unity editors info 6000.0.47f1 --format json
+```
+
+---
+
+### Install
+
+```bash
+# Install an editor (interactive version selection if omitted)
+unity install 6000.0.47f1
+
+# Install with specific modules
+unity install 6000.0.47f1 --module windows-mono --module android
+
+# Install a specific changeset by hash
+unity install 6000.0.47f1 --changeset abc123def456
+
+# Include child modules
+unity install 6000.0.47f1 --cm
+
+# Exclude child modules
+unity install 6000.0.47f1 --no-cm
+
+# Install and accept EULAs automatically (CI)
+unity install 6000.0.47f1 --yes --accept-eula
+
+# Force reinstall even if already present
+unity install 6000.0.47f1 --force
+
+# Resume an interrupted download
+unity install 6000.0.47f1 --resume
+
+# Dry-run: show what would be installed without doing it
+unity install 6000.0.47f1 --dry-run --format json
+```
+
+### Uninstall
+
+```bash
+# Uninstall an editor version
+unity uninstall 6000.0.47f1 --yes
+
+# Uninstall a specific architecture
+unity uninstall 6000.0.47f1 --architecture arm64 --yes
+```
+
+---
+
+### Modules — add/list per editor
+
+```bash
+# List modules for an installed editor
+unity modules list 6000.0.47f1 --format json
+
+# Filter by architecture
+unity modules list 6000.0.47f1 --architecture arm64 --format json
+```
+
+### install-modules
+
+```bash
+# List available modules without installing
+unity install-modules --editor-version 6000.0.47f1 --list
+
+# Install specific modules
+unity install-modules --editor-version 6000.0.47f1 --module android --module ios
+
+# Install all available modules
+unity install-modules --editor-version 6000.0.47f1 --all --yes
+
+# Include child modules (default behaviour)
+unity install-modules --editor-version 6000.0.47f1 --module android --cm
+
+# Exclude child modules
+unity install-modules --editor-version 6000.0.47f1 --module android --no-cm
+
+# Accept EULAs and dry-run
+unity install-modules --editor-version 6000.0.47f1 --all --accept-eula --dry-run
+```
+
+`--list` and `--all` are mutually exclusive. `--list` is also mutually exclusive with `--module`.
+
+---
+
+### Projects — list, open, create, register
+
+```bash
+# List registered projects
+unity projects list --format json
+
+# Register an existing project
+unity projects add /path/to/MyProject
+
+# Remove from registry (does not delete files)
+unity projects remove /path/to/MyProject
+
+# Show project details
+unity projects info /path/to/MyProject --format json
+
+# Open a project in the editor
+unity open /path/to/MyProject
+
+# Open with a specific editor version
+unity open /path/to/MyProject --editor-version 6000.0.47f1
+
+# Pass extra Unity arguments
+unity open /path/to/MyProject --args "-logFile output.log"
+
+# Version shorthand (equivalent to open with --editor-version)
+unity 6000.0.47f1 /path/to/MyProject
+```
+
+#### projects create
+
+Create a project at a given path (non-interactive):
+
+```bash
+unity projects create /path/to/NewProject --editor-version 6000.0.47f1 --template com.unity.template.3d
+```
+
+#### projects new
+
+Interactive project creation wizard:
+
+```bash
+# Launch interactive wizard (prompts for path, editor version, template)
+unity projects new
+
+# Pre-fill options to skip individual prompts
+unity projects new --path /path/to/NewProject --editor-version 6000.0.47f1 --template com.unity.template.3d
+
+# Open the project immediately after creation
+unity projects new --open
+```
+
+#### projects pin / unpin
+
+```bash
+# Pin a project to the top of the list
+unity projects pin /path/to/MyProject
+
+# Unpin
+unity projects unpin /path/to/MyProject
+```
+
+#### projects require
+
+Ensure the editor version required by a project is installed, installing it if needed:
+
+```bash
+unity projects require /path/to/MyProject --yes
+```
+
+On a TTY with no path, prompts interactively.
+
+#### projects upgrade
+
+Upgrade a project to a different Unity editor version:
+
+```bash
+unity projects upgrade /path/to/MyProject --yes
+```
+
+#### projects export / import
+
+```bash
+# Export the project registry to a file (or stdout if -o is omitted)
+unity projects export -o projects.json
+
+# Import a previously exported registry
+unity projects import projects.json
+unity projects import --input projects.json
+```
+
+---
+
+### Releases — browse Unity versions
+
+```bash
+# List recent releases
+unity releases --format json
+
+# Filter by stream (alpha, beta, lts, tech)
+unity releases --stream lts --format json
+unity releases --stream tech --format json
+unity releases --stream beta --format json
+
+# LTS only shorthand
+unity releases --lts --format json
+
+# Filter from a year onward
+unity releases --since 2023 --format json
+
+# Paginate
+unity releases --limit 10 --skip 20 --format json
+```
+
+---
+
+### Templates
+
+```bash
+# List templates for an editor version (uses default editor if --editor is omitted)
+unity templates list --editor 6000.0.47f1 --format json
+
+# List only locally installed templates
+unity templates list --editor 6000.0.47f1 --installed --format json
+
+# Show template details
+unity templates info com.unity.template.3d --editor 6000.0.47f1 --format json
+```
+
+---
+
+### Run — batch/headless execution
+
+```bash
+# Run a Unity project in batch mode and wait for exit
+unity run /path/to/MyProject -- -executeMethod Builder.Build -quit
+
+# Override editor version
+unity run /path/to/MyProject --editor-version 6000.0.47f1 -- -batchmode -logFile out.log
+
+# Install editor automatically if missing
+unity run /path/to/MyProject --allow-install -- -executeMethod Builder.Build
+
+# Kill the Unity process after 300 seconds (useful in CI to prevent hangs)
+unity run /path/to/MyProject --timeout 300 -- -batchmode -quit
+# Equivalent via env var:
+UNITY_RUN_TIMEOUT=300 unity run /path/to/MyProject -- -batchmode -quit
+```
+
+`unity run` passes everything after `--` directly to the Unity executable and returns the editor's exit code.
+
+When `--timeout <seconds>` is set, the process receives SIGTERM at the deadline; if still alive after 2 s it receives SIGKILL. The command exits with code 6 (EXIT_COMMAND_FAILURE) on timeout.
+
+---
+
+### Build
+
+```bash
+# Build a project (requires --target and --execute-method)
+unity build /path/to/MyProject \
+  --target StandaloneOSX \
+  --execute-method Builder.PerformBuild \
+  --output-path ./build/output
+
+# Common build targets: StandaloneOSX, StandaloneWindows64, StandaloneLinux64, Android, iOS, WebGL
+
+# With --format json, stdout includes newline-delimited JSON progress frames before the final envelope:
+unity build /path/to/MyProject --target StandaloneOSX --execute-method Builder.Build --format json
+# Output (each line is a JSON object):
+# {"type":"progress","command":"build","message":"Resolving project..."}
+# {"type":"progress","command":"build","message":"Resolving editor..."}
+# {"type":"progress","command":"build","message":"Starting Unity..."}
+# {"type":"progress","command":"build","message":"Unity exited (code 0)"}
+# { "success": true, "command": "build", "data": { "target": "...", "logFile": "..." } }
+```
+
+---
+
+### Logs — application logs
+
+```bash
+# Show last 20 log lines (default)
+unity logs
+
+# Show last 50 lines
+unity logs --tail 50
+
+# Follow in real-time (like tail -f)
+unity logs --follow
+
+# Filter by level
+unity logs --level error
+unity logs --level warn
+
+# Available levels: trace, debug, info, warn, error, fatal
+```
+
+---
+
+### Doctor — system diagnostics
+
+```bash
+# Full system report
+unity doctor --format json
+
+# Includes: platform info, auth status, installed editors, recent log lines
+unity doctor --tail 50
+```
+
+---
+
+### Environment
+
+```bash
+# Show environment paths
+unity env --format json
+
+# Returns: user data path, editor install path, download cache path, config path, CLI version
+```
+
+---
+
+### Cache
+
+```bash
+# Show cache location and size
+unity cache info --format json
+
+# Clear download cache
+unity cache clean --yes
+```
+
+---
+
+### Language
+
+```bash
+# Show current language and available options
+unity language
+
+# Set language by code
+unity language --set en
+unity language --set ja
+unity language --set zh-hans
+
+# Alias
+unity lang --set ko
+```
+
+On a TTY with no flags, shows an interactive selection prompt.
+
+---
+
+### Completion — shell tab completion
+
+Generate and install shell completion scripts:
+
+```bash
+# Supported shells: bash, zsh, fish, powershell
+unity completion bash
+unity completion zsh
+unity completion fish
+unity completion powershell
+```
+
+---
+
+### Bug — report a bug
+
+Interactive bug reporter that collects system info and recent logs, then submits to Unity:
+
+```bash
+unity bug
+```
+
+Prompts for title, description, email, and reproducibility level.
+
+---
+
+### Upgrade — update the CLI itself
+
+```bash
+# Check for available updates
+unity upgrade --check --format json
+
+# Show changelog for the new version
+unity upgrade --changelog
+
+# Upgrade (interactive confirmation)
+unity upgrade
+
+# Upgrade without prompts
+unity upgrade --yes
+
+# Install a specific version
+unity upgrade --target 0.2.0
+
+# Select update channel (stable or beta)
+unity upgrade --channel beta
+
+# Dry-run: show what would change
+unity upgrade --dry-run
+
+# Rollback to previous version
+unity upgrade --rollback
+```
+
+---
+
+### Self-uninstall — remove the CLI
+
+```bash
+# Uninstall the CLI (interactive confirmation)
+unity self-uninstall
+
+# Uninstall without prompts
+unity self-uninstall --yes
+
+# Also remove config and data files
+unity self-uninstall --purge --yes
+
+# Dry-run: show what would be removed
+unity self-uninstall --dry-run
+```
+
+---
+
+## Common workflows
+
+### Find and install a missing editor
+
+```bash
+# 1. Check what's installed
+unity editors --installed --format json
+
+# 2. Browse available LTS versions
+unity releases --lts --limit 5 --format json
+
+# 3. Install
+unity install 6000.0.47f1 --yes --accept-eula
+```
+
+### Open a project with the correct editor
+
+```bash
+# 1. Check the project's required editor version
+unity projects info /path/to/MyProject --format json
+# Look at "editorVersion" in the result
+
+# 2. Confirm that editor is installed
+unity editors --installed --format json
+
+# 3. Open (warns if the editor version is missing)
+unity open /path/to/MyProject
+```
+
+### CI: headless build
+
+```bash
+unity run /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --allow-install \
+  -- -batchmode -quit -executeMethod Builder.PerformBuild -logFile build.log
+echo "Exit code: $?"
+```
+
+### Debug the CLI
+
+```bash
+# Check auth + installed editors + recent errors in one command
+unity doctor --format json
+
+# Follow live logs during an install
+unity logs --follow --level info
+```
+
+---
+
+## Notes
+
+- `--non-interactive` and `--yes` together suppress all prompts — use both in CI.
+- `--format json` always produces machine-readable output; prefer it over parsing human text.
+- `unity <version> [path]` is a shorthand for `unity open [path] --editor-version <version>`. Works with `lts`, `latest`, or a full version string like `6000.0.47f1`.
+- The CLI supports kubectl-style plugins: any `unity-<name>` binary on PATH is callable as `unity <name>`.
+- The CLI is currently in **beta**. Once GA ships, the `UNITY_CLI_CHANNEL=beta` part of the install command can be dropped.


### PR DESCRIPTION
## Summary

- Adds `skills/cli.md` — the Unity CLI skill for AI coding agents
- Covers installation, all commands (editors, install, projects, run, build, logs, doctor, etc.), global flags, exit codes, and common workflows
- Updates README with install instructions, skills table, and usage examples

## Install

```bash
npx skills add Unity-Technologies/skills
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)