### PR TITLE
docs: beta.6 skill update, gate internal pipeline section, trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,3 @@ Once installed, your agent will automatically use the relevant skill when you as
 ## Issues and feedback
 
 Found a bug or have a suggestion? Post in the [Unity Discussions forum](https://discussions.unity.com/).
-
-## Contributing
-
-Skills live in the `skills/` directory as Markdown files. Internal contributors: [#devs-unity-skills](https://unity.slack.com/messages/C7MKBJ34G/)

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -894,6 +894,8 @@ unity upgrade --rollback
 
 ### Pipeline — Unity Editor automation (experimental)
 
+> **⚠️ Unity-internal only (for now).** `unity pipeline install` clones the Pipeline package from a repository hosted on Unity's internal network, so it currently only succeeds for users with Unity internal access. External users will see a clone/authentication failure. Because the `command`, `eval`, `editor play/stop/pause`, and `status` commands below all require the Pipeline package to be installed in a running editor first, the entire experimental Pipeline workflow is unavailable to external users until the package is published publicly. If you're not on Unity's internal network, skip this section.
+
 The `pipeline` command manages the Unity Pipeline package, which enables programmatic control of running Unity Editor instances. Alias: `pipe`.
 
 ```bash


### PR DESCRIPTION
Updates the `unity-cli` skill and README. This branch carries three related documentation changes:

## Changes

1. **Update `unity-cli` skill for beta.6** (#9) — refreshes the skill to match the `0.1.0-beta.6` CLI surface: auth flows, NDJSON progress frames, proxy config, doctor/env reporting, and the experimental pipeline/command/eval commands.

2. **Gate the experimental Pipeline section as Unity-internal only** — `unity pipeline install` clones the Pipeline package from Unity's internal GitHub Enterprise (`github.cds.internal.unity3d.com`), so external users hit an unexplained clone/auth failure. Since `command`, `eval`, `editor play/stop/pause`, and `status` all depend on the package being installed first, the whole experimental workflow is unavailable externally. Added a prominent warning at the top of the section directing non-internal users to skip it, until the package is published publicly.

3. **Remove the contributing section from the README** — dropped the internal-only `#devs-unity-skills` Slack contributing note so the public README stays public-appropriate.

## Notes

- The internal-repo dependency in (2) is a **CLI bug**, not a skill bug — the skill only documents the command surface the CLI exposes. The real fix is publishing `com.unity.pipeline` to a public location; this PR just prevents public users from being misled in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)