### PR TITLE
docs: add CONTRIBUTING guide and link from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for wanting to add a skill. This repo is a shared, public collection of a
 
 ## Before you start
 
-This is a **public** repository on the open [skills.sh](https://skills.sh) standard. Whatever you contribute ships publicly, so a skill must not reference anything internal — no internal services, internal URLs, credentials, or confidential workflows. If a skill only makes sense inside Unity's network, it doesn't belong here.
+This is a **public** repository built on the open [skills.sh](https://skills.sh) standard. Anything you contribute ships publicly, so a skill must not reference anything internal: no internal services, internal URLs, credentials, or confidential workflows. If a skill only makes sense inside Unity's network, it doesn't belong here.
 
 ## Skill structure
 
@@ -16,24 +16,24 @@ skills/
     SKILL.md
 ```
 
-`SKILL.md` starts with YAML frontmatter and then the instructions the agent follows. The `unity-cli` skill is a good template to copy:
+`SKILL.md` starts with YAML frontmatter, then the instructions the agent follows. The `unity-cli` skill is a good template to copy:
 
 ```yaml
 ---
 name: your-skill
-description: Use when ... — one or two sentences describing exactly when an agent should reach for this skill.
+description: Use when … (one or two sentences on exactly when an agent should reach for this skill).
 allowed-tools:
   - Bash
 ---
 ```
 
-- `name` — matches the folder name, kebab-case.
-- `description` — this is what the agent reads to decide whether to trigger the skill, so be concrete about the situations it applies to. Lead with "Use when …".
-- `allowed-tools` — optional; list the tools the skill needs (omit it if there's no restriction).
+- `name`: matches the folder name, in kebab-case.
+- `description`: what the agent reads to decide whether to trigger the skill, so be specific about when it applies. Start with "Use when …".
+- `allowed-tools`: optional. List the tools the skill needs, or leave it out if there's no restriction.
 
-A README, CHANGELOG, and reference `.md` files alongside `SKILL.md` are all fine — the installer pulls the whole folder. Keep `SKILL.md` itself focused on instructions and push long reference material into separate files the skill links to.
+A README, CHANGELOG, and reference `.md` files alongside `SKILL.md` are all fine; the installer pulls the whole folder. Keep `SKILL.md` focused on instructions and move long reference material into separate files it links to.
 
-Submit skills as plain folders committed to the repo. Don't check in a zipped `.skill` archive — agents read `SKILL.md` directly, and that's what the skills.sh tooling and review expect. You're free to package a `.skill` for distribution elsewhere.
+Submit skills as plain folders committed to the repo. Don't check in a zipped `.skill` archive. Agents read `SKILL.md` directly, which is what the skills.sh tooling and review expect. You're welcome to package a `.skill` for distribution elsewhere.
 
 ## Versioning
 
@@ -43,7 +43,7 @@ There's no per-skill release mechanism. Versioning is just the repo's git histor
 
 1. Add your skill folder under `skills/`.
 2. Test it with realistic prompts in your own agent first.
-3. Open a PR. Keep it to one skill per PR where you can.
+3. Open a PR. Stick to one skill per PR where you can.
 4. A maintainer reviews and merges.
 
 ## Help

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for wanting to add a skill. This repo is a shared, public collection of agent skills for Unity workflows, and new contributions are welcome.
+
+## Before you start
+
+This is a **public** repository on the open [skills.sh](https://skills.sh) standard. Whatever you contribute ships publicly, so a skill must not reference anything internal — no internal services, internal URLs, credentials, or confidential workflows. If a skill only makes sense inside Unity's network, it doesn't belong here.
+
+## Skill structure
+
+Each skill is a folder under `skills/`, with a `SKILL.md` at its root:
+
+```
+skills/
+  your-skill/
+    SKILL.md
+```
+
+`SKILL.md` starts with YAML frontmatter and then the instructions the agent follows. The `unity-cli` skill is a good template to copy:
+
+```yaml
+---
+name: your-skill
+description: Use when ... — one or two sentences describing exactly when an agent should reach for this skill.
+allowed-tools:
+  - Bash
+---
+```
+
+- `name` — matches the folder name, kebab-case.
+- `description` — this is what the agent reads to decide whether to trigger the skill, so be concrete about the situations it applies to. Lead with "Use when …".
+- `allowed-tools` — optional; list the tools the skill needs (omit it if there's no restriction).
+
+A README, CHANGELOG, and reference `.md` files alongside `SKILL.md` are all fine — the installer pulls the whole folder. Keep `SKILL.md` itself focused on instructions and push long reference material into separate files the skill links to.
+
+Submit skills as plain folders committed to the repo. Don't check in a zipped `.skill` archive — agents read `SKILL.md` directly, and that's what the skills.sh tooling and review expect. You're free to package a `.skill` for distribution elsewhere.
+
+## Versioning
+
+There's no per-skill release mechanism. Versioning is just the repo's git history and PRs. A `CHANGELOG.md` inside your skill folder is welcome as documentation, but nothing automated reads it.
+
+## Submitting
+
+1. Add your skill folder under `skills/`.
+2. Test it with realistic prompts in your own agent first.
+3. Open a PR. Keep it to one skill per PR where you can.
+4. A maintainer reviews and merges.
+
+## Help
+
+Questions or feedback? Post in the [Unity Discussions forum](https://discussions.unity.com/).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Once installed, your agent will automatically use the relevant skill when you as
 > "List my registered projects"
 > "Run the project in headless mode"
 
+## Contributing
+
+Want to add a skill? See [CONTRIBUTING.md](CONTRIBUTING.md) for the folder layout, `SKILL.md` format, and PR flow.
+
 ## Issues and feedback
 
 Found a bug or have a suggestion? Post in the [Unity Discussions forum](https://discussions.unity.com/).


### PR DESCRIPTION
## What

Adds a `CONTRIBUTING.md` and links it from the README.

The repo had no contributing guidance (the old section was removed when we made the repo public), so the structure/rules currently live only in maintainers' heads and ad-hoc Slack replies. An external contributor recently asked how to add a skill — this documents the answer so people can self-serve.

## Contents

`CONTRIBUTING.md` covers:
- The public-safety rule — nothing internal-only, since the repo is public
- The `skills/<name>/SKILL.md` folder layout and frontmatter (`name`, `description`, `allowed-tools`), pointing at `unity-cli` as a template
- That a README/CHANGELOG/reference `.md` files alongside `SKILL.md` are fine
- Skills go in as plain committed folders, not zipped `.skill` archives
- Versioning is just git history / PRs (no per-skill releases)
- The submission flow (one skill per PR, test first, open a PR)

README gets a short **Contributing** section linking to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)