### PR TITLE
docs: update unity-cli skill for beta.6

### DIFF
--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -142,6 +142,29 @@ The interactive `unity auth login` flow now prints the sign-in URL to the termin
 
 ---
 
+### Cloud — Unity Cloud organizations and projects
+
+Requires being signed in (`unity auth login`).
+
+```bash
+# Show cloud sign-in state and active organization
+unity cloud status --format json
+
+# Organizations
+unity cloud org list --format json
+unity cloud org current                       # print the active default org id
+unity cloud org set-default <id-or-name>      # set active default org
+unity cloud org clear-default                 # revert to "All Organizations"
+
+# Projects in the active organization
+unity cloud project list --format json
+
+# Override the active organization for a single call
+unity cloud project list --cloud-org <id-or-name>   # also via UNITY_CLOUD_ORG env var
+```
+
+---
+
 ### Editors — list, install, uninstall
 
 ```bash
@@ -361,9 +384,18 @@ unity open /path/to/MyProject --editor-version 6000.0.47f1
 # Pass extra Unity arguments
 unity open /path/to/MyProject --args "-logFile output.log"
 
+# Pass a build target (forwarded to Unity as -buildTarget / -buildTargetGroup)
+unity open /path/to/MyProject --build-target StandaloneOSX
+unity open /path/to/MyProject --build-target-group Standalone
+
+# Use a specific editor binary instead of resolving by version
+unity open /path/to/MyProject --editor-path "/Applications/Unity/Hub/Editor/6000.0.47f1/Unity.app"
+
 # Version shorthand (equivalent to open with --editor-version)
 unity 6000.0.47f1 /path/to/MyProject
 ```
+
+The project argument is matched against the Hub registry first (exact name or path opens immediately; a glob like `"My Game*"` prompts when multiple match); with no registry match it falls back to treating the argument as a filesystem path.
 
 #### projects create
 
@@ -429,6 +461,20 @@ unity projects export -o projects.json
 # Import a previously exported registry
 unity projects import projects.json
 unity projects import --input projects.json
+```
+
+#### projects open / link / unlink
+
+```bash
+# Open a registered project by name, fuzzy title match, or path
+unity projects open MyProject
+# (the top-level `unity open` is the same thing)
+
+# Connect a local project to its cloud / version-control link
+unity projects link
+
+# Disconnect a local project from its cloud / version-control link
+unity projects unlink
 ```
 
 ---
@@ -560,6 +606,13 @@ unity templates location --reset --json
 - `--reset` restores the Hub default templates path
 - JSON output: `{ "path": "..." }` inside the standard envelope
 
+```bash
+# Edit a user-generated (custom) template's metadata
+unity templates edit com.myorg.template.mytemplate --editor 6000.0.47f1
+```
+
+Only user-generated templates can be edited (use `unity templates edit --help` for the editable fields).
+
 ---
 
 ### Config — persisted CLI configuration
@@ -609,28 +662,38 @@ unity config proxy --unset
 ### Run — batch/headless execution
 
 ```bash
-# Run a Unity project in batch mode and wait for exit
-unity run /path/to/MyProject -- -executeMethod Builder.Build -quit
+# Run a Unity project headless (batch mode is automatic — do NOT pass -batchmode/-quit)
+unity run /path/to/MyProject -- -executeMethod Builder.Build
 
 # Override editor version
-unity run /path/to/MyProject --editor-version 6000.0.47f1 -- -batchmode -logFile out.log
+unity run /path/to/MyProject --editor-version 6000.0.47f1 -- -nographics -logFile out.log
 
 # Install editor automatically if missing
 unity run /path/to/MyProject --allow-install -- -executeMethod Builder.Build
 
 # Kill the Unity process after 300 seconds (useful in CI to prevent hangs)
-unity run /path/to/MyProject --timeout 300 -- -batchmode -quit
+unity run /path/to/MyProject --timeout 300 -- -executeMethod Builder.Build
 # Equivalent via env var:
-UNITY_RUN_TIMEOUT=300 unity run /path/to/MyProject -- -batchmode -quit
+UNITY_RUN_TIMEOUT=300 unity run /path/to/MyProject -- -executeMethod Builder.Build
 ```
 
-`unity run` passes everything after `--` directly to the Unity executable and returns the editor's exit code.
+`unity run` always launches the editor in batch mode and forwards the args after `--` to the Unity executable, then returns the editor's exit code.
+
+**Reserved flags — do NOT pass these after `--`.** The command adds them itself: `-batchmode`, `-quit`, `-projectPath`, `-useHub`, `-hubIPC`. Passing any of them fails fast (before launch) with exit code 6:
+
+```
+Error: Forwarded argument '-batchmode' conflicts with a reserved Unity flag managed by this command. Remove it from the args after `--`.
+```
+
+Flags like `-nographics`, `-logFile <path>`, and `-executeMethod <Class.Method>` are not reserved and are forwarded normally.
 
 When `--timeout <seconds>` is set, the process receives SIGTERM at the deadline; if still alive after 2 s it receives SIGKILL. The command exits with code 6 (EXIT_COMMAND_FAILURE) on timeout.
 
 ---
 
 ### Build
+
+`--target` and `--execute-method` are both **required** — Unity has no built-in command-line build, so your `executeMethod` is responsible for the actual build (including honoring `--output-path`).
 
 ```bash
 # Build a project (requires --target and --execute-method)
