### PR TITLE
fix: strip invisible U+FE0F characters flagged by Snyk (W021)

### DIFF
--- a/skills/levelplay-unity-integration/references/best-practices.md
+++ b/skills/levelplay-unity-integration/references/best-practices.md
@@ -64,8 +64,8 @@ Every ad implementation involves a fundamental trade-off between revenue generat
 
 **Expected Outcomes:** *(Industry benchmarks, not LevelPlay-specific)*
 - ✅ 30-50% higher ad revenue
-- ⚠️ 5-15% increase in early abandonment
-- ⚠️ Lower user satisfaction scores
+- ⚠ 5-15% increase in early abandonment
+- ⚠ Lower user satisfaction scores
 - ✅ Strong monetization from engaged users
 
 ### UX-Focused Implementation
@@ -89,7 +89,7 @@ Every ad implementation involves a fundamental trade-off between revenue generat
 - Hide during any active user engagement
 
 **Expected Outcomes:** *(Industry benchmarks, not LevelPlay-specific)*
-- ⚠️ 40-60% lower ad revenue vs revenue-focused
+- ⚠ 40-60% lower ad revenue vs revenue-focused
 - ✅ Better user retention and satisfaction
 - ✅ Higher organic growth and word-of-mouth
 - ✅ Premium brand perception

--- a/skills/levelplay-unity-integration/references/privacy-settings.md
+++ b/skills/levelplay-unity-integration/references/privacy-settings.md
@@ -477,7 +477,7 @@ public class PrivacyComplianceManager : MonoBehaviour
 
 ## Deprecated APIs (SDK 9.3.0 and Lower)
 
-**⚠️ These APIs are deprecated. Use the current `LevelPlayPrivacySettings` APIs instead.**
+**⚠ These APIs are deprecated. Use the current `LevelPlayPrivacySettings` APIs instead.**
 
 ### Deprecated GDPR API — LevelPlay.SetConsent
 

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -1151,7 +1151,7 @@ unity self-uninstall --dry-run
 
 The commands below drive a running Unity Editor through the in-Editor **Pipeline** package, or exercise Unity Cloud Pipeline / Collaboration APIs. They are **absent from the published production CLI** (they only register when `HUB_ENV=development`) and so will not appear in `unity --help` for a normal install. They are documented here for completeness; if you don't see them, they're not available in your build.
 
-> **⚠️ Unity-internal.** `unity pipeline install` clones the Pipeline package from a repository on Unity's internal network, so it currently only succeeds for users with Unity internal access. The `command`, `eval`, `editor play/stop/pause`, `status`, `cloud-pipeline`, and `collab` commands all depend on the Pipeline package (or internal cloud services) and are unavailable to external users until those are published publicly.
+> **⚠ Unity-internal.** `unity pipeline install` clones the Pipeline package from a repository on Unity's internal network, so it currently only succeeds for users with Unity internal access. The `command`, `eval`, `editor play/stop/pause`, `status`, `cloud-pipeline`, and `collab` commands all depend on the Pipeline package (or internal cloud services) and are unavailable to external users until those are published publicly.
 
 ### pipeline (alias: pipe) — manage the Unity Pipeline package
 


### PR DESCRIPTION
## What

Strips the invisible **`U+FE0F` (VARIATION SELECTOR-16)** character from skill docs. This is the combining character that renders a plain `⚠` glyph as the `⚠️` emoji.

## Why

The [skills.sh Snyk audit](https://www.skills.sh/unity-technologies/skills/unity-cli/security/snyk) flagged **W021 — Hidden Unicode Characters** (MEDIUM) on `unity-cli`. Invisible combining characters read as potential obfuscation / prompt-injection to security scanners. The `U+FE0F` selector is easy to miss because its Unicode category is `Mn`, not the `Cf` that most "invisible character" checks look for.

## Changes

- Removed all 5 `U+FE0F` occurrences, keeping the visible `⚠` glyph:
  - `skills/unity-cli/SKILL.md` (1)
  - `skills/levelplay-unity-integration/references/best-practices.md` (3)
  - `skills/levelplay-unity-integration/references/privacy-settings.md` (1)
- CRLF line endings preserved; diff is exactly 5 chars.
- Repo-wide rescan now reports **no** invisible/format/BOM characters.

## Not addressed (by design)

The same audit's **W011 / W012** flag the `curl … | bash` CLI install from `public-cdn.cloud.unity3d.com`. That's Unity's official first-party install over HTTPS and is inherent to an install skill — accepted risk, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)