@@ -640,7 +703,28 @@ unity build /path/to/MyProject \
   --output-path ./build/output
 
 # Common build targets: StandaloneOSX, StandaloneWindows64, StandaloneLinux64, Android, iOS, WebGL
+```
 
+**Options:**
+
+| Flag | Description |
+|---|---|
+| `--target <target>` | Build target (required). |
+| `--execute-method <method>` | Static C# method to invoke, e.g. `Builder.PerformBuild` (required). |
+| `--build-target-group <group>` | Forwarded to Unity as `-buildTargetGroup`. |
+| `-o, --output-path <path>` | Passed as `-buildOutput` (your method must honor it). |
+| `-l, --log-file <path>` | Log file path. Default: `<project>/Logs/build-<target>-<timestamp>.log`. |
+| `--editor-version <version>` | Override editor version (default: from `ProjectVersion.txt`). |
+| `-e, --editor-path <path>` | Use a specific editor binary. |
+| `-a, --architecture <arch>` | Editor architecture (`x86_64` or `arm64`). |
+| `--args <string>` | Extra arguments passed to Unity (shell-split). |
+| `--no-tail` | Do not stream the log to stdout in real time. |
+| `--allow-install` | Install the project's editor version if missing. |
+| `--versioning-strategy <strategy>` | `semantic`, `tag`, `custom`, or `none` (default: `none`). |
+| `--build-version <version>` | Explicit version string; only used with `--versioning-strategy custom`. |
+| `--allow-dirty-build` | Skip the uncommitted-changes guard (default: false). |
+
+```bash
 # With --format json, stdout includes newline-delimited JSON progress frames before the final envelope:
 unity build /path/to/MyProject --target StandaloneOSX --execute-method Builder.Build --format json
 # Output (each line is a JSON object):
@@ -705,6 +789,19 @@ unity cache info --format json
 
 # Clear download cache
 unity cache clean --yes
+```
+
+---
+
+### Analytics — usage/telemetry consent
+
+```bash
+# Show current consent status
+unity analytics status --format json
+
+# Enable / disable anonymous usage data collection
+unity analytics opt-in
+unity analytics opt-out
 ```
 
 ---
@@ -809,36 +906,86 @@ unity pipeline install --project-path /path/to/MyProject
 
 # Use SSH instead of HTTPS when cloning the package
 unity pipeline install --project-path /path/to/MyProject --ssh
+
+# Keep the Samples / Tests folders in the installed package
+unity pipeline install --install-samples --install-tests
+
+# Force reinstall even if the package is already present
+unity pipeline install --force
 ```
+
+`pipeline install` options: `--project-path <path>`, `--ssh`, `--install-samples`, `--install-tests`, `--force`.
 
 **Requires Unity 6.0 or higher.** The Pipeline package is cloned as an embedded package into `Packages/com.unity.pipeline/`.
 
 ---
 
-### Request — send commands to a running Unity Editor (experimental)
+### Command — send commands to a running Unity Editor (experimental)
 
-The `request` command communicates with a running Unity Editor that has the Pipeline package installed. Alias: `req`.
+The `command` command (alias: `cmd`) communicates with a running Unity Editor that has the Pipeline package installed. (`request`/`req` remain as deprecated hidden aliases — prefer `command`.)
 
 ```bash
 # List all commands available on the connected Unity Editor
-unity request
-unity request --format json
+unity command
+unity command --format json
 
 # Execute a specific command
-unity request editor_play
-unity request log_editor "Hello from CLI"
-unity request editor_status --includeMemory true
+unity command editor_play
+unity command log_editor "Hello from CLI"
+unity command editor_status --includeMemory true
 
 # Target a specific project or instance
-unity request editor_play --project-path /path/to/MyProject
-unity request editor_play --instance localhost:8765
+unity command editor_play --project-path /path/to/MyProject
+unity command editor_play --instance localhost:8765
 
 # Connect to a Unity Player runtime instance
-unity request <command> --runtime "MyGame"
-unity request <command> --runtime-path /path/to/port-file
+unity command <command> --runtime "MyGame"
+unity command <command> --runtime-path /path/to/port-file
 
 # Set a timeout (default: 30 seconds)
-unity request editor_play --timeout 60
+unity command editor_play --timeout 60
+```
+
+If no editor with a reachable Pipeline server is found, the command errors with guidance (make sure the editor is running, the Pipeline package is installed, and its HTTP server is up).
+
+#### eval — evaluate a C# expression in a running editor
+
+```bash
+unity eval 'Application.version'
+unity eval '1 + 2'
+unity eval 'Application.version' --json
+unity eval 'Time.realtimeSinceStartup' --timeout 10   # server-side timeout (default: 5s)
+
+# Bare expressions are auto-wrapped as 'return <expr>;'. Include a ';' to run a statement body:
+unity eval 'Debug.Log("hello");'
+unity eval 'var s = Application.dataPath; return s.Length;'
+```
+
+Targeting options match `command`: `--project-path`, `--instance <host:port>`, `--runtime <name>`, `--runtime-path <path>`.
+
+#### editor play / stop / pause — play-mode control
+
+Higher-level wrappers over `command` for the connected editor:
+
+```bash
+unity editor play     # enter play mode
+unity editor stop     # exit play mode
+unity editor pause    # toggle pause
+
+# Target a specific project or instance
+unity editor play --project-path /path/to/MyProject
+unity editor play --instance localhost:8765
+```
+
+#### status — live state of connected editors
+
+```bash
+# Show port, state, project, version, PID for every connected Unity Editor
+unity status --format json
+
+# Filter to one instance
+unity status --port 8765
+unity status --project megacity
 ```
 
 ---
@@ -894,11 +1041,24 @@ unity open /path/to/MyProject
 
 ### CI: headless build
 
+Prefer the dedicated `unity build` command (handles batch mode, logging, and CI flags):
+
+```bash
+unity build /path/to/MyProject \
+  --editor-version 6000.0.47f1 \
+  --target StandaloneLinux64 \
+  --execute-method Builder.PerformBuild \
+  --allow-install
+echo "Exit code: $?"
+```
+
+Or use `unity run` (batch mode is automatic — never pass `-batchmode`/`-quit`):
+
 ```bash
 unity run /path/to/MyProject \
   --editor-version 6000.0.47f1 \
   --allow-install \
-  -- -batchmode -quit -executeMethod Builder.PerformBuild -logFile build.log
+  -- -executeMethod Builder.PerformBuild -logFile build.log
 echo "Exit code: $?"
 ```
 
@@ -920,5 +1080,5 @@ unity logs --follow --level info
 - `--format json` always produces machine-readable output; prefer it over parsing human text.
 - `unity <version> [path]` is a shorthand for `unity open [path] --editor-version <version>`. Works with `lts`, `latest`, or a full version string like `6000.0.47f1`.
 - The CLI supports kubectl-style plugins: any `unity-<name>` binary on PATH is callable as `unity <name>`.
-- The CLI is currently in **beta** (latest: `0.1.0-beta.5`). Once GA ships, the `UNITY_CLI_CHANNEL=beta` part of the install command can be dropped.
+- The CLI is currently in **beta** (latest: `0.1.0-beta.6`). Once GA ships, the `UNITY_CLI_CHANNEL=beta` part of the install command can be dropped.
 - Outbound HTTP from every CLI command honors the resolved proxy (see `unity config proxy`). Inspect what the CLI actually resolved with `unity env --format json` or `unity doctor --format json` — both surface the active proxy URL, its source, and auth source.


### PR DESCRIPTION
## Summary

The `unity-cli` skill was written for `0.1.0-beta.5`; the CLI is now `0.1.0-beta.6`. I installed the CLI, diffed **every** documented command against `--help`, and cross-checked the `run` behavior against the CLI source in `unity-hub/src/cli`. This updates `skills/unity-cli/SKILL.md` accordingly.

## Behavioral fixes (previously produced broken commands)

- **`run` reserved flags** — the skill claimed `run` forwards everything after `--` to Unity. It no longer does: it auto-adds `-batchmode -quit -projectPath -useHub -hubIPC`, and passing any of them now **fails with exit 6**. Rewrote the section + examples and documented the exact reserved set (verified empirically).
- **CI headless-build workflow** — previously passed `-- -batchmode -quit …`, which now errors. Replaced with a `unity build` example and a corrected `unity run` one.

## Renamed command

- **`request|req` → `command|cmd`** (renamed throughout; `request`/`req` retained as deprecated hidden aliases).

## New commands documented

- `cloud` (status / org / project), `analytics` (status / opt-in / opt-out), `eval`, `status`, `editor play|stop|pause`, `projects open|link|unlink`, `templates edit`.

## Filled-in / corrected docs

- `build` — added all missing options (`--build-target-group`, `-l/--log-file`, `--args`, `--no-tail`, `--versioning-strategy`, `--build-version`, `--allow-dirty-build`, `--allow-install`, …) and noted `--target`/`--execute-method` are required.
- `pipeline install` — added `--install-samples`, `--install-tests`, `--force`.
- `open` — added `--build-target`, `--build-target-group`, `--editor-path`, registry-matching behavior.
- Bumped documented version to `0.1.0-beta.6`.

## Verification

Installed `0.1.0-beta.6` and confirmed against live `--help` for every command group. Reserved-flag set for `run` confirmed empirically (`-batchmode`/`-quit`/`-projectPath`/`-useHub`/`-hubIPC` error; `-nographics`/`-logFile`/`-executeMethod` forward fine). Read-only new commands (`cloud status`, `analytics status`, `status`, `command`) run as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)