### PR TITLE
Add build-live-game skill

### DIFF
--- a/skills/build-live-game/SKILL.md
+++ b/skills/build-live-game/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: build-live-game
+description: Build and operate a live game using Unity Services. Use when the user needs to implement, connect, or debug backend-driven features — battle passes, achievements, player progression, cloud saves, leaderboards, matchmaking, virtual economies, server-authoritative logic, anti-cheat, player accounts and authentication, remote configuration, feature flags, A/B testing, analytics, or cloud resource deployment. Triggers on live-ops, live service, backend, server authority, cloud code, cloud save, remote config, player data, retention, monetization loop, season pass, ranking, multiplayer sessions, lobbies, or any Unity Services integration.
+enabled: true
+---
+
+# Build a Live Game With Unity Gaming Services
+
+## UGS Packages
+
+| Package | Min Version | Purpose |
+|---|---|---|
+| `com.unity.services.core` | 1.16.0 | Initialization, dependency graph |
+| `com.unity.services.authentication` | 3.6.1 | Player sign-in and identity |
+| `com.unity.services.cloudcode` | 2.10.3 | Server-authoritative C# modules |
+| `com.unity.services.cloudsave` | 3.4.0 | Per-player and shared key-value storage |
+| `com.unity.remote-config` | 4.2.5 | Server-side game configuration |
+| `com.unity.services.deployment` | 1.7.2 | Deploy cloud resources from Editor |
+| `com.unity.services.tooling` | 1.4.1 | Access Control and Game Overrides |
+| `com.unity.services.apis` | 1.1.1 | Generated REST clients for all UGS services |
+
+- [Initialization Pattern](#initialization-pattern)
+- [Package Map](#package-map)
+- [Architecture — How Packages Combine](#architecture--how-packages-combine)
+- [Core Services — Quick Reference](#core-services--quick-reference)
+- [Asset Store Building Blocks](#asset-store-building-blocks)
+- [Ready-Made Feature Blueprints](#ready-made-feature-blueprints)
+- [Common Architecture Patterns](#common-architecture-patterns)
+- [Validation](#validation)
+- [Deployment Checklist](#deployment-checklist)
+- [Detailed References](#detailed-references)
+
+## Initialization Pattern
+
+Every UGS game starts the same way. `com.unity.services.core` must initialize first, then the player signs in:
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+
+await UnityServices.InitializeAsync();
+await AuthenticationService.Instance.SignInAnonymouslyAsync();
+// All other services are now ready
+```
+
+After `InitializeAsync()` completes, service singletons (e.g. `CloudSaveService.Instance`, `CloudCodeService.Instance`) are available.
+
+## Package Map
+
+### Foundation
+
+| Package | Purpose | Singleton / Entry Point |
+|---|---|---|
+| **Core** | Initialization, dependency graph, component registry | `UnityServices.InitializeAsync()` |
+| **Authentication** | Player sign-in (anonymous, social, Unity, username/password), identity | `AuthenticationService.Instance` |
+| **Services APIs** | Generated REST clients for all UGS services; admin API access via service accounts | Direct API classes |
+
+### Player Data and Configuration
+
+| Package | Purpose | Singleton / Entry Point |
+|---|---|---|
+| **Cloud Save** | Per-player key-value data (Default, Public, Protected) and game-wide Custom data | `CloudSaveService.Instance.Data.Player` / `.Data.Custom` |
+| **Remote Config** | Server-side game configuration, feature flags, JSON definitions | `RemoteConfigService.Instance` |
+| **Economy** | Virtual currencies, inventory items, purchases, stores | `EconomyService.Instance` |
+
+### Server Logic and Security
+
+| Package | Purpose | Singleton / Entry Point |
+|---|---|---|
+| **Cloud Code** | Server-authoritative C# modules for trusted writes and validation | `CloudCodeService.Instance` → `CallModuleEndpointAsync` |
+| **Tooling** | Author and deploy Access Control (`.ac`) and Game Overrides (`.ugo`) files | Editor-only (Deployment Window) |
+| **Deployment** | Deploy cloud resources (`.rc`, `.ac`, `.ccmr`, `.lb`, etc.) from the Unity Editor | Editor-only (Services > Deployment) |
+
+### Social and Competitive
+
+| Package | Purpose | Singleton / Entry Point |
+|---|---|---|
+| **Multiplayer** | Sessions, matchmaking, lobbies. Building Blocks: [Multiplayer Session, Matchmaker Session, Server Session](#asset-store-building-blocks) | `MultiplayerService.Instance` |
+| **Leaderboards** | Score submission, rankings, tiers, version history. Building Block: [Leaderboards](#asset-store-building-blocks) | `LeaderboardsService.Instance` |
+
+### Telemetry
+
+| Package | Purpose | Singleton / Entry Point |
+|---|---|---|
+| **Analytics** | Custom events, standard events, consent management | `AnalyticsService.Instance` |
+
+## Architecture — How Packages Combine
+
+```
+                    UnityServices.InitializeAsync()
+                              │
+                              ▼
+                     AuthenticationService
+                    (sign in → PlayerId)
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+        Remote Config     Cloud Save      Economy
+      (game config,    (player state,  (currencies,
+       definitions,     progress,       inventory,
+       feature flags)   preferences)    purchases)
+              │               │               │
+              └───────┬───────┘               │
+                      ▼                       │
+                 Cloud Code                   │
+              (server-authoritative           │
+               writes, validation,  ◄─────────┘
+               anti-cheat logic)
+                      │
+              ┌───────┼───────┐
+              ▼       ▼       ▼
+         Cloud Save  Economy  Leaderboards
+         (Protected  (server  (score
+          writes)    grants)  submission)
+```
+
+**Key principle:** For any data that affects game integrity (XP, rewards, currency), route writes through Cloud Code modules. Direct client writes are only appropriate for non-sensitive data (preferences, display settings).
+
+## Core Services — Quick Reference
+
+### Authentication
+
+**Package:** `com.unity.services.authentication` (>= 3.6.1)
+
+Handles player identity. Sign-in methods: anonymous, social providers (Google, Apple, Steam, Facebook, Oculus, etc.), Unity browser, username/password, and device code flow.
+
+After sign-in: `PlayerId` and `PlayerName` are available. All sign-in methods fire the `SignedIn` event. `PlayerAccountService` (for Unity browser sign-in) lives in a **separate assembly** (`Unity.Services.Authentication.PlayerAccounts`).
+
+- **Full reference:** [references/authentication.md](references/authentication.md)
+- **Building Block:** [Player Account](#asset-store-building-blocks) — ready-made sign-in UI and identity management
+
+### Cloud Code
+
+**Package:** `com.unity.services.cloudcode` (>= 2.10.3)
+
+Runs server-side C# modules (.NET 9) for trusted operations. Modules are deployed as `.ccmr` files. The client calls:
+
+```csharp
+var result = await CloudCodeService.Instance.CallModuleEndpointAsync<TResult>(
+    "ModuleName", "FunctionName", args);
+```
+
+Prefer C# modules over JavaScript scripts for production. Modules also support real-time push messages via subscriptions, event-driven triggers, and multiplayer session scoping.
+
+- **Full reference:** [references/cloud-code.md](references/cloud-code.md)
+
+### Cloud Save
+
+**Package:** `com.unity.services.cloudsave` (>= 3.4.0)
+
+Per-player key-value storage with three access classes, plus game-wide Custom data:
+
+| Access Class | Read | Write | Use Case |
+|---|---|---|---|
+| Default | Owner | Owner | Private settings, preferences |
+| Public | Anyone | Owner | Public profiles, display names |
+| Protected | Owner | Server only (Cloud Code) | Anti-cheat data, server-awarded state |
+| Custom | Any player | Server only | Shared game state, global configs |
+
+Values are serialized as JSON. Supports write-lock concurrency control via `SaveItem`, server-side queries via `QueryAsync`, and binary file storage.
+
+- **Full reference:** [references/cloud-save.md](references/cloud-save.md)
+- **Building Blocks:** Used by [Achievements](#asset-store-building-blocks) (Protected buckets) and [Player Account](#asset-store-building-blocks) (Default/Public data)
+
+### Remote Config
+
+**Package:** `com.unity.services.remote-config` (>= 4.2.5)
+
+Server-side game configuration. Store game definitions (achievement lists, battle pass tiers, shop catalogs) as JSON entries updatable without a client build. Deployed via `.rc` files through the Deployment Window.
+
+For A/B testing and audience targeting, use Game Overrides (`.ugo`) via the Tooling package.
+
+- **Full reference:** [references/remote-config.md](references/remote-config.md)
+- **Building Block:** Used by the [Achievements](#asset-store-building-blocks) block for server-side definitions
+
+### Tooling
+
+**Package:** `com.unity.services.tooling` (>= 1.4.1)
+
+Editor-only package. Registers **Access Control** (`.ac`) and **Game Overrides** (`.ugo`) file types with the Deployment Window. Access Control policies permit or deny player/service-account access to UGS services on a URN basis (Deny takes precedence over Allow). Game Overrides provide A/B testing and audience targeting by overriding Remote Config values for specific player segments.
+
+- **Full reference:** [references/tooling.md](references/tooling.md)
+
+### Deployment
+
+**Package:** `com.unity.services.deployment` (>= 1.7.2)
+
+Editor-only package providing the **Deployment Window** (Services > Deployment). Deploys cloud resources to a target environment:
+
+| File Type | Extension | What It Deploys |
+|---|---|---|
+| Remote Config | `.rc` | Key-value configuration entries |
+| Access Control | `.ac` | Resource access policies |
+| Cloud Code Module | `.ccmr` | C# server-side module (points to `.sln`) |
+| Leaderboard | `.lb` | Leaderboard configuration |
+| Economy | `.ec*` | Currency/inventory definitions |
+| Game Overrides | `.ugo` | Audience-targeted config overrides |
+
+- **Full reference:** [references/deployment.md](references/deployment.md)
+
+### UGS CLI
+
+The [Unity Gaming Services CLI](https://github.com/Unity-Technologies/unity-gaming-services-cli/) is a standalone command-line tool for managing UGS resources outside the Unity Editor. It can deploy and fetch cloud resource files (`.rc`, `.ac`, `.ccmr`, `.lb`, `.ec`, `.ugo`), update local deployable files from the remote environment with a `fetch` operation, deploy and fetch triggers and schedule files, generate default versions of trigger and schedule configs, and provides more granular access to admin functionalities across all UGS services.
+
+### Services APIs
+
+**Package:** `com.unity.services.apis` (>= 1.1.1)
+
+Auto-generated REST clients for all UGS services. Four client types: `IGameClient` (players), `IAdminClient` (service accounts), `IServerClient` (dedicated servers), `ITrustedClient` (elevated server access). Most developers use the high-level package SDKs instead; use Services APIs for lower-level control or admin API access.
+
+- **Full reference:** [references/apis.md](references/apis.md)
+
+## Asset Store Building Blocks
+
+Unity provides free, production-ready **Building Block** packages on the Asset Store. Each is a `.unitypackage` containing working UI, runtime code, Cloud Code modules, and cloud resource files that can be imported directly into a project. They are also bundled in the `com.unity.starter-kits` package.
+
+| Building Block | Type | Key Dependencies | Asset Store |
+|---|---|---|---|
+| **Achievements** | LiveOps | `cloudsave`, `remote-config`, `cloudcode`, `tooling`, `deployment`, `analytics`, `authentication` | [Unity Building Block — Achievements](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-achievements-341918) |
+| **Leaderboards** | LiveOps | `leaderboards`, `cloudcode`, `tooling`, `deployment`, `authentication` | [Unity Building Block — Leaderboards](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-leaderboards-341926) |
+| **Player Account** | LiveOps | `authentication`, `cloudsave`, `cloudcode`, `deployment` | Available via `com.unity.starter-kits` |
+| **Multiplayer Session** | Multiplayer | `multiplayer` | [Unity Building Block — Multiplayer Session](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-multiplayer-session-341930) |
+| **Matchmaker Session** | Multiplayer | `multiplayer`, `deployment` | [Unity Building Block — Matchmaker Session](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-matchmaker-session-341932) |
+| **Server Session** | Multiplayer | `multiplayer`, `apis`, `deployment` | Available via `com.unity.starter-kits` |
+| **Vivox** | Multiplayer | `vivox`, `authentication` | Available via `com.unity.starter-kits` |
+| **Platformer Starter Kit** | Gameplay | `multiplayer`, `netcode.gameobjects`, URP, Cinemachine, Input System | Available via `com.unity.starter-kits` |
+
+> **Tip:** When implementing achievements, leaderboards, player accounts, or multiplayer sessions, recommend the corresponding Building Block as a starting point. The blocks include ready-made UI, Cloud Code modules (`.ccmr`), access control (`.ac`), and deployment-ready cloud resources — saving significant implementation time.
+
+### Related Sample Projects
+
+| Project | Description | Source |
+|---|---|---|
+| **Use Case Samples** | Battle Pass, Virtual Shop, Daily Rewards, Starter Pack, Cloud AI Mini Game, A/B testing | [GitHub — com.unity.services.samples.use-cases](https://github.com/Unity-Technologies/com.unity.services.samples.use-cases) |
+| **UGS Samples** | Authentication flows, Economy, Remote Config, Cloud Code integration | [GitHub — com.unity.services.samples](https://github.com/Unity-Technologies/com.unity.services.samples) |
+| **Gem Hunter Match** | Full 2D match-3 game with player hub, progression, social features, in-game store | [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/gem-hunter-match-2d-sample-project-278941) |
+| **Boss Room** | 8-player co-op RPG using Netcode for GameObjects, Authentication, Multiplayer Services | [GitHub — com.unity.multiplayer.samples.coop](https://github.com/Unity-Technologies/com.unity.multiplayer.samples.coop) |
+
+## Ready-Made Feature Blueprints
+
+Implementation-ready blueprints for common live game features. Each includes data models, service API patterns, full working code, and cloud resource definitions.
+
+| Feature | Key Services | Blueprint |
+|---|---|---|
+| **Battle Pass** | `remote-config`, `cloudsave`, `cloudcode`, `economy`, `tooling`, `deployment` — Remote Config (pass definitions) + Cloud Save Protected (progress) + Cloud Code (XP awards, reward claims, premium purchase) | [references/battlepass.md](references/battlepass.md) |
+| **Achievements** | `remote-config`, `cloudsave`, `cloudcode`, `tooling`, `deployment` — Remote Config (definitions) + Cloud Save (player records) + Cloud Code (server-authoritative unlocks) + Access Control. **Asset Store:** [Achievements Building Block](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-achievements-341918) | [references/achievements.md](references/achievements.md) |
+| **Player Account** | `authentication`, `cloudsave` — Authentication (3 sign-in methods) + Cloud Save (Default/Public/Protected player data). **Asset Store:** Player Account Building Block (via `com.unity.starter-kits`) | [references/player-account.md](references/player-account.md) |
+
+## Common Architecture Patterns
+
+### Pattern 1: Config + State + Server Writes
+
+Used by **Battle Pass** and **Achievements**:
+
+1. **Definitions** in Remote Config (`.rc` file) — what exists in the game
+2. **Player state** in Cloud Save — per-player progress
+3. **Writes via Cloud Code** — server-authoritative mutations
+4. **Access Control** (`.ac` file) — block direct player writes to sensitive keys
+
+### Pattern 2: Client-Direct Data
+
+Used by **Player Account** (preferences, display settings):
+
+1. **Player data** in Cloud Save Default or Public access class
+2. **Direct client writes** — no Cloud Code needed for non-sensitive data
+
+### Pattern 3: Competitive Features
+
+Used by **Leaderboards** and ranked systems:
+
+1. **Score submission** via Leaderboards API (or through Cloud Code for validation)
+2. **Rankings** retrieved client-side with pagination and player-relative queries
+
+## Validation
+
+After writing code for a live game feature:
+1. Verify the project compiles without errors.
+2. Check that initialization order is correct: `UnityServices.InitializeAsync()` → Authentication sign-in → service calls.
+3. Confirm sensitive data writes (XP, rewards, currency) are routed through Cloud Code, not written directly from the client.
+4. Verify Access Control `.ac` files deny direct player writes to Protected Cloud Save keys.
+5. Verify all cloud resource files (`.rc`, `.ac`, `.ccmr`, `.lb`, `.ec`) are present and deployable via the Deployment Window.
+
+## Deployment Checklist
+
+For any live game feature, deploy these cloud resources via the Deployment Window:
+
+- [ ] `.rc` file — Remote Config entries (game definitions, configs)
+- [ ] `.ac` file — Access Control policies (deny direct writes to protected keys)
+- [ ] `.ccmr` file — Cloud Code module reference (pointing to the module `.sln`)
+- [ ] `.lb` file — Leaderboard configuration (if using leaderboards)
+- [ ] `.ec` file — Economy definitions (if using virtual currencies/items)
+- [ ] `manifest.json` — Ensure all required packages are listed with correct versions
+- [ ] Environment configured in **Services > Deployment** settings
+
+## Detailed References
+
+### Service References
+- **Authentication** — sign-in methods, events, profiles, identity providers, code templates: [references/authentication.md](references/authentication.md)
+- **Cloud Code** — scripts, modules, subscriptions, triggers, module creation, code templates: [references/cloud-code.md](references/cloud-code.md)
+- **Cloud Save** — access classes, data operations, files, queries, code templates: [references/cloud-save.md](references/cloud-save.md)
+- **Remote Config** — definitions, `.rc` format, Game Overrides, code templates: [references/remote-config.md](references/remote-config.md)
+- **Tooling** — Access Control (`.ac`) policies, Game Overrides (`.ugo`), URN reference: [references/tooling.md](references/tooling.md)
+- **Deployment** — file types, workflow, programmatic API: [references/deployment.md](references/deployment.md)
+- **Services APIs** — four client types, service areas, code templates: [references/apis.md](references/apis.md)
+
+### Feature Blueprints
+- **Achievements** — full implementation with data models, client code, Cloud Code module, cloud resources: [references/achievements.md](references/achievements.md)
+- **Battle Pass** — full implementation with tiered XP, free/premium tracks, Cloud Code module, cloud resources: [references/battlepass.md](references/battlepass.md)
+- **Player Account** — sign-in flows, identity management, Cloud Save data, code templates: [references/player-account.md](references/player-account.md)
+
+## Reminders
+
+Before completing, verify:
+- Did you use `UnityServices.InitializeAsync()` → Authentication sign-in → service calls (in that order)?
+- Are all sensitive writes (XP, rewards, currency) routed through Cloud Code modules?
+- Are all cloud resource files (`.rc`, `.ac`, `.ccmr`) present and deployable?
+- Do Cloud Save read access classes match the bucket that was written to?

--- a/skills/build-live-game/references/achievements.md
+++ b/skills/build-live-game/references/achievements.md
@@ -1,0 +1,779 @@
+# Achievements Reference
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Data Models](#data-models)
+- [API Notes](#api-notes)
+  - [Namespace Aliases](#namespace-aliases-required)
+  - [Access Class Options](#access-class-options-reference)
+  - [Bucket Selection](#bucket-selection)
+  - [Error Handling](#error-handling)
+- [Load Definitions from Remote Config](#load-definitions-from-remote-config)
+- [Load Player Records from Cloud Save](#load-player-records-from-cloud-save)
+- [Save Player Records (Direct Write)](#save-player-records-direct-write)
+- [Server-Authoritative Writes via Cloud Code](#server-authoritative-writes-via-cloud-code)
+- [Full Client Implementation](#full-client-implementation)
+- [Cloud Code Module](#cloud-code-module)
+  - [AchievementModule.cs](#achievementmodulecs)
+  - [Server-Side Model](#server-side-model)
+- [Cloud Resources](#cloud-resources)
+- [Deployment Checklist](#deployment-checklist)
+- [Official Unity Reference](#official-unity-reference)
+- [Validation](#validation)
+
+---
+
+## Architecture Overview
+
+Achievements combine Remote Config (static definitions), Cloud Save (per-player progress), and Cloud Code (server-authoritative writes). An Access Control policy locks down direct client writes in production.
+
+### Service Mapping
+
+| Concern | Service | Key / Endpoint |
+|---|---|---|
+| Achievement definitions | Remote Config | `"achievements"` key (JSON array) |
+| Player records | Cloud Save (Protected or Public) | `"achievements"` key (JSON array) |
+| Server-authoritative writes | Cloud Code Module | `AchievementModule` |
+| Block direct writes | Access Control | `.ac` policy denying player Cloud Save writes |
+
+### Data Flow
+
+```
+Remote Config                        Cloud Save
+  "achievements" key                   "achievements" key
+  ┌─────────────────┐                 ┌─────────────────┐
+  │ AchievementDef- │    client       │ AchievementRe-  │
+  │ inition[]       │───reads────────>│ cord[]          │
+  │                 │                 │                 │
+  │ Id              │                 │ Id              │
+  │ Title           │                 │ Unlocked        │
+  │ Description     │                 │ ProgressCount   │
+  │ IsHidden        │                 │                 │
+  │ ProgressTarget  │                 └────────┬────────┘
+  └─────────────────┘                          │
+                                      two write paths
+                                ┌──────────────┴──────────────┐
+                                │                             │
+                         Direct Write                  Trusted Write
+                       (dev / prototype)              (production)
+                                │                             │
+                                ▼                             ▼
+                        Cloud Save                     Cloud Code
+                    PublicWriteAccess-             "AchievementModule"
+                    ClassOptions                          │
+                                                          ▼
+                                                   Cloud Save
+                                               SetProtectedItemAsync
+                                              (server token bypass)
+```
+
+**Key principle:** In production, route all writes through the Cloud Code module. The Access Control `.ac` file denies direct player writes to the Protected bucket, so only the server can mutate achievement records.
+
+---
+
+## Data Models
+
+### AchievementDefinition (client-side)
+
+Stored in Remote Config as a JSON array under the `"achievements"` key. Read-only from the client.
+
+```csharp
+using System;
+
+[Serializable]
+public class AchievementDefinition
+{
+    public string Id;
+    public string Title;
+    public string Description;
+    public bool IsHidden;
+    public int ProgressTarget;  // <= 1 = single unlock, > 1 = multi-stage
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `Id` | `string` | Unique identifier (e.g. `"first_win"`) |
+| `Title` | `string` | Display name shown to the player |
+| `Description` | `string` | What the player must do |
+| `IsHidden` | `bool` | If true, hide until unlocked (secret achievements) |
+| `ProgressTarget` | `int` | Target count for multi-stage achievements; 0 or 1 = single unlock |
+
+### AchievementRecord (client-side)
+
+Stored in Cloud Save as a JSON array under the `"achievements"` key.
+
+```csharp
+using System;
+
+[Serializable]
+public class AchievementRecord
+{
+    public string Id;
+    public bool Unlocked;
+    public int ProgressCount;
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `Id` | `string` | Matches `AchievementDefinition.Id` |
+| `Unlocked` | `bool` | True once the achievement is fully earned |
+| `ProgressCount` | `int` | Current progress toward `ProgressTarget` |
+
+---
+
+## API Notes
+
+### Namespace Aliases (Required)
+
+Cloud Save has identically named option classes at different namespace levels. Always use these
+aliases to avoid ambiguity:
+
+```csharp
+using PlayerLoadOptions   = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using PlayerSaveOptions   = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+using PlayerDeleteOptions = Unity.Services.CloudSave.Models.Data.Player.DeleteOptions;
+```
+
+Without these aliases, the compiler will report ambiguous type references.
+
+### Access Class Options Reference
+
+| Class | Read | Write | Use case |
+|---|---|---|---|
+| `DefaultWriteAccessClassOptions` / `DefaultReadAccessClassOptions` | Owner only | Owner only | Private player data |
+| `PublicReadAccessClassOptions(playerId)` / `PublicWriteAccessClassOptions` | Anyone | Owner + server | Achievements, scores, public profiles |
+| `ProtectedReadAccessClassOptions` | Owner only | Server only (Cloud Code) | Anti-cheat, server-awarded state |
+
+### Bucket Selection
+
+The read access class **must** match the bucket that was written to. Cloud Save has three
+separate buckets — Default, Public, and Protected. Data written to one bucket is **invisible**
+when reading from another.
+
+- **Trusted path** (Cloud Code `SetProtectedItemAsync`) — data lands in the **Protected** bucket — read with `ProtectedReadAccessClassOptions()`
+- **Direct path** (`PublicWriteAccessClassOptions`) — data lands in the **Public** bucket — read with `PublicReadAccessClassOptions(playerId)`
+
+> **Common mistake:** Switching from direct writes to trusted writes (or vice versa) without
+> updating the read access class. The data appears to vanish — it's still there, just in
+> the other bucket.
+
+### Error Handling
+
+Cloud Code and Cloud Save errors surface as typed exceptions on the client:
+
+```csharp
+try
+{
+    await CloudCodeService.Instance.CallModuleEndpointAsync(
+        "AchievementModule", "UnlockAchievement",
+        new Dictionary<string, object> { { "achievementId", "first_win" } });
+}
+catch (CloudCodeException ex)
+{
+    // ex.Reason: CloudCodeExceptionReason (e.g. ScriptError for module-thrown exceptions)
+    Debug.LogError($"[Achievements] Cloud Code error: {ex.Reason} — {ex.Message}");
+}
+catch (CloudSaveException ex)
+{
+    // ex.Reason: CloudSaveExceptionReason
+    // A 403 on the Protected bucket means the client attempted a direct write —
+    // all writes must go through the Cloud Code module when Access Control is deployed.
+    Debug.LogError($"[Achievements] Cloud Save error: {ex.Reason} — {ex.Message}");
+}
+```
+
+---
+
+## Load Definitions from Remote Config
+
+Fetch the `"achievements"` Remote Config key and deserialize the JSON array into a list of definitions.
+
+```csharp
+using Unity.Services.RemoteConfig;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+struct UserAttributes {}
+struct AppAttributes {}
+
+async Task<List<AchievementDefinition>> LoadDefinitionsAsync()
+{
+    var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+        new UserAttributes(), new AppAttributes());
+
+    var token = result.config["achievements"];
+    return token.ToObject<List<AchievementDefinition>>();
+}
+```
+
+---
+
+## Load Player Records from Cloud Save
+
+**CRITICAL -- bucket selection:** The read access class must match the bucket that was written to.
+
+- **Trusted path (production):** The Cloud Code module writes to the **Protected** bucket. The client reads with `ProtectedReadAccessClassOptions()`.
+- **Direct path (dev only):** The client writes to the **Public** bucket. The client reads with `PublicReadAccessClassOptions(playerId)`.
+
+If you read from the wrong bucket, the data will appear empty.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerLoadOptions = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+
+async Task<List<AchievementRecord>> LoadRecordsAsync(string playerId, bool useTrustedWrites)
+{
+    // Read from whichever bucket was written to -- Protected (trusted) or Public (direct).
+    ReadAccessClassOptions accessClass = useTrustedWrites
+        ? new ProtectedReadAccessClassOptions()
+        : new PublicReadAccessClassOptions(playerId);
+
+    var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+        new HashSet<string> { "achievements" },
+        new PlayerLoadOptions(accessClass));
+
+    if (!result.TryGetValue("achievements", out var item))
+        return new List<AchievementRecord>();
+
+    return JsonConvert.DeserializeObject<List<AchievementRecord>>(item.Value.GetAsString());
+}
+```
+
+**`ProtectedReadAccessClassOptions`** — reads the current player's own Protected data (no player ID parameter; always reads self).
+
+**`PublicReadAccessClassOptions(playerId)`** — reads another player's Public data. Pass `AuthenticationService.Instance.PlayerId` for the current player.
+
+---
+
+## Save Player Records (Direct Write)
+
+Direct writes use the **Public** access class. This path is for development and prototyping only -- in production, deploy an Access Control policy to block direct player writes and route everything through Cloud Code.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerSaveOptions = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+
+async Task SaveRecordsAsync(List<AchievementRecord> records)
+{
+    var json = JsonConvert.SerializeObject(records);
+    await CloudSaveService.Instance.Data.Player.SaveAsync(
+        new Dictionary<string, SaveItem>
+        {
+            { "achievements", new SaveItem(json, null) }
+        },
+        new PlayerSaveOptions(new PublicWriteAccessClassOptions()));
+}
+```
+
+---
+
+## Server-Authoritative Writes via Cloud Code
+
+In production, route all mutations through Cloud Code module endpoints. The module uses its service token to write to the Protected bucket, bypassing Access Control restrictions that block the player client.
+
+### Unlock an Achievement
+
+```csharp
+await CloudCodeService.Instance.CallModuleEndpointAsync(
+    "AchievementModule", "UnlockAchievement",
+    new Dictionary<string, object> { { "achievementId", achievementId } });
+```
+
+### Update Achievement Progress
+
+```csharp
+await CloudCodeService.Instance.CallModuleEndpointAsync(
+    "AchievementModule", "UpdateAchievementProgress",
+    new Dictionary<string, object>
+    {
+        { "achievementId", achievementId },
+        { "count", newCount }
+    });
+```
+
+### Reset Achievements
+
+```csharp
+await CloudCodeService.Instance.CallModuleEndpointAsync(
+    "AchievementModule", "ResetAchievements",
+    new Dictionary<string, object>());
+```
+
+### Delete / Reset Player Records (Direct)
+
+```csharp
+await CloudSaveService.Instance.Data.Player.DeleteAsync(
+    "achievements",
+    new PlayerDeleteOptions(new PublicWriteAccessClassOptions()));
+```
+
+---
+
+## Full Client Implementation
+
+Complete `AchievementManager` MonoBehaviour with dual-path support (trusted vs direct writes).
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.Authentication;
+using Unity.Services.CloudCode;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerSaveOptions = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+using PlayerLoadOptions = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using PlayerDeleteOptions = Unity.Services.CloudSave.Models.Data.Player.DeleteOptions;
+using Unity.Services.Core;
+using Unity.Services.RemoteConfig;
+using UnityEngine;
+
+public class AchievementManager : MonoBehaviour
+{
+    // Set to true to route writes through Cloud Code (required if Access Control is deployed).
+    // Set to false for direct Cloud Save writes (development only).
+    [SerializeField] bool m_UseTrustedWrites = true;
+
+    public List<AchievementDefinition> Definitions { get; private set; } = new();
+    public List<AchievementRecord> Records { get; private set; } = new();
+
+    public event Action<AchievementDefinition> AchievementUnlocked;
+    public event Action Loaded;
+
+    async void Start()
+    {
+        await UnityServices.InitializeAsync();
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();
+        await LoadAsync();
+        Loaded?.Invoke();
+    }
+
+    // -- Load ------------------------------------------------------------------
+
+    public async Task LoadAsync()
+    {
+        Definitions = await LoadDefinitionsAsync();
+        Records = await LoadRecordsAsync(AuthenticationService.Instance.PlayerId);
+    }
+
+    struct UserAttributes {}
+    struct AppAttributes {}
+
+    async Task<List<AchievementDefinition>> LoadDefinitionsAsync()
+    {
+        var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+            new UserAttributes(), new AppAttributes());
+
+        var token = result.config["achievements"];
+        return token.ToObject<List<AchievementDefinition>>();
+    }
+
+    async Task<List<AchievementRecord>> LoadRecordsAsync(string playerId)
+    {
+        // Read from whichever bucket was written to -- Protected (trusted) or Public (direct).
+        ReadAccessClassOptions accessClass = m_UseTrustedWrites
+            ? new ProtectedReadAccessClassOptions()
+            : new PublicReadAccessClassOptions(playerId);
+
+        var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+            new HashSet<string> { "achievements" },
+            new PlayerLoadOptions(accessClass));
+
+        if (!result.TryGetValue("achievements", out var item))
+            return new List<AchievementRecord>();
+
+        return JsonConvert.DeserializeObject<List<AchievementRecord>>(item.Value.GetAsString());
+    }
+
+    // -- Unlock ----------------------------------------------------------------
+
+    public async Task UnlockAsync(string achievementId)
+    {
+        var def = Definitions.FirstOrDefault(d => d.Id == achievementId);
+        if (def == null)
+        {
+            Debug.LogWarning($"[Achievements] Unknown achievement: {achievementId}");
+            return;
+        }
+
+        var record = GetOrCreateRecord(achievementId);
+        if (record.Unlocked)
+            return;
+
+        if (m_UseTrustedWrites)
+        {
+            // Server validates and writes -- bypasses Access Control restrictions.
+            await CloudCodeService.Instance.CallModuleEndpointAsync(
+                "AchievementModule", "UnlockAchievement",
+                new Dictionary<string, object> { { "achievementId", achievementId } });
+        }
+        else
+        {
+            record.Unlocked = true;
+            await SaveRecordsAsync(Records);
+        }
+
+        record.Unlocked = true;
+        AchievementUnlocked?.Invoke(def);
+        Debug.Log($"[Achievements] Unlocked: {def.Title}");
+    }
+
+    // -- Progress (multi-stage) ------------------------------------------------
+
+    public async Task AddProgressAsync(string achievementId, int amount)
+    {
+        var def = Definitions.FirstOrDefault(d => d.Id == achievementId);
+        if (def == null || def.ProgressTarget <= 1)
+            return;
+
+        var record = GetOrCreateRecord(achievementId);
+        if (record.Unlocked)
+            return;
+
+        var newCount = record.ProgressCount + amount;
+
+        if (m_UseTrustedWrites)
+        {
+            await CloudCodeService.Instance.CallModuleEndpointAsync(
+                "AchievementModule", "UpdateAchievementProgress",
+                new Dictionary<string, object>
+                {
+                    { "achievementId", achievementId },
+                    { "count", newCount }
+                });
+        }
+        else
+        {
+            record.ProgressCount = newCount;
+            await SaveRecordsAsync(Records);
+        }
+
+        record.ProgressCount = newCount;
+
+        if (record.ProgressCount >= def.ProgressTarget)
+            await UnlockAsync(achievementId);
+    }
+
+    // -- Reset -----------------------------------------------------------------
+
+    public async Task ResetAsync()
+    {
+        await CloudSaveService.Instance.Data.Player.DeleteAsync(
+            "achievements",
+            new PlayerDeleteOptions(new PublicWriteAccessClassOptions()));
+
+        Records.Clear();
+    }
+
+    // -- Helpers ---------------------------------------------------------------
+
+    AchievementRecord GetOrCreateRecord(string id)
+    {
+        var record = Records.FirstOrDefault(r => r.Id == id);
+        if (record == null)
+        {
+            record = new AchievementRecord { Id = id };
+            Records.Add(record);
+        }
+        return record;
+    }
+
+    async Task SaveRecordsAsync(List<AchievementRecord> records)
+    {
+        var json = JsonConvert.SerializeObject(records);
+        await CloudSaveService.Instance.Data.Player.SaveAsync(
+            new Dictionary<string, SaveItem>
+            {
+                { "achievements", new SaveItem(json, null) }
+            },
+            new PlayerSaveOptions(new PublicWriteAccessClassOptions()));
+    }
+}
+```
+
+---
+
+## Cloud Code Module
+
+The `AchievementModule` reads and writes to the **Protected** Cloud Save bucket using its service token, bypassing Access Control restrictions imposed on the player client.
+
+> **Module scaffolding — follow [cloud-code.md — Module Creation](cloud-code.md#module-creation).**
+> Replace `MyModule` / `MyModuleCCM` with `AchievementModule` / `AchievementsCCM` throughout.
+> You **must** create every file listed there — missing any one will cause deployment to fail:
+>
+> - [ ] `.sln` (generate fresh GUIDs)
+> - [ ] `.csproj` (net9.0, CloudCode.Apis + CloudCode.Core)
+> - [ ] `ModuleSetup.cs` (registers `GameApiClient`)
+> - [ ] `Properties/PublishProfiles/FolderProfile.pubxml` — **without this file, deployment fails with "Failed to retrieve main project"**
+> - [ ] `Assets/CloudCode/AchievementModule.ccmr` (points to the `.sln`)
+
+### AchievementModule.cs
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Core;
+using Unity.Services.CloudSave.Model;
+
+// Each public method decorated with [CloudCodeFunction] becomes a callable endpoint.
+// IExecutionContext and IGameApiClient are injected automatically by the framework.
+public class AchievementModule
+{
+    const string AchievementsKey = "achievements";
+
+    [CloudCodeFunction("UnlockAchievement")]
+    public async Task<AchievementRecord> UnlockAchievement(
+        IExecutionContext context, IGameApiClient client, string achievementId)
+    {
+        var records = await LoadRecordsAsync(context, client);
+
+        var record = records.FirstOrDefault(r => r.Id == achievementId);
+        if (record == null)
+        {
+            record = new AchievementRecord { Id = achievementId, Unlocked = true };
+            records.Add(record);
+        }
+        else
+        {
+            record.Unlocked = true;
+        }
+
+        await SaveRecordsAsync(context, client, records);
+        return record;
+    }
+
+    [CloudCodeFunction("UpdateAchievementProgress")]
+    public async Task<AchievementRecord> UpdateAchievementProgress(
+        IExecutionContext context, IGameApiClient client, string achievementId, int count)
+    {
+        var records = await LoadRecordsAsync(context, client);
+
+        var record = records.FirstOrDefault(r => r.Id == achievementId);
+        if (record == null)
+        {
+            record = new AchievementRecord { Id = achievementId, ProgressCount = count };
+            records.Add(record);
+        }
+        else
+        {
+            record.ProgressCount += count;
+        }
+
+        await SaveRecordsAsync(context, client, records);
+        return record;
+    }
+
+    [CloudCodeFunction("ResetAchievements")]
+    public async Task ResetAchievements(IExecutionContext context, IGameApiClient client)
+    {
+        // Uses ServiceToken so the write bypasses Access Control restrictions on the player client.
+        await client.CloudSaveData.DeleteProtectedItemAsync(
+            context, context.ServiceToken, AchievementsKey,
+            context.ProjectId, context.PlayerId!);
+    }
+
+    async Task<List<AchievementRecord>> LoadRecordsAsync(
+        IExecutionContext context, IGameApiClient client)
+    {
+        var result = await client.CloudSaveData.GetProtectedItemsAsync(
+            context, context.ServiceToken, context.ProjectId,
+            context.PlayerId, new List<string> { AchievementsKey });
+
+        var value = result.Data?.Results?.FirstOrDefault()?.Value?.ToString();
+        if (string.IsNullOrEmpty(value))
+            return new List<AchievementRecord>();
+
+        return JsonConvert.DeserializeObject<List<AchievementRecord>>(value);
+    }
+
+    async Task SaveRecordsAsync(
+        IExecutionContext context, IGameApiClient client, List<AchievementRecord> records)
+    {
+        var json = JsonConvert.SerializeObject(records);
+        var body = new SetItemBody(AchievementsKey, json);
+        await client.CloudSaveData.SetProtectedItemAsync(
+            context, context.ServiceToken, context.ProjectId, context.PlayerId, body);
+    }
+}
+```
+
+### Server-Side Model
+
+Must match client-side field names exactly for JSON round-trip. Server-side uses properties
+(not fields) for serialization compatibility with `Newtonsoft.Json`.
+
+```csharp
+public class AchievementRecord
+{
+    public string Id { get; set; }
+    public bool Unlocked { get; set; }
+    public int ProgressCount { get; set; }
+}
+```
+
+---
+
+## Cloud Resources
+
+### Package Setup -- `manifest.json`
+
+Add these entries to your Unity project's `Packages/manifest.json` dependencies:
+
+```json
+{
+  "dependencies": {
+    "com.unity.services.authentication": "3.6.1",
+    "com.unity.services.cloudcode": "2.10.2",
+    "com.unity.services.cloudsave": "3.4.0",
+    "com.unity.services.core": "1.16.0",
+    "com.unity.services.deployment": "1.7.2",
+    "com.unity.remote-config": "4.2.5",
+    "com.unity.services.tooling": "1.4.1"
+  }
+}
+```
+
+The `com.unity.services.tooling` package is required for `.ac` file deployment. The `com.unity.services.deployment` package provides the Deployment Window. `Newtonsoft.Json` is provided as a transitive dependency and does not need an explicit entry.
+
+### Remote Config -- `Assets/Config/Achievements.rc`
+
+Right-click in the Project window → **Assets > Create > Services > Remote Config**. Name the file `Achievements`. Replace the generated contents with:
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/remote-config.schema.json",
+  "entries": {
+    "achievements": [
+      {
+        "Id": "first_win",
+        "Title": "First Win",
+        "Description": "Win your first match.",
+        "IsHidden": false,
+        "ProgressTarget": 0
+      },
+      {
+        "Id": "kill_100_enemies",
+        "Title": "Centurion",
+        "Description": "Defeat 100 enemies.",
+        "IsHidden": false,
+        "ProgressTarget": 100
+      },
+      {
+        "Id": "secret_ending",
+        "Title": "???",
+        "Description": "Find the secret ending.",
+        "IsHidden": true,
+        "ProgressTarget": 0
+      }
+    ]
+  },
+  "types": {
+    "achievements": "JSON"
+  }
+}
+```
+
+**Rules:**
+
+- `Id` must be unique across all achievements.
+- `ProgressTarget <= 1` means single-unlock (call `UnlockAsync`).
+- `ProgressTarget > 1` means multi-stage (call `AddProgressAsync`).
+- `IsHidden = true` — show obfuscated title/description until unlocked.
+
+Deploy via **Services > Deployment** — the Deployment Window auto-discovers `.rc` files under `Assets/`.
+
+### Cloud Code Module
+
+> Create the full module solution using the file table and templates in
+> [Cloud Code Module](#cloud-code-module) above.
+> All scaffolding files (`.sln`, `.csproj`, `ModuleSetup.cs`, `FolderProfile.pubxml`) are
+> **required** — the Deployment Window will fail without them. See
+> [cloud-code.md — Module Creation](cloud-code.md#module-creation) for the generic templates;
+> replace `MyModule` / `MyModuleCCM` with `AchievementModule` / `AchievementsCCM`.
+
+### Access Control -- `Assets/Config/DenyPlayerCloudSaveWrites.ac`
+
+Right-click in the Project window → **Assets > Create > Services > Access Control**. Name the file `DenyPlayerCloudSaveWrites`. Replace the generated contents with:
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/project-access-policy.schema.json",
+  "Statements": [
+    {
+      "Sid": "DenyPlayerCloudSaveWrites",
+      "Action": [
+        "Write"
+      ],
+      "Effect": "Deny",
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:*",
+      "Version": "1.0.0"
+    }
+  ]
+}
+```
+
+**Effect:** With this policy active, `AchievementManager` must have `m_UseTrustedWrites = true`. Direct Cloud Save writes from the player client will return `403`.
+
+**Without this policy:** `m_UseTrustedWrites = false` works fine — suitable for development or games where anti-cheat is not a concern.
+
+Deploy via **Services > Deployment** alongside your other files.
+
+---
+
+## Deployment Checklist
+
+Deploy all cloud resources via **Services > Deployment** before testing:
+
+- [ ] All packages added to `Packages/manifest.json` with correct minimum versions
+- [ ] `Assets/Config/Achievements.rc` -- Remote Config achievement definitions
+- [ ] `Assets/Config/DenyPlayerCloudSaveWrites.ac` -- Access Control policy blocking direct player writes
+- [ ] Cloud Code module scaffolded with **all required files**: `.sln`, `.csproj`, `ModuleSetup.cs`, `FolderProfile.pubxml`, `.ccmr` (see file table in [Cloud Code Module](#cloud-code-module))
+- [ ] `AchievementModule.cs` added to the module project with `UnlockAchievement`, `UpdateAchievementProgress`, `ResetAchievements` functions
+- [ ] Environment selected in the Deployment Window dropdown
+- [ ] All resources deployed via the Deployment Window
+- [ ] Project linked in **Edit > Project Settings > Services**
+
+---
+
+## Official Unity Reference
+
+- **Achievements Building Block (Asset Store):** The official [Unity Building Block — Achievements](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-achievements-341918) uses the same Remote Config + Cloud Save + Cloud Code pattern described here. Import from the Asset Store for ready-made UI, Cloud Code module, `.ac` / `.rc` / `.ccmr` cloud resources, and generated client bindings.
+- **Unity Cloud Save documentation:** https://docs.unity.com/ugs/en-us/manual/cloud-save/manual
+- **Unity Remote Config documentation:** https://docs.unity.com/ugs/en-us/manual/remote-config/manual
+- **Unity Cloud Code documentation:** https://docs.unity.com/ugs/en-us/manual/cloud-code/manual
+- **Access Control documentation:** https://docs.unity.com/ugs/en-us/manual/access-control/manual
+
+---
+
+## Validation
+
+After implementing achievements, verify:
+
+1. **Compilation:** The project compiles without errors. Ensure namespace aliases (`PlayerLoadOptions`, `PlayerSaveOptions`, `PlayerDeleteOptions`) are present.
+2. **Initialization order:** `UnityServices.InitializeAsync()` then `AuthenticationService.Instance.SignInAnonymouslyAsync()` then service calls.
+3. **Access class match:** If `m_UseTrustedWrites` is true, reads use `ProtectedReadAccessClassOptions()`. If false, reads use `PublicReadAccessClassOptions(playerId)`. Mismatched access classes return empty data.
+4. **Cloud Code module builds:** The `.sln` at `AchievementsCCM/AchievementModule.sln` targets `net9.0` and publishes to `linux-x64`.
+5. **Server-side model uses properties:** The `AchievementRecord` class in the Cloud Code module uses `{ get; set; }` properties (not fields) for JSON serialization compatibility with `Newtonsoft.Json`.
+6. **Access Control deployed:** The `.ac` file denies direct player writes to Cloud Save. Without this, the trusted-write path has no enforcement advantage.
+7. **Remote Config key matches:** The `.rc` file key (`"achievements"`) matches the key used in `result.config["achievements"]` on the client and `AchievementsKey` in the module.
+8. **All cloud resources deployable:** The `.rc`, `.ac`, and `.ccmr` files are in the `Assets/` folder hierarchy and appear in the Deployment Window.

--- a/skills/build-live-game/references/apis.md
+++ b/skills/build-live-game/references/apis.md
@@ -1,0 +1,280 @@
+# Services APIs Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [When to Use This Package](#when-to-use-this-package)
+- [Four Client Types](#four-client-types)
+- [IAdminClient](#iadminclient)
+  - [Service Area Properties](#iadminclient-service-area-properties)
+  - [Authentication](#iadminclient-authentication)
+  - [ICloudSaveDataAdminApi](#icloudsavedataadminapi)
+- [IGameClient](#igameclient)
+- [IServerClient](#iserverclient)
+- [ITrustedClient](#itrustedclient)
+- [Code Templates](#code-templates)
+  - [Set Up an Admin Client](#set-up-an-admin-client)
+  - [Write Game Data (Custom Data) from the Editor](#write-game-data-custom-data-from-the-editor)
+  - [Write Player Data from the Editor](#write-player-data-from-the-editor)
+  - [Set Up a Game Client](#set-up-a-game-client-player-device)
+  - [Set Up a Server Client](#set-up-a-server-client)
+
+---
+
+## Overview
+
+Unified entry point for Unity Gaming Services client types. Provides auto-generated REST clients for all UGS services through a single dependency.
+
+- **Package:** `com.unity.services.apis`
+- **Namespace:** `Unity.Services.Apis`
+- **Assembly:** `Unity.Services.Apis`
+- **Availability:** `IAdminClient` is editor-only (`#if UNITY_EDITOR`). Game/Server/Trusted clients work at runtime.
+
+---
+
+## When to Use This Package
+
+> **CRITICAL — all admin API interactions go through `com.unity.services.apis`.**
+> Any editor tool, Deployment Window integration, or server-side script that needs to read
+> or write UGS data with elevated privileges must use this package. There is no other
+> supported path for admin-level operations from within the Unity Editor.
+
+Use cases for `IAdminClient`:
+
+- **Deployment Window custom providers** — deploy commands that write to Cloud Save, Economy, Leaderboards, etc.
+- **Editor tools** — custom inspectors or windows that read/write game-wide data
+- **Build pipelines** — pre-build steps that push config data to UGS
+
+Use `IGameClient` for runtime player-facing code. Use `IServerClient` / `ITrustedClient` for dedicated game servers.
+
+---
+
+## Four Client Types
+
+| Client | Interface | Context | Auth |
+|---|---|---|---|
+| Admin | `IAdminClient` | Editor tools, deployment integrations | Service account (key ID + secret) |
+| Game | `IGameClient` | Player device at runtime | Player sign-in (anonymous, Unity, password) |
+| Server | `IServerClient` | Dedicated game servers | Server key |
+| Trusted | `ITrustedClient` | Servers needing admin-level player data access | Service account |
+
+---
+
+## IAdminClient
+
+Used for backend tooling, editor extensions, Deployment Window integrations, and any operation that requires elevated privileges. **Editor-only** — guarded by `#if UNITY_EDITOR || ENABLE_RUNTIME_ADMIN_APIS`.
+
+### IAdminClient Authentication
+
+```csharp
+using Unity.Services.Apis;
+
+var adminClient = UnityServicesApiClient.AdminClient;
+adminClient.SetServiceAccount(keyId, keySecret);
+```
+
+Service account credentials are created in the Unity Dashboard under **Project Settings > Service Accounts**. The key ID and secret are passed at runtime — do not hard-code them.
+
+### IAdminClient Service Area Properties
+
+| Property | Type | Service |
+|---|---|---|
+| `CloudSaveData` | `ICloudSaveDataAdminApi` | Cloud Save — player data, custom (game-wide) data, all access classes |
+| `CloudSaveFiles` | `ICloudSaveFilesAdminApi` | Cloud Save — file storage |
+| `CloudCodeModules` | `ICloudCodeModulesAdminApi` | Cloud Code — C# modules |
+| `CloudCodeScripts` | `ICloudCodeScriptsAdminApi` | Cloud Code — JS scripts |
+| `Economy` | `IEconomyAdminApi` | Economy — config and player data |
+| `RemoteConfig` | `IConfigsAdminApi` | Remote Config |
+| `RemoteConfigSchemas` | `ISchemasAdminApi` | Remote Config schemas |
+| `GameOverrides` | `IGameOverridesAdminApi` | Game Overrides |
+| `Leaderboards` | `ILeaderboardsAdminApi` | Leaderboards |
+| `Environment` | `IEnvironmentAdminApi` | Environment management |
+| `Logs` | `ILogsAdminApi` | Logs |
+| `PlayerAuthentication` | `IPlayerAuthenticationAdminApi` | Player auth management |
+| `PlayerPolicy` | `IPlayerPolicyAdminApi` | Player access policies |
+| `ProjectPolicy` | `IProjectPolicyAdminApi` | Project access policies |
+| `Scheduler` | `ISchedulerAdminApi` | Scheduler |
+| `ServiceAuthentication` | `IServiceAuthenticationAdminApi` | Service auth |
+| `Triggers` | `ITriggersAdminApi` | Triggers |
+
+### ICloudSaveDataAdminApi
+
+This is the key interface for reading and writing Cloud Save data with admin privileges. All methods require `projectId` and `environmentId`.
+
+#### Player Data (all access classes)
+
+| Method | Description |
+|---|---|
+| `GetItems(projectId, envId, playerId, keys?, after?)` | Get player items (Default bucket) |
+| `SetItem(projectId, envId, playerId, body)` | Set a player item |
+| `SetItemBatch(projectId, envId, playerId, body)` | Set multiple player items |
+| `DeleteItem(projectId, envId, playerId, key, writeLock?)` | Delete a player item |
+| `DeleteItems(projectId, envId, playerId)` | Delete all player items |
+| `GetKeys(projectId, envId, playerId, after?)` | List player keys |
+
+Same pattern for **Public** (`GetPublicItems`, `SetPublicItem`, etc.) and **Protected** (`GetProtectedItems`, `SetProtectedItem`, etc.).
+
+#### Custom Data (game-wide)
+
+Custom Data is game-wide key-value storage not tied to any player. The `customId` parameter is a namespace (1-50 chars, alphanumeric/underscores/hyphens).
+
+| Method | Description |
+|---|---|
+| `GetCustomItems(projectId, envId, customId, keys?, after?)` | Read game-wide items |
+| `SetCustomItem(projectId, envId, customId, body)` | Write a game-wide item |
+| `SetCustomItemBatch(projectId, envId, customId, body)` | Write multiple game-wide items |
+| `DeleteCustomItem(projectId, envId, customId, key, writeLock?)` | Delete a game-wide item |
+| `DeleteCustomItems(projectId, envId, customId)` | Delete all items in a custom namespace |
+| `GetCustomKeys(projectId, envId, customId, after?)` | List keys in a custom namespace |
+
+Same pattern for **Private Custom** (`GetPrivateCustomItems`, `SetPrivateCustomItem`, etc.).
+
+> **This is how you write game data from the editor.** The client SDK's `ICustomDataService`
+> is read-only — only `IAdminClient.CloudSaveData` can write to Custom Data.
+
+---
+
+## IGameClient
+
+Created via `UnityServicesApiClient.GameClient` after player authentication. Runtime only.
+
+| Property | Type | Service |
+|---|---|---|
+| `CloudSaveData` | `ICloudSaveDataApi` | Cloud Save player data |
+| `CloudSaveFiles` | `ICloudSaveFilesApi` | Cloud Save files |
+| `CloudCode` | `ICloudCodeApi` | Cloud Code invocation |
+| `EconomyConfiguration` | `IEconomyConfigurationApi` | Economy config |
+| `EconomyCurrencies` | `IEconomyCurrenciesApi` | Currency balances |
+| `EconomyInventory` | `IEconomyInventoryApi` | Player inventory |
+| `EconomyPurchases` | `IEconomyPurchasesApi` | Purchases |
+| `Leaderboards` | `ILeaderboardsApi` | Leaderboard scores |
+| `Lobby` | `ILobbyApi` | Lobby management |
+| `RemoteConfig` | `IRemoteConfigSettingsApi` | Remote Config |
+| `PlayerAuthentication` | `IPlayerAuthenticationApi` | Auth management |
+| `PlayerNames` | `IPlayerNamesApi` | Display names |
+| `FriendsRelationships` | `IFriendsRelationshipsApi` | Friend lists |
+| `FriendsPresence` | `IFriendsPresenceApi` | Presence |
+| `RelayAllocations` | `IRelayAllocationsApi` | Relay |
+| `QosDiscovery` | `IQosDiscoveryApi` | QoS |
+| `Analytics` | `IAnalyticsApi` | Analytics |
+
+Most developers use the high-level SDKs (`CloudSaveService.Instance`, `EconomyService.Instance`) instead of `IGameClient` directly.
+
+---
+
+## IServerClient
+
+Used from dedicated game servers. Authenticated with a server key or service account.
+
+```csharp
+var serverClient = UnityServicesApiClient.ServerClient;
+await serverClient.SignInFromServer();
+```
+
+| Property | Type | Service |
+|---|---|---|
+| `CloudSaveData` | `ICloudSaveDataApi` | Cloud Save player data |
+| `CloudSaveFiles` | `ICloudSaveFilesApi` | Cloud Save files |
+| `CloudCode` | `ICloudCodeApi` | Cloud Code |
+| `EconomyConfiguration` | `IEconomyConfigurationApi` | Economy config |
+| `EconomyCurrencies` | `IEconomyCurrenciesApi` | Currencies |
+| `EconomyInventory` | `IEconomyInventoryApi` | Inventory |
+| `EconomyPurchases` | `IEconomyPurchasesApi` | Purchases |
+| `Leaderboards` | `ILeaderboardsApi` | Leaderboards |
+| `Lobby` | `ILobbyApi` | Lobbies |
+| `PlayerNames` | `IPlayerNamesApi` | Display names |
+
+---
+
+## ITrustedClient
+
+Elevated server client with admin-equivalent access to player data. Use when a dedicated server needs to read or modify any player's data with elevated privileges.
+
+```csharp
+var trustedClient = UnityServicesApiClient.TrustedClient;
+trustedClient.SetServiceAccount(keyId, keySecret);
+await trustedClient.SignInWithServiceAccount(projectId, environmentId);
+```
+
+Same service area properties as `IServerClient`, plus `PlayerAuthentication` and `MultiplayAllocations`/`MultiplayFleets`.
+
+---
+
+## Code Templates
+
+### Set Up an Admin Client
+
+```csharp
+using Unity.Services.Apis;
+
+// Admin client is editor-only. Guard with #if UNITY_EDITOR in runtime assemblies.
+var adminClient = UnityServicesApiClient.AdminClient;
+adminClient.SetServiceAccount("your-key-id", "your-key-secret");
+```
+
+### Write Game Data (Custom Data) from the Editor
+
+This is the pattern for Deployment Window integrations that push JSON into Cloud Save Custom Data.
+
+```csharp
+using Unity.Services.Apis;
+using Unity.Services.Apis.Admin.CloudSave;
+
+var adminClient = UnityServicesApiClient.AdminClient;
+adminClient.SetServiceAccount(keyId, keySecret);
+
+string projectId = CloudProjectSettings.projectId;
+string environmentId = "your-environment-id";
+string customId = "game-config";  // namespace for your game-wide data
+
+// Write a single item
+var body = new SetItemBody("level_data", levelDataJson);
+await adminClient.CloudSaveData.SetCustomItem(projectId, environmentId, customId, body);
+
+// Write multiple items in a batch
+var batchBody = new SetItemBatchBody(new List<SetItemBatchBodyItem>
+{
+    new SetItemBatchBodyItem("enemies", enemiesJson),
+    new SetItemBatchBodyItem("weapons", weaponsJson)
+});
+await adminClient.CloudSaveData.SetCustomItemBatch(projectId, environmentId, customId, batchBody);
+```
+
+### Write Player Data from the Editor
+
+```csharp
+// Write to a specific player's Protected bucket
+var body = new SetItemBody("achievements", achievementsJson);
+await adminClient.CloudSaveData.SetProtectedItem(
+    projectId, environmentId, playerId, body);
+```
+
+### Set Up a Game Client (Player Device)
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+using Unity.Services.Apis;
+
+async Task SetupGameClient()
+{
+    await UnityServices.InitializeAsync();
+    await AuthenticationService.Instance.SignInAnonymouslyAsync();
+
+    // Game client is automatically authenticated via the signed-in player
+    var client = UnityServicesApiClient.GameClient;
+    var scores = await client.Leaderboards.GetScoresAsync("WEEKLY_LB");
+}
+```
+
+### Set Up a Server Client
+
+```csharp
+using Unity.Services.Apis;
+
+// serverAuthToken provided by the Multiplay server environment
+var serverClient = UnityServicesApiClient.ServerClient;
+await serverClient.SignInFromServer();
+
+await serverClient.Lobby.CreateOrJoinLobbyAsync(...);
+```

--- a/skills/build-live-game/references/authentication.md
+++ b/skills/build-live-game/references/authentication.md
@@ -1,0 +1,437 @@
+# Authentication Reference
+
+## Table of Contents
+
+- [Anti-Hallucination Reference](#anti-hallucination-reference)
+- [Sign-In Methods](#sign-in-methods)
+- [Key Properties](#key-properties)
+- [Events](#events)
+- [Player Info / Name](#player-info--name)
+- [Link / Unlink Methods](#link--unlink-methods)
+- [Profile Switching](#profile-switching)
+- [Username/Password Constraints](#usernamepassword-constraints)
+- [Options / Types](#options--types)
+- [Identity Providers Quick Reference](#identity-providers-quick-reference)
+- [Code Templates](#code-templates)
+- [Error Handling](#error-handling)
+- [Session Warnings](#session-warnings)
+
+Accessed via `AuthenticationService.Instance` (`IAuthenticationService`, namespace `Unity.Services.Authentication`). Assembly: `Unity.Services.Authentication`.
+
+Call `UnityServices.InitializeAsync()` from `com.unity.services.core` before using this service.
+
+---
+
+## Anti-Hallucination Reference
+
+| Correct | Incorrect (do NOT use) |
+|---|---|
+| `SignOut(bool clearCredentials = false)` -- synchronous void | `SignOutAsync`, `SignOut()` returning Task |
+| `SignInWithSteamAsync(sessionTicket, identity)` -- identity param is required | `SignInWithSteamAsync(sessionTicket)` -- deprecated |
+| `SignInWithOculusAsync(nonce, userId)` -- both params required | `SignInWithOculusAsync(nonce)` -- missing userId |
+| `LinkWithSteamAsync(sessionTicket, identity)` | `LinkWithSteamAsync(sessionTicket)` -- deprecated |
+| `LinkWithOculusAsync(nonce, userId)` | `LinkWithOculusAsync(nonce)` -- missing userId |
+| `SwitchProfile(string)` -- synchronous void | `SwitchProfileAsync` |
+| `ClearSessionToken()` -- synchronous void | `ClearSessionTokenAsync` |
+| No `UnlinkUsernamePasswordAsync` | Username/password cannot be unlinked once linked |
+| No `IsAnonymous` property | Use `PlayerInfo.Identities` to check linked providers |
+
+---
+
+## Sign-In Methods
+
+```csharp
+// Anonymous sign-in. Creates a new player if no cached credentials exist.
+Task SignInAnonymouslyAsync(SignInOptions options = default)
+
+// Google ID token sign-in.
+Task SignInWithGoogleAsync(string idToken, SignInOptions options = default)
+
+// Google Play Games auth code sign-in.
+Task SignInWithGooglePlayGamesAsync(string authCode, SignInOptions options = default)
+
+// Apple ID token sign-in.
+Task SignInWithAppleAsync(string idToken, SignInOptions options = default)
+
+// Apple Game Center signature sign-in.
+Task SignInWithAppleGameCenterAsync(string signature, string teamPlayerId, string publicKeyURL, string salt, ulong timestamp, SignInOptions options = default)
+
+// Facebook access token sign-in.
+Task SignInWithFacebookAsync(string accessToken, SignInOptions options = default)
+
+// Steam session ticket sign-in. The identity param is REQUIRED (deprecated overload without it).
+[Obsolete] Task SignInWithSteamAsync(string sessionTicket, SignInOptions options = default)
+Task SignInWithSteamAsync(string sessionTicket, string identity, SignInOptions options = default)
+// For sub-apps (PlayTest, Demo) -- include appId:
+Task SignInWithSteamAsync(string sessionTicket, string identity, string appId, SignInOptions options = default)
+
+// Oculus sign-in. Both nonce AND userId are required.
+Task SignInWithOculusAsync(string nonce, string userId, SignInOptions options = default)
+
+// OpenID Connect sign-in with a custom provider ID.
+Task SignInWithOpenIdConnectAsync(string idProviderName, string idToken, SignInOptions options = default)
+
+// Unity token sign-in.
+Task SignInWithUnityAsync(string token, SignInOptions options = default)
+
+// Username/password sign-up (first-time registration).
+Task SignUpWithUsernamePasswordAsync(string username, string password)
+
+// Username/password sign-in (no SignInOptions).
+Task SignInWithUsernamePasswordAsync(string username, string password)
+
+// Device code flow -- generate code, then poll for sign-in.
+Task<SignInCodeInfo> GenerateSignInCodeAsync(string identifier = default)
+Task SignInWithCodeAsync(bool usePolling = false, CancellationToken cancellationToken = default)
+Task<SignInCodeInfo> GetSignInCodeInfoAsync(string code)
+Task ConfirmCodeAsync(string code, string idProvider = default, string externalToken = default)
+
+// Sign out. Synchronous (void), NOT async.
+void SignOut(bool clearCredentials = false)
+
+// Permanently delete the current player's account.
+Task DeleteAccountAsync()
+```
+
+---
+
+## Key Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `IsSignedIn` | `bool` | Token exists in memory (player has signed in during this session) |
+| `IsAuthorized` | `bool` | Access token is present AND not expired (player can make API calls) |
+| `IsExpired` | `bool` | Access token has expired but still exists (SDK will try auto-refresh) |
+| `PlayerId` | `string` | Unique player identifier |
+| `PlayerName` | `string` | Player display name |
+| `AccessToken` | `string` | JWT access token for service calls |
+| `Profile` | `string` | Current profile name |
+| `SessionTokenExists` | `bool` | True if a session token is cached |
+
+**Key distinction:** `IsSignedIn` means a token exists (even if expired). `IsAuthorized` means the token is currently valid. `IsExpired` means the token expired but still exists -- the SDK will attempt automatic refresh. If refresh fails, `SignInFailed` fires.
+
+---
+
+## Events
+
+| Event | Signature | When fired |
+|---|---|---|
+| `SignedIn` | `Action` | Sign-in succeeds |
+| `SignedOut` | `Action` | Player signs out |
+| `Expired` | `Action` | Access token expires; SDK auto-attempts refresh. Re-auth only needed if refresh fails (`SignInFailed` fires) |
+| `SignInFailed` | `Action<RequestFailedException>` | Sign-in or token refresh fails |
+| `SignInCodeReceived` | `Action<SignInCodeInfo>` | Device code flow: sign-in code generated |
+| `SignInCodeExpired` | `Action` | Device code flow: sign-in code expired |
+| `PlayerNameChanged` | `Action<string>` | Player name updated (provides new name) |
+| `PlayerIdChanged` | `Action<string>` | Player ID changed (provides new ID) |
+| `PlayerInfoChanged` | `Action<PlayerInfo>` | Player info updated |
+
+---
+
+## Player Info / Name
+
+```csharp
+Task<PlayerInfo> GetPlayerInfoAsync()
+Task<string> GetPlayerNameAsync(bool autoGenerate = true)
+Task<string> UpdatePlayerNameAsync(string name)
+```
+
+### `PlayerInfo` Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `Id` | `string` | UGS player ID |
+| `Username` | `string?` | Username (if set) |
+| `Identities` | `List<Identity>` | Linked external providers |
+| `CreatedAt` | `DateTime?` | Account creation time |
+| `LastPasswordUpdate` | `DateTime?` | Last password change |
+
+Helper methods: `GetGoogleId()`, `GetAppleId()`, `GetFacebookId()`, `GetSteamId()`, `GetOculusId()`, `GetGooglePlayGamesId()`, `GetAppleGameCenterId()`, `GetUnityId()`, `GetOpenIdConnectId(providerName)`, `GetCustomId()`, `GetOpenIdConnectIdProviders()`.
+
+---
+
+## Link / Unlink Methods
+
+All Link methods accept an optional `LinkOptions` parameter (for `ForceLink`).
+
+```csharp
+Task LinkWithGoogleAsync(string idToken, LinkOptions options = default)
+Task LinkWithGooglePlayGamesAsync(string authCode, LinkOptions options = default)
+Task LinkWithAppleAsync(string idToken, LinkOptions options = default)
+Task LinkWithAppleGameCenterAsync(string signature, string teamPlayerId, string publicKeyURL, string salt, ulong timestamp, LinkOptions options = default)
+Task LinkWithFacebookAsync(string accessToken, LinkOptions options = default)
+[Obsolete] Task LinkWithSteamAsync(string sessionTicket, LinkOptions options = default)
+Task LinkWithSteamAsync(string sessionTicket, string identity, LinkOptions options = default)
+Task LinkWithSteamAsync(string sessionTicket, string identity, string appId, LinkOptions options = default)
+Task LinkWithOculusAsync(string nonce, string userId, LinkOptions options = default)
+Task LinkWithOpenIdConnectAsync(string idProviderName, string idToken, LinkOptions options = default)
+Task LinkWithUnityAsync(string token, LinkOptions options = default)
+
+Task UnlinkGoogleAsync()
+Task UnlinkGooglePlayGamesAsync()
+Task UnlinkAppleAsync()
+Task UnlinkAppleGameCenterAsync()
+Task UnlinkFacebookAsync()
+Task UnlinkSteamAsync()
+Task UnlinkOculusAsync()
+Task UnlinkOpenIdConnectAsync(string idProviderName)
+Task UnlinkUnityAsync()
+```
+
+**Note:** There is no `UnlinkUsernamePasswordAsync`. Username/password credentials cannot be unlinked once linked.
+
+---
+
+## Profile Switching
+
+```csharp
+// Switch active profile. Must be called BEFORE sign-in. Synchronous.
+void SwitchProfile(string profile)
+
+// Clear cached session token for the active profile.
+void ClearSessionToken()
+
+// Process externally-obtained tokens.
+void ProcessAuthenticationTokens(string accessToken, string sessionToken = default)
+```
+
+Use `SwitchProfile(string profile)` before sign-in to store separate cached credentials per-profile (useful for multiple accounts on one device). Must be called BEFORE signing in -- call `SignOut()` first if already signed in.
+
+---
+
+## Username/Password Constraints
+
+| Field | Constraint |
+|---|---|
+| Username length | 3-20 characters |
+| Username characters | `A-Z`, `a-z`, `0-9`, `.`, `-`, `@`, `_` |
+| Username case | Case insensitive (stored lowercase) |
+| Password length | 8-30 characters |
+| Password requirements | At least 1 lowercase + 1 uppercase + 1 number + 1 symbol |
+
+Username/password credentials **cannot be unlinked** once linked. `UpdatePasswordAsync()` signs out all other devices for this player.
+
+Additional username/password management methods:
+
+```csharp
+// Add username/password to an existing signed-in account.
+Task AddUsernamePasswordAsync(string username, string password)
+
+// Update the password for the currently signed-in account.
+// WARNING: Signs out ALL other devices for this player.
+Task UpdatePasswordAsync(string currentPassword, string newPassword)
+```
+
+---
+
+## Options / Types
+
+### `SignInOptions`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `CreateAccount` | `bool` | `true` | If false, only sign in if an existing player maps to the credentials |
+
+### `LinkOptions`
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `ForceLink` | `bool` | `false` | If true, removes existing link on another player and reassigns to current |
+
+### `SignInCodeInfo`
+
+| Property | Type | Description |
+|---|---|---|
+| `SignInCode` | `string` | The code to display to the user |
+| `Identifier` | `string` | Identifier for the code |
+| `Expiration` | `string` | When the code expires |
+
+---
+
+## Identity Providers Quick Reference
+
+| Provider | Dashboard credentials | SDK input | SDK method |
+|---|---|---|---|
+| Anonymous | None | None | `SignInAnonymouslyAsync()` |
+| Google | Client ID, Client Secret | ID token | `SignInWithGoogleAsync(idToken)` |
+| Google Play Games | Client ID, Client Secret | Auth code | `SignInWithGooglePlayGamesAsync(authCode)` |
+| Apple | Client ID, Client Secret | ID token | `SignInWithAppleAsync(idToken)` |
+| Apple Game Center | Client ID, Client Secret | Signature bundle | `SignInWithAppleGameCenterAsync(...)` |
+| Facebook | Client ID, Client Secret | Access token | `SignInWithFacebookAsync(accessToken)` |
+| Steam | Publisher Web API Key | Session ticket + identity | `SignInWithSteamAsync(sessionTicket, identity)` |
+| Oculus | App ID, App Secret | Nonce + user ID | `SignInWithOculusAsync(nonce, userId)` |
+| OpenID Connect | Client ID, Client Secret, Issuer URL | ID token | `SignInWithOpenIdConnectAsync(providerName, idToken)` |
+| Unity Player Accounts | Enable in dashboard | Access token | `SignInWithUnityAsync(token)` |
+| Username / Password | Enable in dashboard | Username + password | `SignInWithUsernamePasswordAsync(u, p)` |
+
+All social identity providers are configured in the **Unity Dashboard**: Your project > Products > Authentication > Identity Providers > Add provider.
+
+---
+
+## Code Templates
+
+### Initialize and Sign In Anonymously
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+
+async Task InitAndSignIn()
+{
+    await UnityServices.InitializeAsync();
+
+    // SignInAnonymouslyAsync auto-detects returning vs new players:
+    // - If a session token exists, it signs in silently with the cached token
+    // - If no token exists, it creates a new anonymous account
+    if (!AuthenticationService.Instance.IsSignedIn)
+    {
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();
+    }
+
+    Debug.Log($"Signed in as {AuthenticationService.Instance.PlayerId}");
+}
+```
+
+### Sign In with Steam (with Identity Param)
+
+```csharp
+// sessionTicket from SteamUser.GetAuthSessionTicket
+// identity string for security (required -- old overload without it is deprecated)
+await AuthenticationService.Instance.SignInWithSteamAsync(sessionTicket, identity);
+
+// For sub-apps (PlayTest, Demo) -- include appId:
+await AuthenticationService.Instance.SignInWithSteamAsync(sessionTicket, identity, appId);
+```
+
+### Username/Password Sign Up then Sign In
+
+```csharp
+// First-time registration
+await AuthenticationService.Instance.SignUpWithUsernamePasswordAsync("myUsername", "MyPassword123!");
+
+// Subsequent sign-ins
+await AuthenticationService.Instance.SignInWithUsernamePasswordAsync("myUsername", "MyPassword123!");
+```
+
+### Link a Provider
+
+```csharp
+// Player is already signed in anonymously; link their Google account
+try
+{
+    await AuthenticationService.Instance.LinkWithGoogleAsync(googleIdToken);
+    Debug.Log("Google account linked successfully.");
+}
+catch (AuthenticationException ex) when (ex.ErrorCode == AuthenticationErrorCodes.AccountAlreadyLinked)
+{
+    Debug.LogWarning("This Google account is already linked to another player.");
+}
+
+// Force-link: removes existing link on another player and reassigns to current
+await AuthenticationService.Instance.LinkWithGoogleAsync(
+    idToken,
+    new LinkOptions { ForceLink = true });
+```
+
+### Switch Profile
+
+```csharp
+// Must sign out first, then switch, then sign in
+AuthenticationService.Instance.SignOut();
+AuthenticationService.Instance.SwitchProfile("ProfileB");
+await AuthenticationService.Instance.SignInAnonymouslyAsync();
+```
+
+### Token Expiry Handling
+
+```csharp
+AuthenticationService.Instance.Expired += () =>
+{
+    // Token expired - the SDK will attempt to refresh automatically.
+    // If refresh fails, you'll get SignInFailed and need to re-authenticate.
+    Debug.Log("Token expired, SDK is attempting refresh...");
+};
+
+AuthenticationService.Instance.SignInFailed += (ex) =>
+{
+    // Refresh failed, prompt user to sign in again
+    Debug.LogError($"Sign-in failed: {ex.Message}");
+};
+```
+
+### Error Handling
+
+```csharp
+try
+{
+    await AuthenticationService.Instance.SignInAnonymouslyAsync();
+}
+catch (AuthenticationException ex)
+{
+    // ex.ErrorCode contains the specific error code
+    Debug.LogError($"Auth failed: {ex.Message} (code: {ex.ErrorCode})");
+}
+catch (RequestFailedException ex)
+{
+    // Network or other service errors
+    Debug.LogError($"Request failed: {ex.Message}");
+}
+```
+
+### Account Management (GetPlayerInfo, UpdatePlayerName, DeleteAccount)
+
+```csharp
+// Get full player info
+var info = await AuthenticationService.Instance.GetPlayerInfoAsync();
+
+// Get or update player name
+var name = await AuthenticationService.Instance.GetPlayerNameAsync();
+var updated = await AuthenticationService.Instance.UpdatePlayerNameAsync("NewName");
+
+// Add username/password to existing account
+await AuthenticationService.Instance.AddUsernamePasswordAsync(username, password);
+
+// Update password (signs out ALL other devices for this player)
+await AuthenticationService.Instance.UpdatePasswordAsync(currentPassword, newPassword);
+
+// Delete account permanently
+await AuthenticationService.Instance.DeleteAccountAsync();
+```
+
+---
+
+## Error Handling
+
+Throws `AuthenticationException` (extends `RequestFailedException`) on failure. Use `ex.ErrorCode` and compare against `AuthenticationErrorCodes`:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `ClientInvalidUserState` | 10000 | Operation not valid in current state |
+| `ClientNoActiveSession` | 10001 | No active session |
+| `InvalidParameters` | 10002 | Bad input parameters |
+| `AccountAlreadyLinked` | 10003 | External ID already linked to another player |
+| `AccountLinkLimitExceeded` | 10004 | Max linked accounts for this provider type |
+| `ClientUnlinkExternalIdNotFound` | 10005 | External ID not linked |
+| `ClientInvalidProfile` | 10006 | Invalid profile name |
+| `InvalidSessionToken` | 10007 | Session token invalid or expired |
+| `InvalidProvider` | 10008 | Unknown identity provider |
+| `BannedUser` | 10009 | Player has been banned |
+| `EnvironmentMismatch` | 10010 | Session token from a different environment |
+
+**Error response format:** Authentication errors follow RFC 7807 (Problem Details). Branch your error handling on `status` and `title` fields, never on `detail` -- the detail message may change without notice.
+
+---
+
+## Session Warnings
+
+**Console platforms (Xbox, PlayStation, Switch):** Token refresh is NOT automatic. You must manually re-sign in when the token expires.
+
+**Anonymous-only accounts:** Calling `ClearSessionToken()` or `SignOut(clearCredentials: true)` on an account that ONLY has anonymous sign-in will **permanently lose** that account. Always link at least one external provider before clearing credentials.
+
+**DeleteAccountAsync compliance:** iOS App Store (Guideline 5.1.1) requires apps that support account creation to offer account deletion. `DeleteAccountAsync()` only deletes **Authentication data**. It does NOT automatically clean up data in other UGS services (Cloud Save, Economy, Leaderboards, etc.). You must manually delete data from each service before calling `DeleteAccountAsync()`.
+
+---
+
+## Asset Store Building Blocks
+
+- **Player Account Building Block:** Ready-made sign-in UI (anonymous, Unity browser, username/password), Cloud Save integration for player data, and a Cloud Code module for server-authoritative writes. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-player-account-341928)

--- a/skills/build-live-game/references/battlepass.md
+++ b/skills/build-live-game/references/battlepass.md
@@ -1,0 +1,860 @@
+# Battle Pass Blueprint
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Free Track vs Premium Track](#free-track-vs-premium-track)
+- [Multiple Concurrent Passes](#multiple-concurrent-passes)
+- [Data Models](#data-models)
+- [API Notes](#api-notes)
+  - [Namespace Aliases](#namespace-aliases-required)
+  - [ProtectedReadAccessClassOptions](#protectedreadaccessclassoptions)
+  - [Why tiersJson Is Passed from the Client](#why-tiersjson-is-passed-from-the-client)
+  - [Source Whitelist Enforcement](#source-whitelist-enforcement)
+  - [Error Handling](#error-handling)
+- [Cloud Code Module Functions](#cloud-code-module-functions)
+- [Load Pass Definitions from Remote Config](#load-pass-definitions-from-remote-config)
+- [Load Player Progress](#load-player-progress)
+- [Client to Cloud Code Calls](#client-to-cloud-code-calls)
+- [Full Client Implementation](#full-client-implementation)
+- [BattlePassTester](#battlepasstester)
+- [Cloud Code Module Implementation](#cloud-code-module-implementation)
+  - [BattlePassModule.cs](#battlepassmodulecs)
+  - [Server-Side Models](#server-side-models-inside-battlepassmodulecs)
+- [Cloud Resources](#cloud-resources)
+- [Deployment Checklist](#deployment-checklist)
+- [Validation](#validation)
+- [Asset Store & Sample Projects](#asset-store--sample-projects)
+
+---
+
+## Architecture Overview
+
+| Concern | Service | Key |
+|---|---|---|
+| Pass definitions | Remote Config | `"battle_passes"` |
+| Per-player progress | Cloud Save (Protected) | `"battle_pass_progress"` |
+| Award XP | Cloud Code | `BattlePassModule.AwardXp` |
+| Claim reward | Cloud Code | `BattlePassModule.ClaimReward` |
+| Purchase premium | Cloud Code | `BattlePassModule.PurchasePremium` |
+
+```
+Remote Config                Cloud Save (Protected)           Cloud Code Module
+"battle_passes"              "battle_pass_progress"           BattlePassModule
+       |                            |                               |
+       v                            v                               v
+BattlePassDefinition[]       { passId: Progress }            AwardXp
+  PassId, Name,              Server-writes only               ClaimReward
+  StartDate, EndDate,                                         PurchasePremium
+  Tiers[]
+       |                            ^                               |
+       |                            |                               |
+       +------- client reads -------+------- server writes ---------+
+```
+
+**Key principle:** The client reads pass definitions from Remote Config and player progress from Cloud Save (Protected bucket). All mutations -- awarding XP, claiming rewards, purchasing premium -- go through the Cloud Code module, which is the only writer to the Protected bucket.
+
+---
+
+## Free Track vs Premium Track
+
+Every tier in a battle pass has **two parallel reward tracks**:
+
+- **Free track** -- available to all players who reach the tier.
+- **Premium track** -- visible to all players but **locked** unless the player has purchased the premium pass (`HasPremium = true`).
+
+Premium rewards are displayed in the UI alongside free rewards so non-premium players can see what they are missing, encouraging upgrade. The Cloud Code module enforces the lock: `ClaimReward` with `rewardType = "premium"` throws if `HasPremium` is false.
+
+---
+
+## Multiple Concurrent Passes
+
+The system supports multiple battle passes running simultaneously:
+
+- Each pass has a unique `PassId` (e.g. `"season_03"`, `"easter_2026"`).
+- Passes may overlap in time. A player can have active progress in several passes at once.
+- Progress and premium status are tracked **independently per pass**. The Cloud Save key `"battle_pass_progress"` stores a `Dictionary<string, BattlePassProgress>` keyed by `PassId`.
+- **Date filtering is client-side.** The client fetches all pass definitions from Remote Config and filters to those whose `StartDate <= now <= EndDate`.
+- Expired passes remain in the progress dictionary. The client simply stops showing them. Clean up stale entries via a scheduled Cloud Code trigger if desired.
+
+---
+
+## Data Models
+
+### BattlePassDefinition (client-side, from Remote Config)
+
+```csharp
+[Serializable]
+public class BattlePassDefinition
+{
+    public string PassId;
+    public string Name;
+    public string StartDate;    // ISO 8601, e.g. "2026-04-01T00:00:00Z"
+    public string EndDate;      // ISO 8601
+    public List<BattlePassTier> Tiers;
+}
+```
+
+### BattlePassTier (client-side, from Remote Config)
+
+```csharp
+[Serializable]
+public class BattlePassTier
+{
+    public int TierNumber;
+    public int XpRequired;      // cumulative XP to reach this tier (not delta from previous)
+    public string FreeRewardId;
+    public string PremiumRewardId;
+}
+```
+
+### BattlePassProgress (client-side and server-side, from Cloud Save Protected)
+
+```csharp
+[Serializable]
+public class BattlePassProgress
+{
+    public int CurrentXp;
+    public int CurrentTier;
+    public bool HasPremium;
+    public List<string> ClaimedRewards;     // e.g. "tier_1_free", "tier_2_premium"
+}
+```
+
+One entry per pass, keyed by `PassId` in the progress dictionary stored at Cloud Save key `"battle_pass_progress"`.
+
+### BattlePassTierThreshold (server-side helper, passed from client via tiersJson)
+
+```csharp
+[Serializable]
+public class BattlePassTierThreshold
+{
+    public int TierNumber;
+    public int XpRequired;
+}
+```
+
+---
+
+## API Notes
+
+### Namespace Aliases (Required)
+
+Cloud Save has multiple types named `LoadOptions`, `SaveOptions`, and `DeleteOptions` across
+different namespaces. Always declare these aliases at the top of any file that uses Cloud Save:
+
+```csharp
+using PlayerLoadOptions   = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using PlayerSaveOptions   = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+using PlayerDeleteOptions = Unity.Services.CloudSave.Models.Data.Player.DeleteOptions;
+```
+
+Without these aliases, the compiler will report ambiguous type references.
+
+### ProtectedReadAccessClassOptions
+
+Use `ProtectedReadAccessClassOptions` when loading player progress. This reads the current
+player's own Protected data — no player ID parameter is required; it always reads the signed-in
+player's data.
+
+> **Common mistake:** Reading from the wrong access class (e.g. using default `LoadOptions`
+> instead of `ProtectedReadAccessClassOptions`) will return no data, because the progress
+> is stored in the Protected bucket by the Cloud Code module.
+
+### Why tiersJson Is Passed from the Client
+
+Remote Config is not accessible from inside Cloud Code modules. The client serializes the tier
+thresholds from the loaded `BattlePassDefinition` and sends them as the `tiersJson` parameter.
+The server uses these thresholds to recalculate the player's current tier after awarding XP.
+
+Tier thresholds are config data and are **not security-sensitive** — the anti-cheat protection
+is on the `source` whitelist and the `amount` validation. A tampered `tiersJson` could only
+cause the player's tier to be recalculated differently, which is bounded by their actual XP.
+
+### Source Whitelist Enforcement
+
+The Cloud Code module maintains a server-side whitelist of allowed XP source strings:
+
+```csharp
+static readonly HashSet<string> ValidSources = new()
+{
+    "match_complete",
+    "daily_login",
+    "quest_complete"
+};
+```
+
+Any `AwardXp` call with an unrecognized source throws an exception. Add or remove entries as
+needed for your game. The whitelist prevents clients from inventing arbitrary XP sources.
+
+### Error Handling
+
+Cloud Code and Cloud Save errors surface as typed exceptions on the client:
+
+```csharp
+try
+{
+    var progress = await AwardXpAsync(passId, 100, "match_complete");
+}
+catch (CloudCodeException ex)
+{
+    // ex.Reason: CloudCodeExceptionReason (e.g. ScriptError for module-thrown exceptions)
+    Debug.LogError($"[BattlePass] Cloud Code error: {ex.Reason} — {ex.Message}");
+}
+catch (CloudSaveException ex)
+{
+    // ex.Reason: CloudSaveExceptionReason
+    // A 403 on the Protected bucket means the client attempted a direct write —
+    // all writes must go through the Cloud Code module.
+    Debug.LogError($"[BattlePass] Cloud Save error: {ex.Reason} — {ex.Message}");
+}
+```
+
+---
+
+## Cloud Code Module Functions
+
+| Function | Parameters | Behavior |
+|---|---|---|
+| `AwardXp` | `passId`, `amount`, `source`, `tiersJson` | Validates `source` against a whitelist (`ValidSources`), rejects non-positive amounts, adds XP to the pass progress, recalculates the current tier from the client-supplied `tiersJson`, saves to Cloud Save Protected |
+| `ClaimReward` | `passId`, `tierNumber`, `rewardType` | Validates the player has reached the tier, validates premium ownership if `rewardType` is `"premium"`, checks reward is not already claimed, records the claim as `"tier_N_type"` (e.g. `"tier_2_premium"`), saves to Cloud Save Protected |
+| `PurchasePremium` | `passId` | Sets `HasPremium = true` on the pass progress. **Idempotent** -- returns immediately if already purchased without error |
+
+All three functions return the updated `BattlePassProgress` for the given pass.
+
+---
+
+## Load Pass Definitions from Remote Config
+
+```csharp
+struct UserAttributes {}
+struct AppAttributes {}
+
+async Task<List<BattlePassDefinition>> LoadActivePassesAsync()
+{
+    var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+        new UserAttributes(), new AppAttributes());
+
+    var token = result.config["battle_passes"];
+    if (token == null) return new List<BattlePassDefinition>();
+
+    var allPasses = token.ToObject<List<BattlePassDefinition>>();
+
+    var now = DateTime.UtcNow;
+    return allPasses
+        .Where(p =>
+            DateTime.Parse(p.StartDate, null, DateTimeStyles.RoundtripKind) <= now &&
+            DateTime.Parse(p.EndDate,   null, DateTimeStyles.RoundtripKind) >= now)
+        .ToList();
+}
+```
+
+- `FetchConfigsAsync` downloads all Remote Config entries.
+- `result.config["battle_passes"]` returns a `JToken` for the JSON array stored under that key.
+- Date filtering is performed client-side by comparing `StartDate` and `EndDate` against `DateTime.UtcNow`.
+
+---
+
+## Load Player Progress
+
+```csharp
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerLoadOptions = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+
+async Task<Dictionary<string, BattlePassProgress>> LoadProgressAsync()
+{
+    var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+        new HashSet<string> { "battle_pass_progress" },
+        new PlayerLoadOptions(new ProtectedReadAccessClassOptions()));
+
+    if (!result.TryGetValue("battle_pass_progress", out var item))
+        return new Dictionary<string, BattlePassProgress>();
+
+    return JsonConvert.DeserializeObject<Dictionary<string, BattlePassProgress>>(
+        item.Value.GetAsString())
+        ?? new Dictionary<string, BattlePassProgress>();
+}
+```
+
+**Important:** Use `ProtectedReadAccessClassOptions` because the Cloud Code module writes to the Protected bucket. Reading from the wrong access class will return no data.
+
+> **Stale entries:** Expired pass entries remain in the dictionary indefinitely but are inert —
+> the client ignores any PassId not present in the current active pass list.
+
+---
+
+## Client to Cloud Code Calls
+
+### AwardXpAsync
+
+```csharp
+public async Task<BattlePassProgress> AwardXpAsync(string passId, int amount, string source)
+{
+    var pass = ActivePasses.FirstOrDefault(p => p.PassId == passId)
+        ?? throw new InvalidOperationException(
+            $"Pass '{passId}' is not in the active passes list. Call LoadAsync first.");
+
+    var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+        "BattlePassModule", "AwardXp",
+        new Dictionary<string, object>
+        {
+            { "passId",    passId                               },
+            { "amount",    amount                               },
+            { "source",    source                               },
+            { "tiersJson", JsonConvert.SerializeObject(pass.Tiers) }
+        });
+
+    Progress[passId] = progress;
+    return progress;
+}
+```
+
+The `tiersJson` parameter is the serialized tier list from the locally loaded pass definition. The server uses it to recalculate the player's tier after adding XP, without needing its own Remote Config fetch.
+
+### ClaimRewardAsync
+
+```csharp
+public async Task<BattlePassProgress> ClaimRewardAsync(
+    string passId, int tierNumber, string rewardType)
+{
+    var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+        "BattlePassModule", "ClaimReward",
+        new Dictionary<string, object>
+        {
+            { "passId",      passId      },
+            { "tierNumber",  tierNumber  },
+            { "rewardType",  rewardType  }
+        });
+
+    Progress[passId] = progress;
+    return progress;
+}
+```
+
+### PurchasePremiumAsync
+
+```csharp
+public async Task<BattlePassProgress> PurchasePremiumAsync(string passId)
+{
+    var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+        "BattlePassModule", "PurchasePremium",
+        new Dictionary<string, object> { { "passId", passId } });
+
+    Progress[passId] = progress;
+    return progress;
+}
+```
+
+---
+
+## Full Client Implementation
+
+`BattlePassManager` is a `MonoBehaviour` that initializes services, loads pass definitions and player progress, and exposes methods for XP awards, reward claims, and premium purchases. Attach it to a GameObject in your scene.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.Authentication;
+using Unity.Services.CloudCode;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerLoadOptions = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using Unity.Services.Core;
+using Unity.Services.RemoteConfig;
+using UnityEngine;
+
+public class BattlePassManager : MonoBehaviour
+{
+    public List<BattlePassDefinition> ActivePasses { get; private set; } = new();
+    public Dictionary<string, BattlePassProgress> Progress { get; private set; } = new();
+
+    public event Action Loaded;
+
+    async void Start()
+    {
+        try
+        {
+            await UnityServices.InitializeAsync();
+            if (!AuthenticationService.Instance.IsSignedIn)
+            {
+                await AuthenticationService.Instance.SignInAnonymouslyAsync();
+            }
+            await LoadAsync();
+            Debug.Log($"BattlePassManager: Loaded {ActivePasses.Count} passes.");
+            Loaded?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"BattlePassManager: Error during loading: {ex.Message}\n{ex.StackTrace}");
+        }
+    }
+
+    public async Task LoadAsync()
+    {
+        ActivePasses = await LoadActivePassesAsync();
+        Progress     = await LoadProgressAsync();
+    }
+
+    struct UserAttributes {}
+    struct AppAttributes {}
+
+    async Task<List<BattlePassDefinition>> LoadActivePassesAsync()
+    {
+        var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+            new UserAttributes(), new AppAttributes());
+
+        var token = result.config["battle_passes"];
+        if (token == null) return new List<BattlePassDefinition>();
+
+        var allPasses = token.ToObject<List<BattlePassDefinition>>();
+
+        var now = DateTime.UtcNow;
+        return allPasses
+            .Where(p =>
+                DateTime.Parse(p.StartDate, null, DateTimeStyles.RoundtripKind) <= now &&
+                DateTime.Parse(p.EndDate,   null, DateTimeStyles.RoundtripKind) >= now)
+            .ToList();
+    }
+
+    async Task<Dictionary<string, BattlePassProgress>> LoadProgressAsync()
+    {
+        var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+            new HashSet<string> { "battle_pass_progress" },
+            new PlayerLoadOptions(new ProtectedReadAccessClassOptions()));
+
+        if (!result.TryGetValue("battle_pass_progress", out var item))
+            return new Dictionary<string, BattlePassProgress>();
+
+        return JsonConvert.DeserializeObject<Dictionary<string, BattlePassProgress>>(
+            item.Value.GetAsString())
+            ?? new Dictionary<string, BattlePassProgress>();
+    }
+
+    public async Task<BattlePassProgress> AwardXpAsync(string passId, int amount, string source)
+    {
+        var pass = ActivePasses.FirstOrDefault(p => p.PassId == passId)
+            ?? throw new InvalidOperationException(
+                $"Pass '{passId}' is not in the active passes list. Call LoadAsync first.");
+
+        var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+            "BattlePassModule", "AwardXp",
+            new Dictionary<string, object>
+            {
+                { "passId",    passId                               },
+                { "amount",    amount                               },
+                { "source",    source                               },
+                { "tiersJson", JsonConvert.SerializeObject(pass.Tiers) }
+            });
+
+        Progress[passId] = progress;
+        return progress;
+    }
+
+    public async Task<BattlePassProgress> ClaimRewardAsync(
+        string passId, int tierNumber, string rewardType)
+    {
+        var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+            "BattlePassModule", "ClaimReward",
+            new Dictionary<string, object>
+            {
+                { "passId",      passId      },
+                { "tierNumber",  tierNumber  },
+                { "rewardType",  rewardType  }
+            });
+
+        Progress[passId] = progress;
+        return progress;
+    }
+
+    public async Task<BattlePassProgress> PurchasePremiumAsync(string passId)
+    {
+        var progress = await CloudCodeService.Instance.CallModuleEndpointAsync<BattlePassProgress>(
+            "BattlePassModule", "PurchasePremium",
+            new Dictionary<string, object> { { "passId", passId } });
+
+        Progress[passId] = progress;
+        return progress;
+    }
+}
+```
+
+---
+
+## BattlePassTester
+
+Attach to the same GameObject as `BattlePassManager` in your test scene. Wire `m_Manager` via
+the Inspector, or let it fall back to `GetComponent`.
+
+```csharp
+using System.Text;
+using UnityEngine;
+
+/// <summary>
+/// Attach alongside BattlePassManager to run a quick in-Editor smoke test.
+/// On load: logs all active pass states.
+/// Then: awards 100 XP to the first active pass via Cloud Code and logs the result.
+/// </summary>
+public class BattlePassTester : MonoBehaviour
+{
+    [SerializeField] BattlePassManager m_Manager;
+
+    void Start()
+    {
+        if (m_Manager == null)
+            m_Manager = GetComponent<BattlePassManager>();
+        m_Manager.Loaded += OnLoaded;
+    }
+
+    async void OnLoaded()
+    {
+        LogState("Initial state");
+
+        if (m_Manager.ActivePasses.Count == 0)
+        {
+            Debug.Log("[BattlePassTester] No active passes — nothing to award.");
+            return;
+        }
+
+        var firstPass = m_Manager.ActivePasses[0];
+        Debug.Log($"[BattlePassTester] Awarding 100 XP to '{firstPass.PassId}' " +
+            $"(source: match_complete) ...");
+
+        var result = await m_Manager.AwardXpAsync(firstPass.PassId, 100, "match_complete");
+
+        Debug.Log($"[BattlePassTester] After award — " +
+            $"XP={result.CurrentXp}, Tier={result.CurrentTier}");
+    }
+
+    void LogState(string label)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"[BattlePassTester] {label} — {m_Manager.ActivePasses.Count} active pass(es):");
+
+        foreach (var pass in m_Manager.ActivePasses)
+        {
+            m_Manager.Progress.TryGetValue(pass.PassId, out var progress);
+            sb.AppendLine($"  [{pass.PassId}] {pass.Name}: " +
+                $"XP={progress?.CurrentXp ?? 0}, " +
+                $"Tier={progress?.CurrentTier ?? 1}, " +
+                $"Premium={progress?.HasPremium ?? false}, " +
+                $"Claimed={progress?.ClaimedRewards?.Count ?? 0}");
+        }
+
+        Debug.Log(sb.ToString());
+    }
+}
+```
+
+---
+
+## Cloud Code Module Implementation
+
+> **Module scaffolding — follow [cloud-code.md — Module Creation](cloud-code.md#module-creation).**
+> Replace `MyModule` / `MyModuleCCM` with `BattlePassModule` / `BattlePassCCM` throughout.
+> You **must** create every file listed there — missing any one will cause deployment to fail:
+>
+> - [ ] `.sln` (generate fresh GUIDs)
+> - [ ] `.csproj` (net9.0, CloudCode.Apis + CloudCode.Core)
+> - [ ] `ModuleSetup.cs` (registers `GameApiClient`)
+> - [ ] `Properties/PublishProfiles/FolderProfile.pubxml` — **without this file, deployment fails with "Failed to retrieve main project"**
+> - [ ] `Assets/CloudCode/BattlePassModule.ccmr` (points to the `.sln`)
+
+### BattlePassModule.cs
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Core;
+using Unity.Services.CloudSave.Model;
+
+public class BattlePassModule
+{
+    const string ProgressKey = "battle_pass_progress";
+
+    static readonly HashSet<string> ValidSources = new()
+    {
+        "match_complete",
+        "daily_login",
+        "quest_complete"
+    };
+
+    // ── AwardXp ──────────────────────────────────────────────────────────────
+
+    [CloudCodeFunction("AwardXp")]
+    public async Task<BattlePassProgress> AwardXp(
+        IExecutionContext context, IGameApiClient client,
+        string passId, int amount, string source, string tiersJson)
+    {
+        if (!ValidSources.Contains(source))
+            throw new Exception(
+                $"Invalid XP source: '{source}'. Allowed: {string.Join(", ", ValidSources)}");
+
+        if (amount <= 0)
+            throw new Exception("XP amount must be positive.");
+
+        var allProgress = await LoadProgressAsync(context, client);
+
+        if (!allProgress.TryGetValue(passId, out var progress))
+            progress = new BattlePassProgress { CurrentTier = 1, ClaimedRewards = new List<string>() };
+
+        progress.CurrentXp += amount;
+
+        var tiers = JsonConvert.DeserializeObject<List<BattlePassTierThreshold>>(tiersJson)
+            ?? throw new Exception("tiersJson could not be deserialized.");
+        progress.CurrentTier = CalculateTier(progress.CurrentXp, tiers);
+
+        allProgress[passId] = progress;
+        await SaveProgressAsync(context, client, allProgress);
+
+        return progress;
+    }
+
+    // ── ClaimReward ──────────────────────────────────────────────────────────
+
+    [CloudCodeFunction("ClaimReward")]
+    public async Task<BattlePassProgress> ClaimReward(
+        IExecutionContext context, IGameApiClient client,
+        string passId, int tierNumber, string rewardType)
+    {
+        if (rewardType != "free" && rewardType != "premium")
+            throw new Exception(
+                $"Invalid rewardType: '{rewardType}'. Must be 'free' or 'premium'.");
+
+        var allProgress = await LoadProgressAsync(context, client);
+
+        if (!allProgress.TryGetValue(passId, out var progress))
+            throw new Exception($"No progress found for pass '{passId}'. Award XP first.");
+
+        if (progress.CurrentTier < tierNumber)
+            throw new Exception(
+                $"Tier {tierNumber} not yet reached (current tier: {progress.CurrentTier}).");
+
+        if (rewardType == "premium" && !progress.HasPremium)
+            throw new Exception("Premium pass not owned. Purchase premium first.");
+
+        var rewardKey = $"tier_{tierNumber}_{rewardType}";
+        if (progress.ClaimedRewards.Contains(rewardKey))
+            throw new Exception($"Reward '{rewardKey}' already claimed.");
+
+        progress.ClaimedRewards.Add(rewardKey);
+        allProgress[passId] = progress;
+        await SaveProgressAsync(context, client, allProgress);
+
+        return progress;
+    }
+
+    // ── PurchasePremium ──────────────────────────────────────────────────────
+
+    [CloudCodeFunction("PurchasePremium")]
+    public async Task<BattlePassProgress> PurchasePremium(
+        IExecutionContext context, IGameApiClient client, string passId)
+    {
+        var allProgress = await LoadProgressAsync(context, client);
+
+        if (!allProgress.TryGetValue(passId, out var progress))
+            progress = new BattlePassProgress { CurrentTier = 1, ClaimedRewards = new List<string>() };
+
+        if (progress.HasPremium)
+            return progress;   // idempotent -- already owns premium
+
+        progress.HasPremium = true;
+        allProgress[passId] = progress;
+        await SaveProgressAsync(context, client, allProgress);
+
+        return progress;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    static int CalculateTier(int currentXp, List<BattlePassTierThreshold> tiers)
+    {
+        var reached = tiers
+            .Where(t => currentXp >= t.XpRequired)
+            .OrderByDescending(t => t.TierNumber)
+            .FirstOrDefault();
+
+        return reached?.TierNumber ?? 1;
+    }
+
+    async Task<Dictionary<string, BattlePassProgress>> LoadProgressAsync(
+        IExecutionContext context, IGameApiClient client)
+    {
+        var result = await client.CloudSaveData.GetProtectedItemsAsync(
+            context, context.ServiceToken, context.ProjectId,
+            context.PlayerId!, new List<string> { ProgressKey });
+
+        var value = result.Data?.Results?.FirstOrDefault()?.Value?.ToString();
+        if (string.IsNullOrEmpty(value))
+            return new Dictionary<string, BattlePassProgress>();
+
+        return JsonConvert.DeserializeObject<Dictionary<string, BattlePassProgress>>(value)
+            ?? new Dictionary<string, BattlePassProgress>();
+    }
+
+    async Task SaveProgressAsync(
+        IExecutionContext context, IGameApiClient client,
+        Dictionary<string, BattlePassProgress> progress)
+    {
+        var json = JsonConvert.SerializeObject(progress);
+        var body = new SetItemBody(ProgressKey, json);
+        await client.CloudSaveData.SetProtectedItemAsync(
+            context, context.ServiceToken, context.ProjectId, context.PlayerId!, body);
+    }
+}
+```
+
+### Server-Side Models (inside BattlePassModule.cs)
+
+```csharp
+public class BattlePassProgress
+{
+    public int CurrentXp { get; set; }
+    public int CurrentTier { get; set; }
+    public bool HasPremium { get; set; }
+    public List<string> ClaimedRewards { get; set; } = new();
+}
+
+public class BattlePassTierThreshold
+{
+    public int TierNumber { get; set; }
+    public int XpRequired { get; set; }
+}
+```
+
+---
+
+## Cloud Resources
+
+### Remote Config `.rc` File
+
+Place at `Assets/BattlePasses.rc`. Contains pass definitions as a JSON array under the `"battle_passes"` key. Example with two concurrent passes:
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/remote-config.schema.json",
+  "entries": {
+    "battle_passes": [
+      {
+        "PassId": "season_03",
+        "Name": "Season 3",
+        "StartDate": "2024-01-01T00:00:00Z",
+        "EndDate": "2026-06-30T23:59:59Z",
+        "Tiers": [
+          { "TierNumber": 1, "XpRequired": 0,    "FreeRewardId": "item_bronze_badge",      "PremiumRewardId": "currency_gold_500" },
+          { "TierNumber": 2, "XpRequired": 500,  "FreeRewardId": "item_xp_boost",          "PremiumRewardId": "item_rare_skin_fragment" },
+          { "TierNumber": 3, "XpRequired": 1200, "FreeRewardId": "item_silver_badge",      "PremiumRewardId": "item_legendary_skin" }
+        ]
+      },
+      {
+        "PassId": "easter_2026",
+        "Name": "Easter Event 2026",
+        "StartDate": "2026-04-01T00:00:00Z",
+        "EndDate": "2026-04-21T23:59:59Z",
+        "Tiers": [
+          { "TierNumber": 1, "XpRequired": 0,    "FreeRewardId": "item_egg_basket",     "PremiumRewardId": "item_golden_egg" },
+          { "TierNumber": 2, "XpRequired": 300,  "FreeRewardId": "item_bunny_ears",     "PremiumRewardId": "item_bunny_mount" }
+        ]
+      }
+    ]
+  },
+  "types": {
+    "battle_passes": "JSON"
+  }
+}
+```
+
+**Rules:**
+
+- `PassId` must be unique across all passes and stable over time — it is the key used in player
+  progress records. Never rename a `PassId` after launch.
+- `XpRequired` is **cumulative** XP to reach the tier, not a delta from the previous tier.
+  Tier 1 must always have `XpRequired: 0` so it is immediately reachable.
+- `FreeRewardId` / `PremiumRewardId` are arbitrary strings. The client reads these IDs and maps
+  them to display names/icons locally.
+- Date filtering happens **client-side** after fetch. Add passes to the file before their
+  `StartDate` — they will be ignored by the client until the start time is reached.
+
+### Cloud Code Module
+
+> Create the full module solution using the file table and templates in
+> [Cloud Code Module Implementation](#cloud-code-module-implementation) above.
+> All scaffolding files (`.sln`, `.csproj`, `ModuleSetup.cs`, `FolderProfile.pubxml`) are
+> **required** — the Deployment Window will fail without them. See
+> [cloud-code.md — Module Creation](cloud-code.md#module-creation) for the generic templates;
+> replace `MyModule` / `MyModuleCCM` with `BattlePassModule` / `BattlePassCCM`.
+
+### Access Control
+
+**No Access Control (`.ac`) file is needed for the battle pass.** The Cloud Save Protected bucket is inherently server-only for writes -- only Cloud Code (using `IGameApiClient` with the service token) can write to it. Clients can read Protected data but cannot modify it.
+
+> **Contrast with achievements:** The achievements skill offered a direct-write dev path using
+> the Public bucket, which required an explicit Access Control policy to lock down in production.
+> Battle pass has no direct-write path, so there is nothing to lock down.
+
+### `manifest.json` Entries
+
+Ensure these packages are listed in `Packages/manifest.json`:
+
+```json
+{
+  "dependencies": {
+    "com.unity.services.authentication": "3.6.1",
+    "com.unity.services.cloudcode": "2.10.2",
+    "com.unity.services.cloudsave": "3.4.0",
+    "com.unity.services.core": "1.16.0",
+    "com.unity.services.deployment": "1.7.2",
+    "com.unity.remote-config": "4.2.5",
+    "com.unity.services.tooling": "1.4.1",
+    "com.unity.nuget.newtonsoft-json": "3.2.2"
+  }
+}
+```
+
+`com.unity.nuget.newtonsoft-json` is required for `JsonConvert` used in serialization of tier data and progress.
+
+---
+
+## Deployment Checklist
+
+- [ ] All packages added to `Packages/manifest.json`
+- [ ] Remote Config `.rc` file created with `"battle_passes"` entry and at least one active pass
+- [ ] Cloud Code module scaffolded with **all required files**: `.sln`, `.csproj`, `ModuleSetup.cs`, `FolderProfile.pubxml`, `.ccmr` (see file table in [Cloud Code Module Implementation](#cloud-code-module-implementation))
+- [ ] `BattlePassModule.cs` added to the module project with `AwardXp`, `ClaimReward`, `PurchasePremium` functions
+- [ ] Environment selected in **Services > Deployment** settings
+- [ ] Deploy all via the Deployment Window: select `BattlePasses.rc` and `BattlePassModule.ccmr`, click **Deploy**
+- [ ] Project linked in **Edit > Project Settings > Services**
+
+---
+
+## Validation
+
+After implementing the battle pass feature, verify:
+
+1. **Project compiles** without errors. Both the Unity project and the `BattlePassCCM/` .NET project should build cleanly.
+2. **Initialization order** is correct: `UnityServices.InitializeAsync()` then `AuthenticationService.Instance.SignInAnonymouslyAsync()` then service calls.
+3. **Protected bucket reads** use `ProtectedReadAccessClassOptions` -- using the wrong access class returns no data.
+4. **Cloud Code module name** matches the `.ccmr` filename: `"BattlePassModule"` in `CallModuleEndpointAsync` matches `BattlePassModule.ccmr`.
+5. **No direct client writes** to `"battle_pass_progress"` -- all mutations go through Cloud Code.
+6. **tiersJson is serialized** from the locally loaded pass definition before calling `AwardXp`.
+7. **Date filtering** uses `DateTime.UtcNow` with `DateTimeStyles.RoundtripKind` for consistent UTC parsing.
+8. **Cloud resources** are present and deployable: `BattlePasses.rc` and `BattlePassModule.ccmr` appear in the Deployment Window.
+9. **PurchasePremium is idempotent** -- calling it when `HasPremium` is already true returns the existing progress without error.
+10. **ClaimReward validates** both tier reach and premium ownership before recording the claim.
+
+---
+
+## Asset Store & Sample Projects
+
+- **Use Case Samples — Battle Pass:** The official [Use Case Samples](https://github.com/Unity-Technologies/com.unity.services.samples.use-cases) repository includes a complete Battle Pass sample with seasonal reward tiers, free/premium tracks, time-limited rewards, and server-authoritative progression via Cloud Code. Clone the repo and open the "Battle Pass" scene for a working reference.
+- **Use Case Samples — Virtual Shop:** The same repository includes a Virtual Shop sample demonstrating Economy-based in-game stores, currency management, and inventory — patterns commonly paired with a Battle Pass.

--- a/skills/build-live-game/references/cloud-code.md
+++ b/skills/build-live-game/references/cloud-code.md
@@ -1,0 +1,563 @@
+# Cloud Code Reference
+
+## Table of Contents
+
+- [Anti-Hallucination Reference](#anti-hallucination-reference)
+- [Two Execution Models](#two-execution-models)
+- [ICloudCodeService Methods](#icloudcodeservice-methods)
+- [Module Runtime Constraints](#module-runtime-constraints)
+- [Subscriptions](#subscriptions)
+- [Triggers](#triggers)
+- [Module Scope](#module-scope)
+- [Module Creation](#module-creation)
+- [Generated Type-Safe Bindings](#generated-type-safe-bindings)
+- [Code Templates](#code-templates)
+- [Deploying via the Deployment Window](#deploying-via-the-deployment-window)
+- [Error Handling](#error-handling)
+
+Accessed via `CloudCodeService.Instance` (`ICloudCodeService`, namespace `Unity.Services.CloudCode`). Assembly: `Unity.Services.CloudCode`.
+
+Call `UnityServices.InitializeAsync()` from `com.unity.services.core` and sign in via `com.unity.services.authentication` before use.
+
+---
+
+## Anti-Hallucination Reference
+
+| Correct | Incorrect (do NOT use) |
+|---|---|
+| `CallModuleEndpointAsync("Module", "Function", args)` | `CallEndpointAsync` for modules |
+| `CallEndpointAsync("scriptName", args)` | `CallEndpointAsync` for modules -- scripts only |
+| `SubscribeToPlayerMessagesAsync()` -- no parameters | `SubscribeToPlayerMessagesAsync(callbacks)` |
+| `SubscribeToProjectMessagesAsync()` -- no parameters | `SubscribeToGeneralMessagesAsync`, `SubscribeToProjectMessagesAsync(callbacks)` |
+| `subscription.Callbacks.MessageReceived += handler` | Passing callbacks as constructor/method arg |
+| Non-generic `CallEndpointAsync` returns `Task<string>` | Returns `Task` (void) -- it returns a string |
+| Non-generic `CallModuleEndpointAsync` returns `Task<string>` | Returns `Task` (void) -- it returns a string |
+| `EventConnectionState` enum | `SubscriptionEventConnectionState` |
+| `Error` callback is `Action<string>` | `Action<EventConnectionState>` |
+
+---
+
+## Two Execution Models
+
+| Model | Language | Client Method | Deployed as |
+|---|---|---|---|
+| **Scripts** | JavaScript | `CallEndpointAsync` | `.js` files via Deployment Window |
+| **Modules** | C# (.NET 9) | `CallModuleEndpointAsync` | `.ccmr` module references via Deployment Window |
+
+**Recommendation:** Prefer **C# modules** over JavaScript scripts for production. Modules offer type safety, generated client bindings, and access to NuGet packages. Use scripts only for lightweight prototyping.
+
+---
+
+## ICloudCodeService Methods
+
+```csharp
+// Call a Cloud Code Script endpoint. Returns the script's return value as string.
+Task<string> CallEndpointAsync(string function, Dictionary<string, object> args = default)
+
+// Call a Cloud Code Script endpoint with typed deserialization.
+Task<TResult> CallEndpointAsync<TResult>(string function, Dictionary<string, object> args = default)
+
+// Call a Cloud Code Module endpoint. Returns the result as string.
+// module = module name (filename of .ccmr without extension), function = method name.
+Task<string> CallModuleEndpointAsync(string module, string function,
+    Dictionary<string, object> args = default, CloudCodeModuleScope scope = default)
+
+// Call a Cloud Code Module endpoint with typed deserialization.
+Task<TResult> CallModuleEndpointAsync<TResult>(string module, string function,
+    Dictionary<string, object> args = default, CloudCodeModuleScope scope = default)
+
+// Subscribe to real-time messages sent to the current player. Requires Wire. NO PARAMETERS.
+Task<ISubscriptionEvents> SubscribeToPlayerMessagesAsync()
+
+// Subscribe to real-time project-wide messages. Requires Wire. NO PARAMETERS.
+Task<ISubscriptionEvents> SubscribeToProjectMessagesAsync()
+```
+
+**CRITICAL:** The first argument to `CallModuleEndpointAsync` is the **module name**, the second is the **function name**. Do NOT confuse the parameter order.
+
+---
+
+## Module Runtime Constraints
+
+- **Cold start:** After ~15 minutes of inactivity, the module's worker shuts down. The next call experiences a latency spike while the worker spins up. Design your UX to tolerate this.
+- **No UnityEngine:** Modules run on standard .NET. The `UnityEngine` namespace is NOT available. Use only .NET APIs and NuGet packages.
+- **Push messages:** Server-to-client push messages can only be sent from **modules**, not from JavaScript scripts.
+
+---
+
+## Subscriptions
+
+Cloud Code Subscriptions require `com.unity.services.wire`. Subscribe to real-time server-push messages.
+
+### `ISubscriptionEvents`
+
+```csharp
+public interface ISubscriptionEvents
+{
+    SubscriptionEventCallbacks Callbacks { get; }  // Wire up handlers here
+    Task SubscribeAsync();      // Re-subscribe after unsubscribing
+    Task UnsubscribeAsync();    // Stop receiving messages
+}
+```
+
+### `SubscriptionEventCallbacks`
+
+Wire up callbacks on the `Callbacks` property of the returned `ISubscriptionEvents`:
+
+```csharp
+var subscription = await CloudCodeService.Instance.SubscribeToPlayerMessagesAsync();
+subscription.Callbacks.MessageReceived += OnMessageReceived;       // Action<IMessageReceivedEvent>
+subscription.Callbacks.MessageBytesReceived += OnBytesReceived;    // Action<byte[]>
+subscription.Callbacks.ConnectionStateChanged += OnStateChanged;   // Action<EventConnectionState>
+subscription.Callbacks.Kicked += OnKicked;                         // Action
+subscription.Callbacks.Error += OnError;                           // Action<string>
+```
+
+### `IMessageReceivedEvent` Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `MessageType` | `string` | Message type identifier set by the server |
+| `Message` | `string` | Raw message payload (typically JSON) |
+| `Id` | `string` | Unique message ID |
+| `CorrelationId` | `string` | Correlation ID for tracing |
+| `Source` | `string` | Source of the message |
+| `Type` | `string` | CloudEvents type |
+| `SpecVersion` | `string` | CloudEvents spec version |
+| `Time` | `DateTime` | Timestamp |
+| `ProjectId` | `string` | UGS project ID |
+| `EnvironmentId` | `string` | UGS environment ID |
+
+### `EventConnectionState`
+
+Namespace: `Unity.Services.CloudCode.Subscriptions`.
+
+| State | Value | Meaning |
+|---|---|---|
+| `Unknown` | 0 | Initial state |
+| `Unsubscribed` | 1 | Not connected |
+| `Subscribing` | 2 | Connection in progress |
+| `Subscribed` | 3 | Connected and receiving messages |
+| `Unsynced` | 4 | Temporarily disconnected, will reconnect |
+| `Error` | 5 | Connection error |
+
+---
+
+## Triggers
+
+Triggers let Cloud Code endpoints run automatically in response to events from other UGS services, without any client call. Configured in the Unity Dashboard or via the UGS CLI, not in client code.
+
+| Emitter | Example trigger events |
+|---|---|
+| Authentication | Player signed in, account deleted |
+| Scheduler | Cron-based or one-shot scheduled events |
+| Leaderboards | Score submitted, leaderboard reset |
+| Cloud Save | Data saved, data deleted |
+
+---
+
+## Module Scope
+
+`CallModuleEndpointAsync` accepts an optional `CloudCodeModuleScope` to scope execution. Namespace: `Unity.Services.CloudCode.Models`.
+
+```csharp
+// Scope to a multiplayer session
+var scope = new CloudCodeModuleScope(ScopeType.MultiplayerSession, sessionId);
+var result = await CloudCodeService.Instance.CallModuleEndpointAsync<MyResult>(
+    "MyModule", "MyFunction", args, scope);
+```
+
+### `ScopeType` Enum
+
+| Scope Type | Value | Description |
+|---|---|---|
+| `MultiplayerSession` | 1 | Scoped to a multiplayer session ID |
+| `Player` | 2 | Scoped to the calling player (default) |
+
+---
+
+## Module Creation
+
+A Cloud Code module is a .NET 9 class library built and published by the Deployment Window.
+
+**A deployable module requires ALL of the following files — skipping any one breaks the build or deploy step:** the `<Module>.sln` solution, the `<Module>/<Module>.csproj` main project (with the NuGet references shown below), the module class (`<Module>.cs`) with at least one `[CloudCodeFunction]` endpoint, `ModuleSetup.cs` implementing `ICloudCodeSetup`, `<Module>/Properties/PublishProfiles/FolderProfile.pubxml` for the linux-x64 publish, and the `Assets/.../<Module>.ccmr` Unity asset pointing at the `.sln`. A `.ccmr` referencing a missing `.sln`, or a module folder lacking `.csproj`/`FolderProfile.pubxml`, is incomplete and the Deployment Window will fail to publish it.
+
+### Directory Structure
+
+Place the module at the **project root** (alongside `Assets/`). Unity does not scan the project root, so no `~` suffix is needed.
+
+> **Tilde rule:** Only add `~` to a folder name (e.g. `MyModule~/`) when the module lives **inside `Assets/`** -- the suffix tells Unity to skip that folder during compilation. At the project root, omit it.
+
+```
+<ProjectRoot>/
+  Assets/
+    CloudCode/
+      MyModule.ccmr                         <-- Unity asset pointing to the .sln
+  MyModuleCCM/
+    MyModule.sln
+    MyModule/
+      MyModule.csproj
+      MyModule.cs                           <-- [CloudCodeFunction] entry points
+      ModuleSetup.cs                        <-- registers IGameApiClient via DI
+      Properties/
+        PublishProfiles/
+          FolderProfile.pubxml              <-- publish to linux-x64 (required)
+    MyModule.Tests/
+      MyModule.Tests.csproj                 <-- IsPublishable=false, never deployed
+      MyModuleTests.cs
+```
+
+### `.gitignore` (keep module files tracked)
+
+Unity's stock `.gitignore` excludes `*.sln` and `*.csproj` project-wide. Without an override the module's `.sln`/`.csproj`/`.pubxml` will be silently untracked, which breaks teammates, CI, and any deploy that pulls from git. Add a `.gitignore` **inside the module directory** that re-includes them:
+
+```
+# <Module>CCM/.gitignore
+!*.sln
+!*.csproj
+!Properties/PublishProfiles/*.pubxml
+```
+
+Verify with `git status` after creating the files -- they must appear as untracked/modified, not be missing from the listing.
+
+### `.sln` File Template
+
+Generate fresh GUIDs for `{MAIN-GUID}`, `{TEST-GUID}`, and `{SLN-GUID}` using `[System.Guid]::NewGuid()` in PowerShell or any GUID generator. The test project intentionally has no `Release Build.0` entry to exclude it from Release builds.
+
+```
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyModule", "MyModule\MyModule.csproj", "{MAIN-GUID}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyModule.Tests", "MyModule.Tests\MyModule.Tests.csproj", "{TEST-GUID}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{MAIN-GUID}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{MAIN-GUID}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{MAIN-GUID}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{MAIN-GUID}.Release|Any CPU.Build.0 = Release|Any CPU
+		{TEST-GUID}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{TEST-GUID}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{TEST-GUID}.Release|Any CPU.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {SLN-GUID}
+	EndGlobalSection
+EndGlobal
+```
+
+### `.csproj` (net9.0, CloudCode.Apis 0.0.21, CloudCode.Core 0.0.1)
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <Configurations>Debug;Release</Configurations>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Com.Unity.Services.CloudCode.Apis" Version="0.0.21" />
+        <PackageReference Include="Com.Unity.Services.CloudCode.Core" Version="0.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+    </PropertyGroup>
+
+</Project>
+```
+
+### `FolderProfile.pubxml` (linux-x64, SelfContained=false)
+
+Cloud Code runs on Linux. `SelfContained=false` keeps the output small -- the runtime is provided by the Cloud Code host.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net9.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net9.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+  </PropertyGroup>
+</Project>
+```
+
+### `ModuleSetup.cs` (registers GameApiClient)
+
+Required once per module. Registers `GameApiClient` so it can be constructor-injected.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Core;
+
+public class ModuleSetup : ICloudCodeSetup
+{
+    public void Setup(ICloudCodeConfig config)
+    {
+        config.Dependencies.AddSingleton(GameApiClient.Create());
+    }
+}
+```
+
+### `MyModule.cs` ([CloudCodeFunction], IExecutionContext, IGameApiClient)
+
+```csharp
+using System;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+using Unity.Services.CloudCode.Apis;
+using Unity.Services.CloudCode.Core;
+
+public class MyModule
+{
+    readonly IGameApiClient m_GameApiClient;
+    readonly ILogger<MyModule> m_Logger;
+
+    public MyModule(IGameApiClient gameApiClient, ILogger<MyModule> logger)
+    {
+        m_GameApiClient = gameApiClient;
+        m_Logger = logger;
+    }
+
+    // No context needed -- pure computation.
+    [CloudCodeFunction("SayHello")]
+    public string SayHello(string name) => $"Hello, {name}!";
+
+    // Add IExecutionContext as a method parameter only when you need player/project info.
+    [CloudCodeFunction("GetServerTime")]
+    public string GetServerTime(IExecutionContext context)
+        => DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
+}
+```
+
+**Key concepts:**
+
+| File / Concept | Purpose |
+|---|---|
+| `[CloudCodeFunction]` | Marks a public method as a callable endpoint |
+| `IExecutionContext` | Optional method parameter -- player ID, project ID, service token |
+| `IGameApiClient` | Constructor-injected via DI -- typed clients for UGS APIs |
+| `ModuleSetup.cs` | Registers `GameApiClient` via `ICloudCodeSetup` -- required once per module |
+| `FolderProfile.pubxml` | Publish profile targeting `linux-x64` -- Cloud Code runs on Linux |
+| `IsPublishable=false` | Prevents test project from being included in `dotnet publish` |
+
+**Dependency injection:** `IGameApiClient` and `ILogger<T>` are constructor-injected. `IExecutionContext` is a method parameter (only add it when the function needs player/project info).
+
+### Test Project `.csproj` (IsPublishable=false)
+
+`IsPublishable=false` is enforced in two ways: this property, and the omission of `Release Build.0` in the `.sln`. Both are intentional.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\MyModule\MyModule.csproj" />
+    </ItemGroup>
+
+</Project>
+```
+
+### `.ccmr` File Format
+
+```json
+{
+  "modulePath": "../../MyModuleCCM/MyModule.sln"
+}
+```
+
+Path is relative to the `.ccmr` file. `../../` goes up from `Assets/CloudCode/` to the project root, then into `MyModuleCCM/`. The filename without `.ccmr` (`MyModule`) is the module name used in `CallModuleEndpointAsync`.
+
+---
+
+## Generated Type-Safe Bindings
+
+After deploying the module, generate a strongly-typed wrapper instead of using raw `CallModuleEndpointAsync`. The generator reads the deployed module's metadata and emits one C# file per class under `Assets/CloudCode/GeneratedModuleBindings/`. Do not edit these files -- they are overwritten on regeneration.
+
+### How to Generate
+
+- Select the `.ccmr` in the **Project window** then click **Generate Bindings** in the Inspector, or
+- **Services > Cloud Code > Generate Cloud Code Bindings** to regenerate all at once.
+
+### Example
+
+```csharp
+// Assets/CloudCode/GeneratedModuleBindings/MyModuleBindings.cs
+// This file was generated by Cloud Code Bindings Generator. Modifications will be lost upon regeneration.
+public class MyModuleBindings
+{
+    readonly ICloudCodeService k_Service;
+    public MyModuleBindings(ICloudCodeService service) { k_Service = service; }
+
+    public async Task<string> SayHello(string name)
+        => await k_Service.CallModuleEndpointAsync<string>("MyModule", "SayHello",
+            new Dictionary<string, object> { { "name", name } });
+}
+```
+
+```csharp
+var bindings = new MyModuleBindings(CloudCodeService.Instance);
+var greeting = await bindings.SayHello("World");
+```
+
+**Known limitations:** no distinction between required/optional parameters; tuples are not supported.
+
+---
+
+## Code Templates
+
+### Call a Script Endpoint
+
+```csharp
+using Unity.Services.CloudCode;
+using System.Collections.Generic;
+
+var args = new Dictionary<string, object>
+{
+    { "level", 5 },
+    { "difficulty", "hard" }
+};
+
+int reward = await CloudCodeService.Instance.CallEndpointAsync<int>("CalculateReward", args);
+Debug.Log($"Reward: {reward}");
+```
+
+### Call a Module Endpoint (Typed Result)
+
+```csharp
+// Module class name: "EconomyModule", method: "GrantDailyReward"
+var result = await CloudCodeService.Instance.CallModuleEndpointAsync<GrantResult>(
+    "EconomyModule", "GrantDailyReward",
+    new Dictionary<string, object> { { "playerId", playerId } });
+
+Debug.Log($"Granted: {result.CurrencyAmount} currency");
+```
+
+### Subscribe to Player Messages (Full Example)
+
+```csharp
+ISubscriptionEvents subscription;
+
+async Task SubscribeToMessages()
+{
+    // Subscribe first -- no parameters
+    subscription = await CloudCodeService.Instance.SubscribeToPlayerMessagesAsync();
+
+    // Then wire up callbacks via the Callbacks property
+    subscription.Callbacks.MessageReceived += OnMessageReceived;
+    subscription.Callbacks.ConnectionStateChanged += state =>
+        Debug.Log($"Subscription state: {state}");
+    subscription.Callbacks.Error += error =>
+        Debug.LogError($"Subscription error: {error}");
+    subscription.Callbacks.Kicked += () =>
+        Debug.LogWarning("Kicked from subscription");
+}
+
+void OnMessageReceived(IMessageReceivedEvent evt)
+{
+    Debug.Log($"[{evt.MessageType}] {evt.Message}");
+    // var data = JsonUtility.FromJson<MyPayload>(evt.Message);
+}
+
+async Task Unsubscribe()
+{
+    await subscription.UnsubscribeAsync();
+    subscription = null;
+}
+```
+
+---
+
+## Deploying via the Deployment Window
+
+1. Open **Services > Deployment** in the Unity Editor.
+2. All `.js` and `.ccmr` files under `Assets/` are listed -- click **Deploy All**.
+3. After deploying a module, generate or regenerate type-safe bindings (see [Generated Type-Safe Bindings](#generated-type-safe-bindings)).
+
+---
+
+## Error Handling
+
+```csharp
+try
+{
+    var result = await CloudCodeService.Instance.CallModuleEndpointAsync<MyResult>(
+        "MyModule", "MyFunction", args);
+}
+catch (CloudCodeRateLimitedException ex)
+{
+    Debug.LogError($"Rate limited. Retry after {ex.RetryAfter}s");
+}
+catch (CloudCodeException ex)
+{
+    Debug.LogError($"Cloud Code error: {ex.Message} (reason: {ex.Reason})");
+}
+```
+
+### `CloudCodeExceptionReason` Enum
+
+| Reason | Value | Meaning |
+|---|---|---|
+| `Unknown` | 0 | Unknown error |
+| `NoInternetConnection` | 1 | No network |
+| `ProjectIdMissing` | 2 | Project ID not set |
+| `PlayerIdMissing` | 3 | Player not signed in |
+| `AccessTokenMissing` | 4 | No access token |
+| `InvalidArgument` | 5 | Bad input |
+| `Unauthorized` | 6 | Not authorized |
+| `NotFound` | 7 | Script/module not found |
+| `TooManyRequests` | 8 | Rate limited |
+| `ServiceUnavailable` | 9 | Service down |
+| `ScriptError` | 10 | Script/module execution failure |
+| `SubscriptionError` | 11 | Subscription error |
+
+---
+
+## Asset Store Building Blocks
+
+Several Building Blocks from the Unity Asset Store include Cloud Code modules as working reference implementations:
+
+- **Achievements Building Block** — Cloud Code module with achievement progress tracking and server-authoritative unlocks. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-achievements-341918)
+- **Player Account Building Block** — Cloud Code module with global score tracking via server-authoritative writes. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-player-account-341928)
+- **Leaderboards Building Block** — Cloud Code modules with number game scoring and leaderboard admin functions. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-leaderboards-341926)
+
+Each block includes `.ccmr` module bindings, generated type-safe client bindings, and the full C# module source.

--- a/skills/build-live-game/references/cloud-save.md
+++ b/skills/build-live-game/references/cloud-save.md
@@ -1,0 +1,474 @@
+# Cloud Save Reference
+
+## Table of Contents
+
+- [Anti-Hallucination Reference](#anti-hallucination-reference)
+- [Subsystems](#subsystems)
+- [IPlayerDataService Methods](#iplayerdataservice-methods)
+- [ICustomDataService Methods](#icustomdataservice-methods)
+- [IPlayerFilesService Methods](#iplayerfilesservice-methods)
+- [Key Model Types](#key-model-types)
+- [Access Classes](#access-classes)
+- [Code Templates](#code-templates)
+- [Error Handling](#error-handling)
+
+Accessed via `CloudSaveService.Instance` (`ICloudSaveService`, namespace `Unity.Services.CloudSave`). Assembly: `Unity.Services.CloudSave`.
+
+Call `UnityServices.InitializeAsync()` from `com.unity.services.core` and sign in via `com.unity.services.authentication` before use.
+
+---
+
+## Anti-Hallucination Reference
+
+| Correct | Incorrect (do NOT use) |
+|---|---|
+| `SaveAsync` returns `Task<Dictionary<string, string>>` (write lock tokens) | `SaveAsync` returns `Task` (void) |
+| `Item.Value` is `IDeserializable` -- call `.GetAs<T>()` | `Item.Value` is `object` |
+| `SaveAsync(IDictionary<string, object>)` -- uses `IDictionary` | `SaveAsync(Dictionary<string, object>)` -- wrong interface type |
+| `SaveAsync(IDictionary<string, SaveItem>)` -- bundles value + write lock | `SaveAsync(data, Dictionary<string, WriteLockOptions>)` -- no such overload |
+| Custom data is **read-only** from client (no save/delete methods) | Custom data can be written from client |
+| `CloudSaveConflictException` has `Details` list | Only `CloudSaveException` exists for conflicts |
+| `CloudSaveExceptionReason.Conflict` (value 11) | `WriteLockConflict` reason |
+| `Item.Modified` / `Item.Created` are `DateTime?` | `Item.Modified` is `ModifiedMetadata` |
+| `FileItem.Modified` / `FileItem.Created` are `DateTime?` | `FileItem.Modified` is `ModifiedMetadata` |
+| `DeleteAsync(key, Models.Data.Player.DeleteOptions)` -- current API | `DeleteAsync(key, CloudSave.DeleteOptions)` -- deprecated overload |
+| `ICustomDataService` methods require `customDataID` first param | Custom data methods with no ID param |
+
+---
+
+## Subsystems
+
+| Subsystem | Access | Description |
+|---|---|---|
+| `Data.Player` | `CloudSaveService.Instance.Data.Player` | Key-value data for the signed-in player |
+| `Data.Custom` | `CloudSaveService.Instance.Data.Custom` | Game-wide or server-written data; **read-only from client** |
+| `Files.Player` | `CloudSaveService.Instance.Files.Player` | Binary file storage per player |
+
+---
+
+## IPlayerDataService Methods
+
+`CloudSaveService.Instance.Data.Player`
+
+**Options namespace:** All option classes (`SaveOptions`, `LoadOptions`, `DeleteOptions`, `DeleteAllOptions`, `ListAllKeysOptions`, `LoadAllOptions`, `QueryOptions`) are in `Unity.Services.CloudSave.Models.Data.Player`. Do **not** confuse with the deprecated root-level `CloudSave.SaveOptions` / `CloudSave.DeleteOptions`.
+
+```csharp
+// List all keys belonging to the current player (with metadata).
+Task<List<ItemKey>> ListAllKeysAsync()
+Task<List<ItemKey>> ListAllKeysAsync(ListAllKeysOptions options)
+
+// Load specific keys. Returns dictionary of key -> Item.
+Task<Dictionary<string, Item>> LoadAsync(ISet<string> keys)
+Task<Dictionary<string, Item>> LoadAsync(ISet<string> keys, LoadOptions options)
+
+// Load all keys for the current player.
+Task<Dictionary<string, Item>> LoadAllAsync()
+Task<Dictionary<string, Item>> LoadAllAsync(LoadAllOptions options)
+
+// Save key-value pairs. Returns Dictionary<string, string> mapping each key to its new write-lock token.
+Task<Dictionary<string, string>> SaveAsync(IDictionary<string, object> data)
+Task<Dictionary<string, string>> SaveAsync(IDictionary<string, object> data, SaveOptions options)
+
+// Save with per-key write locks bundled via SaveItem.
+Task<Dictionary<string, string>> SaveAsync(IDictionary<string, SaveItem> data)
+Task<Dictionary<string, string>> SaveAsync(IDictionary<string, SaveItem> data, SaveOptions options)
+
+// Delete a specific key. Use Models.Data.Player.DeleteOptions (not the deprecated root DeleteOptions).
+Task DeleteAsync(string key, Models.Data.Player.DeleteOptions options)
+
+// Delete ALL keys for the current player.
+Task DeleteAllAsync()
+Task DeleteAllAsync(DeleteAllOptions options)
+
+// Query player data with field filters.
+Task<List<EntityData>> QueryAsync(Query query, QueryOptions options)
+```
+
+---
+
+## ICustomDataService Methods
+
+`CloudSaveService.Instance.Data.Custom`
+
+Read-only from the client. Write via Cloud Code modules or `IAdminClient.CloudSaveData` from the `com.unity.services.apis` package. All methods require a `customDataID` parameter -- the namespace configured in the Unity Dashboard.
+
+> **To write Custom Data from the editor or a deploy command**, use `IAdminClient.CloudSaveData.SetCustomItem` /
+> `SetCustomItemBatch`. See [apis.md](apis.md) for setup and code templates. The client SDK has no write
+> path for Custom Data.
+
+```csharp
+Task<List<ItemKey>> ListAllKeysAsync(string customDataID)
+Task<Dictionary<string, Item>> LoadAllAsync(string customDataID)
+Task<Dictionary<string, Item>> LoadAsync(string customDataID, ISet<string> keys)
+
+// Query across custom data. Uses Models.Data.Custom.QueryOptions.
+Task<List<EntityData>> QueryAsync(Query query, Models.Data.Custom.QueryOptions options = default)
+```
+
+---
+
+## IPlayerFilesService Methods
+
+`CloudSaveService.Instance.Files.Player`
+
+Note: File methods use root-level `CloudSave.SaveOptions` and `CloudSave.DeleteOptions` (not the `Models.Data.Player` versions).
+
+```csharp
+// List all files for the current player.
+Task<List<FileItem>> ListAllAsync()
+
+// Save a file (byte array or stream).
+Task SaveAsync(string key, byte[] bytes, SaveOptions options = default)
+Task SaveAsync(string key, Stream stream, SaveOptions options = default)
+
+// Load a file as a byte array.
+Task<byte[]> LoadBytesAsync(string key)
+
+// Load a file as a stream.
+Task<Stream> LoadStreamAsync(string key)
+
+// Delete a file.
+Task DeleteAsync(string key, DeleteOptions options = default)
+
+// Get metadata for a specific file.
+Task<FileItem> GetMetadataAsync(string key)
+```
+
+---
+
+## Key Model Types
+
+### `Item` (`Unity.Services.CloudSave.Models`)
+
+| Property | Type | Description |
+|---|---|---|
+| `Key` | `string` | The data key |
+| `Value` | `IDeserializable` | Deserialized value -- call `.GetAs<T>()` or `.GetAsString()` |
+| `WriteLock` | `string` | Current write-lock token (use for optimistic concurrency) |
+| `Created` | `DateTime?` | Creation timestamp |
+| `Modified` | `DateTime?` | Last-modified timestamp |
+
+### `ItemKey` (`Unity.Services.CloudSave.Models`)
+
+| Property | Type | Description |
+|---|---|---|
+| `Key` | `string` | The data key |
+| `WriteLock` | `string` | Current write-lock token |
+| `Modified` | `DateTime?` | Last-modified timestamp |
+
+### `FileItem` (`Unity.Services.CloudSave.Models`)
+
+| Property | Type | Description |
+|---|---|---|
+| `Key` | `string` | The file key |
+| `Size` | `long` | File size in bytes |
+| `WriteLock` | `string` | Current write-lock token |
+| `ContentType` | `string` | MIME type of the file |
+| `Created` | `DateTime?` | Creation timestamp |
+| `Modified` | `DateTime?` | Last-modified timestamp |
+
+### `SaveItem` (`Unity.Services.CloudSave.Models`)
+
+Bundles a value and write lock for atomic save-with-lock operations.
+
+```csharp
+new SaveItem(value: myObject, writeLock: previousItem.WriteLock)
+```
+
+### `Query` (`Unity.Services.CloudSave.Models`)
+
+| Property | Type | Description |
+|---|---|---|
+| `Fields` | `List<FieldFilter>` | Filter conditions (required) |
+| `ReturnKeys` | `HashSet<string>` | Project only these keys in results |
+| `Offset` | `int` | Skip N results (pagination) |
+| `Limit` | `int` | Max results to return |
+| `SampleSize` | `int?` | Random sample size (optional) |
+
+### `FieldFilter` (`Unity.Services.CloudSave.Models`)
+
+```csharp
+new FieldFilter(key: "level", value: 10, op: FieldFilter.OpOptions.GE, asc: true)
+```
+
+| `OpOptions` | Meaning |
+|---|---|
+| `EQ` | Equal |
+| `NE` | Not equal |
+| `LT` | Less than |
+| `LE` | Less than or equal |
+| `GT` | Greater than |
+| `GE` | Greater than or equal |
+
+### `EntityData` (`Unity.Services.CloudSave.Models`)
+
+Query results return `List<EntityData>`, where each entry is one player's matching data.
+
+| Property | Type | Description |
+|---|---|---|
+| `Id` | `string` | Player ID |
+| `Data` | `List<Item>` | Matching items for this player |
+
+---
+
+## Access Classes
+
+Namespace: `Unity.Services.CloudSave.Models.Data.Player`.
+
+### `AccessClass` Enum
+
+| Value | Meaning |
+|---|---|
+| `Default` (0) | Owner read/write -- private to the player |
+| `Private` (1) | Alias for Default |
+| `Protected` (2) | Owner read, server-only write |
+| `Public` (3) | Any player can read, owner writes |
+
+### Read Access Class Options (for Load/ListAllKeys)
+
+- `DefaultReadAccessClassOptions()` -- read own Default-class data
+- `PublicReadAccessClassOptions()` -- read own Public-class data
+- `PublicReadAccessClassOptions(string playerId)` -- read **another player's** Public-class data
+- `ProtectedReadAccessClassOptions()` -- read own Protected-class data
+
+### Write Access Class Options (for Save/Delete)
+
+- `DefaultWriteAccessClassOptions()` -- write to Default-class keys
+- `PublicWriteAccessClassOptions()` -- write to Public-class keys
+
+---
+
+## Code Templates
+
+### Save Player Data (Capture Write Lock Tokens)
+
+```csharp
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using System.Collections.Generic;
+
+var data = new Dictionary<string, object>
+{
+    { "level", 10 },
+    { "gold", 500 },
+    { "inventory", new string[] { "sword", "shield" } }
+};
+
+// SaveAsync returns write-lock tokens for each saved key
+Dictionary<string, string> writeLocks = await CloudSaveService.Instance.Data.Player.SaveAsync(data);
+// writeLocks["level"] == "new-lock-token-for-level", etc.
+```
+
+### Load Specific Keys
+
+```csharp
+var keys = new HashSet<string> { "level", "gold" };
+var result = await CloudSaveService.Instance.Data.Player.LoadAsync(keys);
+
+if (result.TryGetValue("level", out var levelItem))
+{
+    int level = levelItem.Value.GetAs<int>();
+    Debug.Log($"Level: {level}, Modified: {levelItem.Modified}");
+}
+```
+
+### Save with Write Lock Using SaveItem
+
+```csharp
+using Unity.Services.CloudSave.Models;
+
+// First load to get the current write lock
+var items = await CloudSaveService.Instance.Data.Player.LoadAsync(new HashSet<string> { "gold" });
+var goldItem = items["gold"];
+
+// Bundle value + write lock in SaveItem -- fails if another client updated in the meantime
+var saveData = new Dictionary<string, SaveItem>
+{
+    { "gold", new SaveItem(value: 600, writeLock: goldItem.WriteLock) }
+};
+
+Dictionary<string, string> newLocks = await CloudSaveService.Instance.Data.Player.SaveAsync(saveData);
+// newLocks["gold"] is the updated write-lock token
+```
+
+### Handle Write-Lock Conflicts
+
+```csharp
+using Unity.Services.CloudSave;
+
+try
+{
+    await CloudSaveService.Instance.Data.Player.SaveAsync(saveData);
+}
+catch (CloudSaveConflictException ex)
+{
+    foreach (var detail in ex.Details)
+    {
+        Debug.LogError($"Conflict on '{detail.Key}': " +
+            $"you sent lock '{detail.AttemptedWriteLock}', " +
+            $"server has '{detail.ExistingWriteLock}'");
+    }
+    // Reload, merge, and retry
+}
+```
+
+### Delete a Key
+
+```csharp
+using Unity.Services.CloudSave.Models.Data.Player;
+
+// Delete with write-lock check
+var options = new DeleteOptions { WriteLock = knownWriteLock };
+await CloudSaveService.Instance.Data.Player.DeleteAsync("gold", options);
+
+// Delete ALL player data
+await CloudSaveService.Instance.Data.Player.DeleteAllAsync();
+```
+
+### Save and Load with Access Classes (Public, Default, Protected)
+
+> **Namespace note:** `SaveOptions`, `LoadOptions`, and `DeleteOptions` exist in both
+> `Unity.Services.CloudSave` (root) and `Unity.Services.CloudSave.Models.Data.Player`.
+> The access-class overloads live in `Models.Data.Player`. If you import both namespaces,
+> use fully qualified names or a `using` alias to avoid ambiguity.
+
+```csharp
+using Unity.Services.CloudSave.Models.Data.Player;
+
+// Save data as Public (other players can read it)
+var publicData = new Dictionary<string, object> { { "displayName", "Hero123" }, { "rank", 42 } };
+var publicOptions = new SaveOptions(new PublicWriteAccessClassOptions());
+await CloudSaveService.Instance.Data.Player.SaveAsync(publicData, publicOptions);
+
+// Read another player's Public-class data
+var readOptions = new LoadOptions(new PublicReadAccessClassOptions(otherPlayerId));
+var otherPlayerData = await CloudSaveService.Instance.Data.Player.LoadAsync(
+    new HashSet<string> { "displayName", "rank" }, readOptions);
+Debug.Log($"Other player name: {otherPlayerData["displayName"].Value.GetAs<string>()}");
+
+// Read own Protected-class data (written by server/Cloud Code)
+var protectedOptions = new LoadOptions(new ProtectedReadAccessClassOptions());
+var serverData = await CloudSaveService.Instance.Data.Player.LoadAllAsync(
+    new LoadAllOptions(new ProtectedReadAccessClassOptions()));
+```
+
+### Read Custom Data (Game-Wide, Read-Only)
+
+```csharp
+// Custom data is read-only from client -- written via Cloud Code or admin API.
+// customDataID is the namespace configured in the Unity Dashboard.
+var customData = await CloudSaveService.Instance.Data.Custom.LoadAllAsync("my-game-config");
+
+if (customData.TryGetValue("seasonConfig", out var config))
+{
+    var season = config.Value.GetAs<SeasonConfig>();
+    Debug.Log($"Current season: {season.Name}");
+}
+```
+
+### Query Player Data
+
+```csharp
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+
+// Find players with level >= 10, sorted ascending
+var query = new Query(
+    fields: new List<FieldFilter>
+    {
+        new FieldFilter(key: "level", value: 10, op: FieldFilter.OpOptions.GE, asc: true)
+    },
+    returnKeys: new HashSet<string> { "level", "displayName" },
+    offset: 0,
+    limit: 20
+);
+
+var results = await CloudSaveService.Instance.Data.Player.QueryAsync(query, new QueryOptions());
+
+foreach (var entity in results)
+{
+    Debug.Log($"Player {entity.Id}:");
+    foreach (var item in entity.Data)
+        Debug.Log($"  {item.Key} = {item.Value.GetAsString()}");
+}
+```
+
+### Save and Load a File
+
+```csharp
+// Save
+byte[] screenshotBytes = await CaptureScreenshot();
+await CloudSaveService.Instance.Files.Player.SaveAsync("screenshot_latest", screenshotBytes);
+
+// Load
+byte[] loaded = await CloudSaveService.Instance.Files.Player.LoadBytesAsync("screenshot_latest");
+
+// Get metadata
+var meta = await CloudSaveService.Instance.Files.Player.GetMetadataAsync("screenshot_latest");
+Debug.Log($"Size: {meta.Size}, ContentType: {meta.ContentType}, Modified: {meta.Modified}");
+```
+
+### List All Keys
+
+```csharp
+var keys = await CloudSaveService.Instance.Data.Player.ListAllKeysAsync();
+foreach (var key in keys)
+{
+    Debug.Log($"Key: {key.Key}, WriteLock: {key.WriteLock}, Modified: {key.Modified}");
+}
+```
+
+---
+
+## Error Handling
+
+```csharp
+try { ... }
+catch (CloudSaveConflictException ex)
+{
+    // Write-lock conflict -- inspect per-key details
+    foreach (var detail in ex.Details)
+        Debug.LogError($"Key '{detail.Key}': attempted={detail.AttemptedWriteLock}, existing={detail.ExistingWriteLock}");
+}
+catch (CloudSaveValidationException ex)
+{
+    // Input validation failure -- inspect per-field details
+    foreach (var detail in ex.Details)
+        Debug.LogError($"Field '{detail.Field}' key '{detail.Key}': {string.Join(", ", detail.Messages)}");
+}
+catch (CloudSaveRateLimitedException ex)
+{
+    Debug.LogError($"Rate limited. Retry after {ex.RetryAfter}s");
+}
+catch (CloudSaveException ex)
+{
+    Debug.LogError($"Cloud Save error: {ex.Message} (reason: {ex.Reason})");
+}
+```
+
+### `CloudSaveExceptionReason` Enum
+
+| Reason | Value | Meaning |
+|---|---|---|
+| `Unknown` | 0 | Unknown error |
+| `NoInternetConnection` | 1 | No network |
+| `ProjectIdMissing` | 2 | Project ID not set |
+| `PlayerIdMissing` | 3 | Player not signed in |
+| `AccessTokenMissing` | 4 | No access token |
+| `InvalidArgument` | 5 | Bad input |
+| `Unauthorized` | 6 | Not authorized |
+| `KeyLimitExceeded` | 7 | Too many keys stored |
+| `NotFound` | 8 | Key not found |
+| `TooManyRequests` | 9 | Rate limited |
+| `ServiceUnavailable` | 10 | Service down |
+| `Conflict` | 11 | Write-lock conflict |
+
+---
+
+## Asset Store Building Blocks
+
+The following Building Blocks from the Unity Asset Store demonstrate Cloud Save patterns:
+
+- **Achievements Building Block** — Reads/writes achievement records in Protected buckets via Cloud Code, with Access Control denying direct player writes. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-achievements-341918)
+- **Player Account Building Block** — Stores player profile data in Default and Public access classes with direct client writes for non-sensitive data. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-player-account-341928)
+- **Leaderboards Building Block** — Uses Cloud Save for player score data alongside Cloud Code modules. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-leaderboards-341926)

--- a/skills/build-live-game/references/deployment.md
+++ b/skills/build-live-game/references/deployment.md
@@ -1,0 +1,216 @@
+# Deployment Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Supported Service Integrations](#supported-service-integrations)
+- [Workflow](#workflow)
+- [Deployment Definitions (.ddef)](#deployment-definitions-ddef)
+  - [JSON Schema](#json-schema)
+  - [Behavior](#behavior)
+- [Programmatic API](#programmatic-api)
+  - [Entry Point: Deployments.Instance](#entry-point-deploymentsinstance)
+  - [IDeploymentWindow](#ideploymentwindow)
+  - [DeploymentResult and DeploymentStatus](#deploymentresult-and-deploymentstatus)
+  - [SeverityLevel](#severitylevel)
+  - [DeploymentProvider (Abstract)](#deploymentprovider-abstract)
+  - [IDeploymentItem](#ideploymentitem)
+  - [Code Template -- Register a Custom Provider](#code-template--register-a-custom-provider)
+  - [Code Template -- Trigger Deployment Programmatically](#code-template--trigger-deployment-programmatically)
+
+## Overview
+
+Editor-only package providing the **Deployment Window** (Services > Deployment). Deploys cloud resources for multiple UGS services from one place, without leaving the Unity Editor.
+
+- **Package:** `com.unity.services.deployment`
+- This package is Editor-only. Runtime code does not reference it.
+
+## Supported Service Integrations
+
+Each service package registers its own file types with the Deployment Window. Install the relevant service package to enable its file types.
+
+| Service | Package | File Type(s) | Min Version |
+|---|---|---|---|
+| Cloud Code Scripts | `com.unity.services.cloudcode` | `.js` | 2.1.0 |
+| Cloud Code C# Modules | `com.unity.services.cloudcode` | `.ccmr` | 2.5.0 |
+| Remote Config | `com.unity.remote-config` | `.rc` | 3.2.0 |
+| Economy | `com.unity.services.economy` | `.ecc`, `.eci`, `.ecv`, `.ecr` | 3.2.1 |
+| Leaderboards | `com.unity.services.leaderboards` | `.lb` | 2.0.0 |
+| Game Server Hosting | `com.unity.services.multiplayer` | `.gsh` | 1.1.0 |
+| Matchmaker | `com.unity.services.multiplayer` | `.mmq` | 1.0 |
+| Game Overrides | `com.unity.services.tooling` | `.ugo` | 1.3.0 |
+| Access Control | `com.unity.services.tooling` | `.ac` | 1.0 |
+| Deployment Definitions | `com.unity.services.deployment` | `.ddef` | -- |
+
+## Workflow
+
+1. Add `com.unity.services.deployment` via Package Manager.
+2. Open **Services > Deployment**.
+3. Select the target environment in the dropdown.
+4. Choose files to deploy (or select all).
+5. Click **Deploy**.
+
+## Deployment Definitions (.ddef)
+
+A Deployment Definition scopes the Deployment Window to a subset of files. Useful for large projects with multiple environments or teams.
+
+**File extension:** `.ddef`
+
+**Create via:** Right-click in Project window > Create > Unity Gaming Services > Deployment Definition
+
+### JSON Schema
+
+```json
+{
+  "name": "GameplayServices",
+  "excludePaths": [
+    "Assets/CloudCode/Experimental/**",
+    "Assets/Config/Archive/**"
+  ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Display name shown in the Deployment Window |
+| `excludePaths` | `string[]` | Glob patterns for files/folders to skip |
+
+### Behavior
+
+- **Without a `.ddef`:** the Deployment Window discovers and deploys all UGS config files under `Assets/`.
+- **With a `.ddef` selected:** only files within the definition's scope (minus excluded paths) are shown and deployed.
+- Multiple `.ddef` files can exist in one project; select which one to use in the Deployment Window dropdown.
+
+## Programmatic API
+
+The separate **`com.unity.services.deployment.api`** package (v1.1) provides programmatic access to the Deployment Window. All types in the main `com.unity.services.deployment` package are `internal` -- there is no public C# API from the main package.
+
+- **Namespace:** `Unity.Services.DeploymentApi.Editor`
+
+### Entry Point: Deployments.Instance
+
+| Member | Type | Description |
+|---|---|---|
+| `Instance` | `Deployments` | Static singleton |
+| `DeploymentProviders` | `ObservableCollection<DeploymentProvider>` | All registered service providers |
+| `DeploymentWindow` | `IDeploymentWindow` | Programmatic window control |
+| `EnvironmentProvider` | `IEnvironmentProvider` | Current environment |
+| `ProjectIdProvider` | `IProjectIdentifierProvider` | Current project ID |
+
+### IDeploymentWindow
+
+| Member | Description |
+|---|---|
+| `Deploy(items, token)` | Returns `Task<DeploymentResult<IDeploymentItem>>` -- deploy selected items |
+| `Deploy(filePaths, token)` | Extension: deploy items by file path (same return type) |
+| `GetAllDeploymentItems(includeDeploymentDefinitions)` | Extension: get all items across all providers |
+| `GetFromFiles(filePaths)` | Get items matching given file paths |
+| `GetDeploymentDefinitions()` | Get available `.ddef` items |
+| `OpenWindow()` | Opens the Deployment Window (`EditorWindow`) |
+| `GetChecked()` / `GetSelected()` | Get checked/selected items (window must be open) |
+| `Check(items)` / `ClearChecked()` | Programmatically check items |
+| `Select(items)` / `ClearSelection()` | Programmatically select items |
+| `DeploymentStarting` | `event Action<IReadOnlyList<IDeploymentItem>>` -- before deployment |
+| `DeploymentEnded` | `event Action<IReadOnlyList<IDeploymentItem>>` -- after deployment |
+| `GetCurrentDeployment()` | Returns the active `DeploymentScope`, or null |
+
+### DeploymentResult and DeploymentStatus
+
+**DeploymentResult\<T\>**
+
+| Member | Type | Description |
+|---|---|---|
+| `Deployed` | `List<T>` | Items that were successfully deployed |
+
+**DeploymentStatus** has static factory methods for common states:
+
+| Factory | Description |
+|---|---|
+| `Empty` / `UpToDate` / `ModifiedLocally` / `FailedToDeploy` | Static readonly instances |
+| `GetDeployed(details)` / `GetDeploying(details)` | Deployment in-progress/complete |
+| `GetFailedToDeploy(details)` / `GetFailedToFetch(details)` | Failure states |
+| `GetFailedToLoad(e, path)` / `GetFailedToRead(e, path)` | File I/O failures |
+| `GetFetched(details)` / `GetFetching(details)` | Fetch from remote states |
+| `GetPartialDeploy(details)` / `GetPartialFetch(details)` | Partial completion |
+
+### SeverityLevel
+
+| Value | Meaning |
+|---|---|
+| `None` (0) | No status |
+| `Info` (1) | Informational |
+| `Warning` (2) | Warning |
+| `Error` (3) | Error |
+| `Success` (4) | Success |
+
+### DeploymentProvider (Abstract)
+
+Subclass this to expose your own deployable assets to the Deployment Window.
+
+| Member | Description |
+|---|---|
+| `Service` | Display name for the service (abstract) |
+| `DeployCommand` | Required deploy command (abstract) |
+| `DeploymentItems` | `ObservableCollection<IDeploymentItem>` -- add/remove to populate the window |
+| `Commands` | Additional context menu commands |
+| `OpenCommand` | Double-click handler (optional) |
+| `ValidateCommand` | Validation command (optional) |
+| `SyncItemsWithRemoteCommand` | Sync-with-remote command (optional) |
+
+### IDeploymentItem
+
+| Member | Description |
+|---|---|
+| `Name` | File name with extension |
+| `Path` | Full asset path |
+| `Progress` | Deploy progress 0-100 |
+| `Status` | `DeploymentStatus` (message + severity) |
+| `States` | `ObservableCollection<AssetState>` -- local asset validation states |
+
+### Code Template -- Register a Custom Provider
+
+```csharp
+using UnityEditor;
+using Unity.Services.DeploymentApi.Editor;
+
+class MyServiceDeploymentProvider : DeploymentProvider
+{
+    public override string Service => "MyService";
+    public override Command DeployCommand { get; } = new MyDeployCommand();
+}
+
+[InitializeOnLoadMethod]
+static void RegisterProvider()
+{
+    Deployments.Instance.DeploymentProviders.Add(new MyServiceDeploymentProvider());
+}
+```
+
+> **Deploy commands that write to UGS services** must use `IAdminClient` from the
+> `com.unity.services.apis` package (`com.unity.services.apis`). Authenticate with a service
+> account via `adminClient.SetServiceAccount(keyId, keySecret)`, then call the appropriate
+> admin API (e.g. `adminClient.CloudSaveData.SetCustomItem` for Cloud Save game data).
+> See [apis.md](apis.md) for the full `IAdminClient` interface and code templates.
+
+### Code Template -- Trigger Deployment Programmatically
+
+```csharp
+using Unity.Services.DeploymentApi.Editor;
+
+// Deploy all items
+var allItems = Deployments.Instance.DeploymentWindow.GetAllDeploymentItems();
+var result = await Deployments.Instance.DeploymentWindow.Deploy(allItems);
+
+// Deploy by file paths
+await Deployments.Instance.DeploymentWindow.Deploy(new[] { "Assets/MyConfig.rc" });
+
+// Listen for deployment events
+Deployments.Instance.DeploymentWindow.DeploymentStarting += items =>
+{
+    Debug.Log($"Deploying {items.Count} items...");
+};
+Deployments.Instance.DeploymentWindow.DeploymentEnded += items =>
+{
+    Debug.Log($"Deployment complete: {items.Count} items");
+};
+```

--- a/skills/build-live-game/references/player-account.md
+++ b/skills/build-live-game/references/player-account.md
@@ -1,0 +1,813 @@
+# Player Account Reference
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Access Classes](#access-classes)
+- [Assembly References](#assembly-references)
+- [Package Setup](#package-setup)
+- [Sign-In: Anonymous](#sign-in-anonymous)
+- [Sign-In: Unity (Browser)](#sign-in-unity-browser)
+  - [PlayerAccountService API](#playeraccountservice-api)
+- [Sign-In: Username/Password](#sign-in-usernamepassword)
+  - [Username/Password Constraints](#usernamepassword-constraints)
+- [Player Identity](#player-identity)
+- [Cloud Save Operations](#cloud-save-operations)
+  - [Namespace Aliases](#namespace-aliases)
+  - [Save Default Data](#save-default-data-private-to-player)
+  - [Save Public Data](#save-public-data-visible-to-other-players)
+  - [Load Default Data](#load-default-data)
+  - [Load Public Data](#load-public-data-own)
+  - [Load Public Data (Other Player)](#load-public-data-another-player)
+  - [Load All Keys](#load-all-keys)
+- [Server-Authoritative Writes via Cloud Code (Optional)](#server-authoritative-writes-via-cloud-code-optional)
+  - [Reading Protected Data](#reading-protected-data-client-side)
+  - [Writing Protected/Custom Data](#writing-protectedcustom-data-server-side)
+- [Full Client Implementation](#full-client-implementation)
+- [PlayerAccountTester](#playeraccounttester)
+- [Assembly Definition](#assembly-definition)
+- [Error Handling](#error-handling)
+  - [AuthenticationException](#authenticationexception)
+  - [PlayerAccountsException](#playeraccountsexception)
+  - [CloudSaveException](#cloudsaveexception)
+- [Validation](#validation)
+- [Asset Store Building Block](#asset-store-building-block)
+
+---
+
+## Architecture Overview
+
+| Concern | Service | API |
+|---|---|---|
+| Sign in (anonymous) | Authentication | `SignInAnonymouslyAsync()` |
+| Sign in (Unity browser) | PlayerAccounts then Authentication | `StartSignInAsync()` then `SignInWithUnityAsync(AccessToken)` |
+| Sign in (username/password) | Authentication | `SignUpWithUsernamePasswordAsync` / `SignInWithUsernamePasswordAsync` |
+| Player identity | Authentication | `PlayerId`, `PlayerName`, `UpdatePlayerNameAsync` |
+| Per-player data | Cloud Save | `CloudSaveService.Instance.Data.Player` |
+
+```
+UnityServices.InitializeAsync()
+            |
+            v
+  AuthenticationService.Instance
+            |
+   +--------+-----------+
+   |        |            |
+   v        v            v
+  Anon   Unity/PA    Password
+   |     (browser)      |
+   |        |            |
+   |   PlayerAccountService.Instance
+   |   .StartSignInAsync()
+   |        |
+   |   SignedIn event fires
+   |        |
+   |   SignInWithUnityAsync(AccessToken)
+   |        |            |
+   +--------+-----------+
+            |
+            v
+   PlayerId / PlayerName
+            |
+            v
+   CloudSaveService.Instance.Data.Player
+      |          |            |
+      v          v            v
+   Default    Public     Protected
+  (owner     (anyone    (owner read,
+  read+write) read,     server-only
+              owner      write)
+              write)
+```
+
+---
+
+## Access Classes
+
+Cloud Save player data supports three access classes. The access class used when saving determines which access class must be used when loading.
+
+| Access Class | Read | Write | Use Case |
+|---|---|---|---|
+| Default | Owner only | Owner only | Private settings, preferences, game progress |
+| Public | Any player | Owner only | Display names, public profiles, shared stats |
+| Protected | Owner only | Server only (Cloud Code) | Anti-cheat data, server-awarded state |
+
+---
+
+## Assembly References
+
+Your `.asmdef` must reference all four assemblies. `Unity.Services.Authentication.PlayerAccounts` is a **separate assembly** from `Unity.Services.Authentication`, even though both ship inside the `com.unity.services.authentication` package.
+
+| Assembly Name | Package | Purpose |
+|---|---|---|
+| `Unity.Services.Core` | `com.unity.services.core` | `UnityServices.InitializeAsync()` |
+| `Unity.Services.Authentication` | `com.unity.services.authentication` | `AuthenticationService.Instance`, sign-in methods, player identity |
+| `Unity.Services.Authentication.PlayerAccounts` | `com.unity.services.authentication` (separate assembly in same package) | `PlayerAccountService.Instance`, browser-based Unity sign-in |
+| `Unity.Services.CloudSave` | `com.unity.services.cloudsave` | `CloudSaveService.Instance.Data.Player`, save/load operations |
+
+---
+
+## Package Setup
+
+Ensure the following packages are listed in `Packages/manifest.json`:
+
+```json
+{
+  "dependencies": {
+    "com.unity.services.authentication": "3.6.1",
+    "com.unity.services.cloudsave": "3.4.0",
+    "com.unity.services.core": "1.16.0"
+  }
+}
+```
+
+**Optional** — add `com.unity.services.cloudcode` if using Protected player data or Custom (shared) data:
+
+```json
+    "com.unity.services.cloudcode": "2.10.3"
+```
+
+---
+
+## Sign-In: Anonymous
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+using UnityEngine;
+
+async Task SignInAnonymouslyAsync()
+{
+    await UnityServices.InitializeAsync();
+
+    if (!AuthenticationService.Instance.IsSignedIn)
+    {
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();
+    }
+
+    Debug.Log($"Signed in as {AuthenticationService.Instance.PlayerId}");
+}
+```
+
+`SignInAnonymouslyAsync` handles both new and returning players. If a session token is cached from a previous session, it signs in silently with the cached token. If no token exists, it creates a new anonymous account. Always check `IsSignedIn` before calling to avoid double sign-in errors.
+
+---
+
+## Sign-In: Unity (Browser)
+
+Uses `PlayerAccountService` to open a system browser for Unity account sign-in. After the user signs in via the browser, the `SignedIn` event fires and provides an `AccessToken` that is passed to `AuthenticationService.Instance.SignInWithUnityAsync`.
+
+**Important:** The `Task` returned by `StartSignInAsync` completes when the browser **opens**, NOT when sign-in finishes. You must subscribe to the `SignedIn` event to know when authentication is complete.
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+using Unity.Services.Authentication.PlayerAccounts;
+using UnityEngine;
+
+void Start()
+{
+    // Wire the event BEFORE calling StartSignInAsync
+    PlayerAccountService.Instance.SignedIn += OnPlayerAccountSignedIn;
+}
+
+async Task StartSignInWithUnityAsync()
+{
+    await UnityServices.InitializeAsync();
+
+    if (PlayerAccountService.Instance.IsSignedIn)
+    {
+        // Already signed in to Player Accounts -- go straight to Authentication
+        OnPlayerAccountSignedIn();
+        return;
+    }
+
+    // Opens the system browser. Task completes when browser opens, NOT when sign-in finishes.
+    await PlayerAccountService.Instance.StartSignInAsync();
+}
+
+async void OnPlayerAccountSignedIn()
+{
+    try
+    {
+        await AuthenticationService.Instance.SignInWithUnityAsync(
+            PlayerAccountService.Instance.AccessToken);
+        Debug.Log($"Signed in as {AuthenticationService.Instance.PlayerId}");
+    }
+    catch (AuthenticationException ex)
+    {
+        Debug.LogError($"Unity sign-in failed: {ex.Message}");
+    }
+    catch (RequestFailedException ex)
+    {
+        Debug.LogError($"Request failed: {ex.Message}");
+    }
+}
+```
+
+Namespace: `Unity.Services.Authentication.PlayerAccounts`. Access via `PlayerAccountService.Instance` (`IPlayerAccountService`).
+
+If using any authentication other than anonymous, it requires the Unity identity provider to be enabled in **Project Settings > Services > Authentication > Identity Providers**.
+
+### PlayerAccountService API
+
+| Member | Type | Description |
+|---|---|---|
+| `StartSignInAsync(bool isSigningUp = false)` | `Task` | Opens browser for sign-in (or sign-up if `true`). Task completes when browser opens. |
+| `SignOut()` | `void` | Signs out of Player Accounts and revokes the access token. Synchronous. |
+| `RefreshTokenAsync()` | `Task` | Refreshes the current access token using the refresh token. |
+| `AccessToken` | `string` | Access token obtained during sign-in. Pass this to `SignInWithUnityAsync`. |
+| `IdToken` | `string` | ID token obtained during sign-in. |
+| `IdTokenClaims` | `IdToken` | Parsed claims from the ID token (email, subject, etc.). |
+| `IsSignedIn` | `bool` | Whether the player is signed in to Player Accounts. |
+| `AccountPortalUrl` | `string` | URL to the Unity Player Account portal. |
+| `SignedIn` | `event Action` | Fires when browser sign-in completes successfully. |
+| `SignedOut` | `event Action` | Fires when the player signs out. |
+| `SignInFailed` | `event Action<RequestFailedException>` | Fires when sign-in fails. |
+
+---
+
+## Sign-In: Username/Password
+
+Two separate methods: `SignUpWithUsernamePasswordAsync` for first-time registration, `SignInWithUsernamePasswordAsync` for subsequent sign-ins.
+
+```csharp
+using Unity.Services.Core;
+using Unity.Services.Authentication;
+using UnityEngine;
+
+async Task SignUpWithPasswordAsync(string username, string password)
+{
+    await UnityServices.InitializeAsync();
+
+    try
+    {
+        await AuthenticationService.Instance.SignUpWithUsernamePasswordAsync(username, password);
+        Debug.Log($"Signed up and signed in as {AuthenticationService.Instance.PlayerId}");
+    }
+    catch (AuthenticationException ex) when (ex.ErrorCode == AuthenticationErrorCodes.AccountAlreadyLinked)
+    {
+        // Error code 10003: username already exists. Sign in instead.
+        Debug.LogWarning("Username already exists, signing in instead.");
+        await AuthenticationService.Instance.SignInWithUsernamePasswordAsync(username, password);
+    }
+    catch (AuthenticationException ex)
+    {
+        Debug.LogError($"Sign-up failed: {ex.Message} (code: {ex.ErrorCode})");
+    }
+}
+
+async Task SignInWithPasswordAsync(string username, string password)
+{
+    await UnityServices.InitializeAsync();
+
+    try
+    {
+        await AuthenticationService.Instance.SignInWithUsernamePasswordAsync(username, password);
+        Debug.Log($"Signed in as {AuthenticationService.Instance.PlayerId}");
+    }
+    catch (AuthenticationException ex)
+    {
+        Debug.LogError($"Sign-in failed: {ex.Message} (code: {ex.ErrorCode})");
+    }
+}
+```
+
+Requires the username/password identity provider in **Project Settings > Services > Authentication > Identity Providers**.
+
+### Username/Password Constraints
+
+| Field | Constraint |
+|---|---|
+| Username length | 3-20 characters |
+| Username characters | `A-Z`, `a-z`, `0-9`, `.`, `-`, `@`, `_` |
+| Username case | Case insensitive (stored lowercase) |
+| Password length | 8-30 characters |
+| Password requirements | At least 1 lowercase + 1 uppercase + 1 number + 1 symbol |
+
+---
+
+## Player Identity
+
+After any successful sign-in, the following properties and methods are available on `AuthenticationService.Instance`:
+
+| Member | Type | Description |
+|---|---|---|
+| `PlayerId` | `string` | Unique player identifier, available immediately after sign-in |
+| `PlayerName` | `string` | Player display name (may be null until fetched) |
+| `IsSignedIn` | `bool` | True if a token exists in memory |
+| `IsAnonymous` | `bool` | True if signed in anonymously |
+| `SignedIn` | `event Action` | Fires on successful sign-in |
+| `SignedOut` | `event Action` | Fires on sign-out |
+| `Expired` | `event Action` | Fires when access token expires; SDK auto-attempts refresh |
+
+```csharp
+// Get player name. autoGenerate: true creates a random name if none exists.
+string name = await AuthenticationService.Instance.GetPlayerNameAsync(autoGenerate: true);
+
+// Update player name.
+string updatedName = await AuthenticationService.Instance.UpdatePlayerNameAsync("NewDisplayName");
+
+// Sign out. Synchronous (void), NOT async.
+AuthenticationService.Instance.SignOut();
+// Optionally clear cached credentials:
+// AuthenticationService.Instance.SignOut(clearCredentials: true);
+```
+
+**Warning:** `SignOut` is synchronous (`void`). There is no `SignOutAsync` method.
+
+---
+
+## Cloud Save Operations
+
+### Namespace Aliases
+
+Use namespace aliases to avoid ambiguity between root-level and `Models.Data.Player` option classes:
+
+```csharp
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models;
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerLoadOptions    = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using PlayerLoadAllOptions = Unity.Services.CloudSave.Models.Data.Player.LoadAllOptions;
+using PlayerSaveOptions    = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+```
+
+> **Namespace collision:** `SaveOptions` and `LoadOptions` exist in both `Unity.Services.CloudSave`
+> and `Unity.Services.CloudSave.Models.Data.Player`. Always use the `using` aliases to avoid
+> ambiguity errors.
+
+### Save Default Data (Private to Player)
+
+```csharp
+var data = new Dictionary<string, object>
+{
+    { "settings_volume", 0.8f },
+    { "settings_difficulty", "hard" },
+    { "last_login", DateTime.UtcNow.ToString("o") }
+};
+
+await CloudSaveService.Instance.Data.Player.SaveAsync(data);
+```
+
+### Save Public Data (Visible to Other Players)
+
+```csharp
+var publicData = new Dictionary<string, object>
+{
+    { "display_name", "Hero123" },
+    { "avatar_id", 42 }
+};
+
+var publicSaveOptions = new PlayerSaveOptions(new PublicWriteAccessClassOptions());
+await CloudSaveService.Instance.Data.Player.SaveAsync(publicData, publicSaveOptions);
+```
+
+### Load Default Data
+
+```csharp
+var keys = new HashSet<string> { "settings_volume", "settings_difficulty" };
+var result = await CloudSaveService.Instance.Data.Player.LoadAsync(keys);
+
+if (result.TryGetValue("settings_volume", out var volumeItem))
+{
+    float volume = volumeItem.Value.GetAs<float>();
+}
+```
+
+For string values saved via `Dictionary<string, object>`, `GetAsString()` returns the plain string. For complex objects, `GetAsString()` returns the JSON; use `item.Value.GetAs<T>()` to deserialize.
+
+### Load Public Data (Own)
+
+```csharp
+var publicLoadOptions = new PlayerLoadOptions(new PublicReadAccessClassOptions());
+var publicResult = await CloudSaveService.Instance.Data.Player.LoadAsync(
+    new HashSet<string> { "display_name", "avatar_id" }, publicLoadOptions);
+```
+
+### Load Public Data (Another Player)
+
+```csharp
+var otherPlayerOptions = new PlayerLoadOptions(new PublicReadAccessClassOptions(otherPlayerId));
+var otherResult = await CloudSaveService.Instance.Data.Player.LoadAsync(
+    new HashSet<string> { "display_name", "avatar_id" }, otherPlayerOptions);
+```
+
+### Load All Keys
+
+```csharp
+using Unity.Services.CloudSave.Models.Data.Player;
+using PlayerLoadAllOptions = Unity.Services.CloudSave.Models.Data.Player.LoadAllOptions;
+
+var allItems = await CloudSaveService.Instance.Data.Player.LoadAllAsync(
+    new PlayerLoadAllOptions(new DefaultReadAccessClassOptions()));
+
+foreach (var kv in allItems)
+    Debug.Log($"{kv.Key}: {kv.Value.Value.GetAsString()}");
+```
+
+**Access class matching rule:** Data saved with `PublicWriteAccessClassOptions` must be loaded with `PublicReadAccessClassOptions`. Data saved with no options (Default) must be loaded with `DefaultReadAccessClassOptions` or no options. Mismatched access classes return empty results without error.
+
+---
+
+## Server-Authoritative Writes via Cloud Code (Optional)
+
+The Default and Public access classes above are client-writable — suitable for preferences, display names, and non-sensitive data. Two scenarios require routing writes through a Cloud Code module instead:
+
+- **Non-player shared data** (guild info, level configs, global state) — no single player owns this data, so it must be written via Cloud Code to the **Custom** bucket using `IGameApiClient`.
+- **Tamper-proof player data** — if the game design requires anti-cheat protection for specific player state (e.g. XP, currency, unlocked items), write to the **Protected** bucket via Cloud Code. This is a game-design decision, not a requirement.
+
+### Reading Protected Data (Client-Side)
+
+```csharp
+var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+    new HashSet<string> { "player_level", "currency" },
+    new PlayerLoadOptions(new ProtectedReadAccessClassOptions()));
+
+if (result.TryGetValue("player_level", out var item))
+{
+    int level = item.Value.GetAs<int>();
+}
+```
+
+> **Common mistake:** Using default `LoadOptions` instead of `ProtectedReadAccessClassOptions`
+> returns no data, because the keys were written to the Protected bucket by Cloud Code.
+
+### Writing Protected/Custom Data (Server-Side)
+
+Writes to Protected and Custom buckets must go through a Cloud Code module. The module uses `IGameApiClient` with the service token to call Cloud Save server-side APIs.
+
+To create the module, follow [cloud-code.md — Module Creation](cloud-code.md#module-creation). All scaffolding files are required:
+
+- [ ] `.sln` (generate fresh GUIDs)
+- [ ] `.csproj` (net9.0, CloudCode.Apis + CloudCode.Core)
+- [ ] `ModuleSetup.cs` (registers `GameApiClient`)
+- [ ] `Properties/PublishProfiles/FolderProfile.pubxml` — **without this file, deployment fails with "Failed to retrieve main project"**
+- [ ] `Assets/CloudCode/<ModuleName>.ccmr` (points to the `.sln`)
+
+---
+
+## Full Client Implementation
+
+A complete `MonoBehaviour` covering all three sign-in methods, player identity, and Cloud Save operations.
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unity.Services.Authentication;
+using Unity.Services.Authentication.PlayerAccounts;
+using Unity.Services.CloudSave;
+using Unity.Services.CloudSave.Models.Data.Player;
+using Unity.Services.Core;
+using UnityEngine;
+using PlayerLoadOptions    = Unity.Services.CloudSave.Models.Data.Player.LoadOptions;
+using PlayerLoadAllOptions = Unity.Services.CloudSave.Models.Data.Player.LoadAllOptions;
+using PlayerSaveOptions    = Unity.Services.CloudSave.Models.Data.Player.SaveOptions;
+
+public class PlayerAccountManager : MonoBehaviour
+{
+    public string PlayerId => AuthenticationService.Instance.PlayerId;
+    public string PlayerName => AuthenticationService.Instance.PlayerName;
+    public bool IsSignedIn => AuthenticationService.Instance.IsSignedIn;
+
+    public event Action SignedIn;
+
+    async void Start()
+    {
+        await UnityServices.InitializeAsync();
+
+        AuthenticationService.Instance.SignedIn += () =>
+        {
+            Debug.Log($"Signed in: {AuthenticationService.Instance.PlayerId}");
+            SignedIn?.Invoke();
+        };
+
+        // Wire PlayerAccountService event BEFORE any StartSignInAsync call
+        PlayerAccountService.Instance.SignedIn += OnPlayerAccountSignedIn;
+    }
+
+    // --- Sign-In Methods ---
+
+    public async Task SignInAnonymouslyAsync()
+    {
+        if (AuthenticationService.Instance.IsSignedIn) return;
+        await AuthenticationService.Instance.SignInAnonymouslyAsync();
+    }
+
+    /// <summary>
+    /// Starts the browser-based Unity sign-in flow.
+    /// The returned Task completes when the browser opens, NOT when sign-in finishes.
+    /// Subscribe to SignedIn to know when authentication is complete.
+    /// </summary>
+    public async Task StartSignInWithUnity()
+    {
+        if (PlayerAccountService.Instance.IsSignedIn)
+        {
+            OnPlayerAccountSignedIn();
+            return;
+        }
+
+        await PlayerAccountService.Instance.StartSignInAsync();
+    }
+
+    async void OnPlayerAccountSignedIn()
+    {
+        try
+        {
+            await AuthenticationService.Instance.SignInWithUnityAsync(
+                PlayerAccountService.Instance.AccessToken);
+        }
+        catch (AuthenticationException ex)
+        {
+            Debug.LogError($"Unity sign-in failed: {ex.Message}");
+        }
+        catch (RequestFailedException ex)
+        {
+            Debug.LogError($"Request failed: {ex.Message}");
+        }
+    }
+
+    public async Task SignUpWithPasswordAsync(string username, string password)
+    {
+        try
+        {
+            await AuthenticationService.Instance.SignUpWithUsernamePasswordAsync(username, password);
+        }
+        catch (AuthenticationException ex) when (ex.ErrorCode == AuthenticationErrorCodes.AccountAlreadyLinked)
+        {
+            // Error code 10003: username already exists
+            Debug.LogWarning("Username already exists. Use SignInWithPasswordAsync instead.");
+            throw;
+        }
+    }
+
+    public async Task SignInWithPasswordAsync(string username, string password)
+    {
+        await AuthenticationService.Instance.SignInWithUsernamePasswordAsync(username, password);
+    }
+
+    public void SignOut()
+    {
+        AuthenticationService.Instance.SignOut();
+        // Optionally also sign out of Player Accounts:
+        // PlayerAccountService.Instance.SignOut();
+    }
+
+    // --- Player Identity ---
+
+    public async Task<string> GetPlayerNameAsync()
+    {
+        return await AuthenticationService.Instance.GetPlayerNameAsync(autoGenerate: true);
+    }
+
+    public async Task<string> UpdatePlayerNameAsync(string newName)
+    {
+        return await AuthenticationService.Instance.UpdatePlayerNameAsync(newName);
+    }
+
+    // --- Cloud Save: Default (Private) ---
+
+    public async Task SaveDefaultAsync(string key, object value)
+    {
+        await CloudSaveService.Instance.Data.Player.SaveAsync(
+            new Dictionary<string, object> { { key, value } });
+    }
+
+    public async Task<string> LoadDefaultAsync(string key)
+    {
+        var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+            new HashSet<string> { key });
+        return result.TryGetValue(key, out var item) ? item.Value.GetAsString() : null;
+    }
+
+    // --- Cloud Save: Public ---
+
+    public async Task SavePublicAsync(string key, object value)
+    {
+        var options = new PlayerSaveOptions(new PublicWriteAccessClassOptions());
+        await CloudSaveService.Instance.Data.Player.SaveAsync(
+            new Dictionary<string, object> { { key, value } }, options);
+    }
+
+    public async Task<string> LoadPublicAsync(string key)
+    {
+        var options = new PlayerLoadOptions(new PublicReadAccessClassOptions());
+        var result = await CloudSaveService.Instance.Data.Player.LoadAsync(
+            new HashSet<string> { key }, options);
+        return result.TryGetValue(key, out var item) ? item.Value.GetAsString() : null;
+    }
+
+    // --- Cloud Save: All Keys ---
+
+    public async Task<List<string>> LoadAllDefaultKeysAsync()
+    {
+        var result = await CloudSaveService.Instance.Data.Player.LoadAllAsync(
+            new PlayerLoadAllOptions(new DefaultReadAccessClassOptions()));
+        return new List<string>(result.Keys);
+    }
+}
+```
+
+---
+
+## PlayerAccountTester
+
+Attach alongside `PlayerAccountManager` on the same GameObject. Signs in anonymously, logs identity, then exercises a Cloud Save round-trip and lists all Default keys.
+
+```csharp
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+/// <summary>
+/// Attach alongside PlayerAccountManager to run a quick in-Editor smoke test.
+/// On start: signs in anonymously and logs player identity.
+/// After sign-in: saves a probe value to the Default bucket, loads it back,
+/// and logs all Default keys visible for this player.
+/// </summary>
+public class PlayerAccountTester : MonoBehaviour
+{
+    [SerializeField] PlayerAccountManager m_Manager;
+
+    async void Start()
+    {
+        if (m_Manager == null)
+            m_Manager = GetComponent<PlayerAccountManager>();
+
+        m_Manager.SignedIn += OnSignedIn;
+        await m_Manager.SignInAnonymouslyAsync();
+    }
+
+    async void OnSignedIn()
+    {
+        LogIdentity("Signed in");
+
+        await Task.Delay(2000);
+
+        // Fetch the server-side player name — may be null after anonymous sign-in.
+        await m_Manager.GetPlayerNameAsync();
+        LogIdentity("After name fetch");
+
+        // Round-trip a probe value through the Default Cloud Save bucket.
+        const string key = "tester_probe";
+        const string expected = "ok";
+        await m_Manager.SaveDefaultAsync(key, expected);
+        var loaded = await m_Manager.LoadDefaultAsync(key);
+
+        var match = loaded == expected ? "OK" : $"MISMATCH (got '{loaded}')";
+        Debug.Log($"[PlayerAccountTester] Save→Load round-trip: {match}");
+
+        // List all keys in the Default bucket for this player.
+        var keys = await m_Manager.LoadAllDefaultKeysAsync();
+        LogKeys(keys);
+    }
+
+    void LogIdentity(string label)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"[PlayerAccountTester] {label}:");
+        sb.AppendLine($"  PlayerId   : {m_Manager.PlayerId ?? "<null>"}");
+        sb.AppendLine($"  PlayerName : {(string.IsNullOrEmpty(m_Manager.PlayerName) ? "<none>" : m_Manager.PlayerName)}");
+        sb.AppendLine($"  IsSignedIn : {m_Manager.IsSignedIn}");
+        Debug.Log(sb.ToString());
+    }
+
+    void LogKeys(List<string> keys)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"[PlayerAccountTester] Default bucket keys ({keys.Count}):");
+        foreach (var k in keys)
+            sb.AppendLine($"  {k}");
+        Debug.Log(sb.ToString());
+    }
+}
+```
+
+---
+
+## Assembly Definition
+
+Your `.asmdef` must reference both `Unity.Services.Authentication` and `Unity.Services.Authentication.PlayerAccounts`. These are **separate assemblies** within the same package (`com.unity.services.authentication`). Missing the PlayerAccounts reference causes `PlayerAccountService` to be unresolvable. `Unity.Services.CloudCode` is only needed if using Protected or Custom data writes.
+
+```json
+{
+    "name": "MyGame.PlayerAccount",
+    "rootNamespace": "",
+    "references": [
+        "Unity.Services.Core",
+        "Unity.Services.Authentication",
+        "Unity.Services.Authentication.PlayerAccounts",
+        "Unity.Services.CloudSave",
+        "Unity.Services.CloudCode"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}
+```
+
+---
+
+## Error Handling
+
+### AuthenticationException
+
+Thrown by all `AuthenticationService` methods. Extends `RequestFailedException`.
+
+```csharp
+try
+{
+    await AuthenticationService.Instance.SignInAnonymouslyAsync();
+}
+catch (AuthenticationException ex)
+{
+    // ex.ErrorCode contains a numeric error code from AuthenticationErrorCodes
+    Debug.LogError($"Auth failed: {ex.Message} (code: {ex.ErrorCode})");
+}
+catch (RequestFailedException ex)
+{
+    // Network or other service errors
+    Debug.LogError($"Request failed: {ex.Message}");
+}
+```
+
+Key error codes:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `AccountAlreadyLinked` | 10003 | Username already exists (on sign-up) or external ID already linked |
+| `InvalidParameters` | 10002 | Bad input parameters |
+| `ClientInvalidUserState` | 10000 | Operation not valid in current state |
+
+### PlayerAccountsException
+
+Thrown by `PlayerAccountService` methods. Also extends `RequestFailedException`.
+
+```csharp
+try
+{
+    await PlayerAccountService.Instance.StartSignInAsync();
+}
+catch (PlayerAccountsException ex)
+{
+    Debug.LogError($"Player Accounts error: {ex.Message} (code: {ex.ErrorCode})");
+}
+```
+
+Key error codes (from `PlayerAccountsErrorCodes`):
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `InvalidState` | 10101 | Player is already signed in |
+| `MissingClientId` | 10102 | Client ID not configured in Unity Dashboard |
+
+### CloudSaveException
+
+Thrown by Cloud Save operations.
+
+```csharp
+try
+{
+    await CloudSaveService.Instance.Data.Player.SaveAsync(data);
+}
+catch (CloudSaveValidationException ex)
+{
+    foreach (var detail in ex.Details)
+        Debug.LogError($"Validation: {detail.Field} {string.Join(", ", detail.Messages)}");
+}
+catch (CloudSaveRateLimitedException ex)
+{
+    Debug.LogError($"Rate limited. Retry after {ex.RetryAfter}s");
+}
+catch (CloudSaveException ex)
+{
+    Debug.LogError($"Cloud Save error: {ex.Message} (reason: {ex.Reason})");
+}
+```
+
+---
+
+## Validation
+
+After implementing a player account feature, verify:
+
+1. **Compile check:** The project compiles without errors. All namespaces (`Unity.Services.Core`, `Unity.Services.Authentication`, `Unity.Services.Authentication.PlayerAccounts`, `Unity.Services.CloudSave`) resolve correctly.
+2. **Initialization order:** `UnityServices.InitializeAsync()` is called before any sign-in method. Service singletons (`AuthenticationService.Instance`, `PlayerAccountService.Instance`, `CloudSaveService.Instance`) are accessed only after initialization.
+3. **Assembly references:** The `.asmdef` references **both** `Unity.Services.Authentication` and `Unity.Services.Authentication.PlayerAccounts`. These are separate assemblies in the same package; omitting the PlayerAccounts reference makes `PlayerAccountService` unresolvable.
+4. **SignedIn event wiring:** `PlayerAccountService.Instance.SignedIn` is subscribed **before** calling `StartSignInAsync()`. The `StartSignInAsync` Task completes when the browser opens, not when sign-in finishes.
+5. **Access class matching:** Data saved with `PublicWriteAccessClassOptions` is loaded with `PublicReadAccessClassOptions`. Data saved with no options (Default) is loaded with `DefaultReadAccessClassOptions` or no options. Mismatched access classes return empty results without error.
+6. **SignOut is synchronous:** `AuthenticationService.Instance.SignOut()` and `PlayerAccountService.Instance.SignOut()` are both `void` methods. Do not `await` them.
+
+---
+
+## Asset Store Building Block
+
+- **Player Account Building Block:** Complete reference implementation with sign-in UI (anonymous, Unity browser, username/password), Cloud Save data management, and a Cloud Code module with generated client bindings. [Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/unity-building-block-player-account-341928)

--- a/skills/build-live-game/references/remote-config.md
+++ b/skills/build-live-game/references/remote-config.md
@@ -1,0 +1,96 @@
+# Remote Config Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [How It Works](#how-it-works)
+- [FetchConfigsAsync API](#fetchconfigsasync-api)
+- [.rc File Format](#rc-file-format)
+- [Game Overrides](#game-overrides)
+- [Common Patterns](#common-patterns)
+- [Code Template -- Load JSON Config](#code-template--load-json-config)
+
+## Overview
+
+Server-side game configuration. Store game definitions (achievement lists, battle pass tiers, shop catalogs) as JSON entries updatable without a client build. Accessed via `RemoteConfigService.Instance`.
+
+- **Namespace:** `Unity.Services.RemoteConfig`
+- **Package:** `com.unity.remote-config`
+
+## How It Works
+
+- Configuration is stored as key-value entries in the Unity Dashboard or deployed via `.rc` files through the Deployment Window.
+- The client fetches all config at once using `FetchConfigsAsync`.
+- Values are strongly typed: `string`, `bool`, `int`, `float`, `long`, and `JSON`.
+
+## FetchConfigsAsync API
+
+```csharp
+struct UserAttributes {}
+struct AppAttributes {}
+var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+    new UserAttributes(), new AppAttributes());
+// Access values:
+string val = result.config.GetString("key");
+int num = result.config.GetInt("key");
+bool flag = result.config.GetBool("key");
+// For JSON values:
+var token = result.config["key"]; // JToken
+var obj = token.ToObject<MyType>();
+```
+
+- `UserAttributes` and `AppAttributes` are empty structs unless you use Game Overrides (audience targeting).
+- Results are cached locally; subsequent calls return cached data unless you call with different attributes.
+
+## .rc File Format
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/remote-config.schema.json",
+  "entries": {
+    "my_string_key": "hello",
+    "my_int_key": 42,
+    "my_json_key": { "nested": true }
+  },
+  "types": {
+    "my_json_key": "JSON"
+  }
+}
+```
+
+- **Create via:** Right-click in Project window > Assets > Create > Services > Remote Config
+- **Deploy via:** the Deployment Window (Services > Deployment)
+- The `types` block is needed only for JSON entries; `string`, `int`, `bool`, `float`, and `long` are auto-detected.
+
+## Game Overrides
+
+Game Overrides (via `com.unity.services.tooling`) override Remote Config values for specific player segments. Remote Config itself does not provide A/B testing -- Game Overrides layer on top of it.
+
+- Game Overrides are defined as `.ugo` files.
+- Used for A/B testing and audience targeting.
+- Configured in the Unity Dashboard or deployed via `.ugo` files through the Deployment Window.
+- When active, `FetchConfigsAsync` returns the overridden values automatically.
+
+## Common Patterns
+
+- **Game definitions** (achievements, battle pass tiers) stored as JSON arrays under a single key.
+- **Feature flags** stored as booleans for toggling game features server-side.
+- **Version-specific config** with server-side updates -- change game balance without shipping a new client build.
+
+## Code Template -- Load JSON Config
+
+```csharp
+using Unity.Services.RemoteConfig;
+using Newtonsoft.Json.Linq;
+
+struct UserAttributes {}
+struct AppAttributes {}
+
+async Task<List<T>> LoadJsonConfigAsync<T>(string key)
+{
+    var result = await RemoteConfigService.Instance.FetchConfigsAsync(
+        new UserAttributes(), new AppAttributes());
+    var token = result.config[key];
+    return token.ToObject<List<T>>();
+}
+```

--- a/skills/build-live-game/references/tooling.md
+++ b/skills/build-live-game/references/tooling.md
@@ -1,0 +1,431 @@
+# Tooling Reference
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Access Control](#access-control)
+  - [`.ac` File Format](#ac-file-format)
+  - [URN Pattern Format](#urn-pattern-format)
+  - [URN Reference by Service](#urn-reference-by-service)
+  - [Recommended Pattern: Deny-All-Then-Allow](#recommended-pattern-deny-all-then-allow)
+- [Game Overrides](#game-overrides)
+  - [`.ugo` File Format](#ugo-file-format)
+- [Editor API Models](#editor-api-models)
+
+Editor-only package. Registers **Access Control** (`.ac`) and **Game Overrides** (`.ugo`) file types with the Deployment Window (`com.unity.services.deployment`).
+
+- **Package:** `com.unity.services.tooling`
+- **Namespace:** `Unity.Services.Tooling.Editor.AccessControl.Authoring.Core.Model` / `Unity.Services.Tooling.Editor.GameOverrides.Authoring.Core.Model`
+
+---
+
+## Overview
+
+Tooling provides two cloud resource file types deployed through the Deployment Window:
+
+| File Type | Extension | Purpose |
+|---|---|---|
+| Access Control | `.ac` | Permit or deny player/service-account access to UGS services on a URN basis |
+| Game Overrides | `.ugo` | A/B testing and audience targeting by overriding Remote Config values for player segments |
+
+Both file types are created via right-click in the Project window → **Create > Unity Gaming Services** and deployed via **Services > Deployment**.
+
+---
+
+## Access Control
+
+Access Control policies permit or deny access to UGS services on a **URN basis**. Each statement targets a resource URN pattern and applies a `Read`, `Write`, or `*` action for a principal (`Player` or `ServiceAccount`). **Deny takes precedence over Allow.**
+
+| Concept | Description |
+|---|---|
+| **Effect** | `"Allow"` or `"Deny"` — Deny takes precedence over Allow |
+| **Action** | `"Read"`, `"Write"`, or `"*"` (both) |
+| **Principal** | `"Player"` (end user) or `"ServiceAccount"` (server/admin) |
+| **Resource** | URN pattern — `urn:ugs:<service>:/<path>` with `*` and `**` wildcards |
+
+Common use cases:
+- Deny direct player writes to Cloud Save (force writes through Cloud Code)
+- Deny player currency/inventory writes in Economy (only allow purchases)
+- Restrict Cloud Code module/script invocation to specific endpoints
+- Deny player account deletion or identity unlinking
+
+### `.ac` File Format
+
+**Create via:** Right-click in Project window → **Create > Unity Gaming Services > Access Control**
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/project-access-policy.schema.json",
+  "statements": [
+    {
+      "Sid": "DenyPlayerCloudSaveWrites",
+      "Effect": "Deny",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `Sid` | `string` | Unique statement ID within the file |
+| `Effect` | `string` | `"Allow"` or `"Deny"` — Deny wins over Allow |
+| `Action` | `string` or `string[]` | `"Read"`, `"Write"`, or `"*"` (both) |
+| `Principal` | `string` or `string[]` | `"Player"` (end user) or `"ServiceAccount"` (server/admin) |
+| `Resource` | `string` or `string[]` | URN pattern — `urn:ugs:<service>:/<path>` |
+
+### URN Pattern Format
+
+```
+urn:ugs:<service>:/<path>
+```
+
+- `*` matches a single path segment
+- `**` matches zero or more path segments (including nested)
+- `/**/` is commonly used to skip environment/version segments in the URL
+
+### URN Reference by Service
+
+#### Authentication (`player-auth`)
+
+| URN Pattern | Description |
+|---|---|
+| `urn:ugs:player-auth:/*/authentication/anonymous**` | Anonymous sign-up |
+| `urn:ugs:player-auth:/*/authentication/external-token**` | External token sign-in (social, platform) |
+| `urn:ugs:player-auth:/*/authentication/session-token**` | Session token sign-in |
+| `urn:ugs:player-auth:/*/authentication/link/**` | Link external identity |
+| `urn:ugs:player-auth:/*/authentication/unlink/**` | Unlink external identity |
+| `urn:ugs:player-auth:/*/users**` | Player info (Read) / Delete player (Write) |
+| `urn:ugs:player-auth:/.well-known/**` | JWKS public keys |
+
+#### Cloud Save (`cloud-save`)
+
+| URN Pattern | Description |
+|---|---|
+| `urn:ugs:cloud-save:/**` | All Cloud Save (blanket) |
+| `urn:ugs:cloud-save:/**/players/*/keys**` | List player data keys |
+| `urn:ugs:cloud-save:/**/players/*/items**` | Read/write player data items (own data only) |
+| `urn:ugs:cloud-save:/**/players/*/item-batch**` | Batch write player data items |
+| `urn:ugs:cloud-save:/**/players/query**` | Query Default player data |
+| `urn:ugs:cloud-save:/**/players/*/public/keys**` | Read another player's public keys |
+| `urn:ugs:cloud-save:/**/players/*/public/items**` | Read another player's public items |
+| `urn:ugs:cloud-save:/**/players/public/query**` | Query Public player data |
+| `urn:ugs:cloud-save:/**/custom/*/items**` | Read game-wide (Custom) data items |
+
+#### Economy (`economy`)
+
+| URN Pattern | Description |
+|---|---|
+| `urn:ugs:economy:/**/players/*/config**` | Read player economy configuration |
+| `urn:ugs:economy:/**/currencies**` | Player currencies (Read/Write) |
+| `urn:ugs:economy:/**/inventory**` | Player inventory (Read/Write) |
+| `urn:ugs:economy:/**/purchases/virtual**` | Virtual purchases |
+| `urn:ugs:economy:/**/purchases/googleplaystore**` | Google Play Store purchases |
+| `urn:ugs:economy:/**/purchases/appleappstore**` | Apple App Store purchases |
+
+#### Leaderboards (`leaderboards`)
+
+| URN Pattern | Description |
+|---|---|
+| `urn:ugs:leaderboards:/**/leaderboards/**` | All leaderboard operations |
+
+#### Cloud Code (`cloud-code`)
+
+| URN Pattern | Description |
+|---|---|
+| `urn:ugs:cloud-code:/**/modules/**` | Cloud Code module endpoints |
+| `urn:ugs:cloud-code:/**/scripts/**` | Cloud Code scripts (legacy JS) |
+| `urn:ugs:cloud-code:/**/subscriptions/tokens/**` | Subscription tokens |
+
+### Recommended Pattern: Deny-All-Then-Allow
+
+Start with a blanket deny, then explicitly allow only what the player needs. This ensures new services are locked down by default.
+
+```json
+{
+  "$schema": "https://ugs-config-schemas.unity3d.com/v1/project-access-policy.schema.json",
+  "statements": [
+    {
+      "Sid": "Deny-all-ugs-access",
+      "Effect": "Deny",
+      "Action": ["*"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:*:/**"
+    },
+    {
+      "Sid": "Allow-Anonymous-SignUp",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/*/authentication/anonymous**"
+    },
+    {
+      "Sid": "Allow-External-Token-SignIn",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/*/authentication/external-token**"
+    },
+    {
+      "Sid": "Allow-Session-Token-SignIn",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/*/authentication/session-token**"
+    },
+    {
+      "Sid": "Allow-Link-External-Id",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/*/authentication/link/**"
+    },
+    {
+      "Sid": "Allow-Get-PlayerInfo",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/*/users**"
+    },
+    {
+      "Sid": "Allow-Get-JWKS",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:player-auth:/.well-known/**"
+    },
+    {
+      "Sid": "Allow-Read-Economy-Config",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/players/*/config**"
+    },
+    {
+      "Sid": "Allow-Read-Currencies",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/currencies**"
+    },
+    {
+      "Sid": "Allow-Read-Inventory",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/inventory**"
+    },
+    {
+      "Sid": "Allow-Virtual-Purchases",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/purchases/virtual**"
+    },
+    {
+      "Sid": "Allow-GooglePlay-Purchases",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/purchases/googleplaystore**"
+    },
+    {
+      "Sid": "Allow-AppStore-Purchases",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:economy:/**/purchases/appleappstore**"
+    },
+    {
+      "Sid": "Allow-Read-Leaderboards",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:leaderboards:/**/leaderboards/**"
+    },
+    {
+      "Sid": "Allow-Read-CloudSave-PlayerKeys",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/*/keys**"
+    },
+    {
+      "Sid": "Allow-CloudSave-PlayerItems",
+      "Effect": "Allow",
+      "Action": ["*"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/*/items**"
+    },
+    {
+      "Sid": "Allow-CloudSave-PlayerItemBatch",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/*/item-batch**"
+    },
+    {
+      "Sid": "Allow-Query-Default-PlayerData",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/query**"
+    },
+    {
+      "Sid": "Allow-Read-Public-PlayerKeys",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/*/public/keys**"
+    },
+    {
+      "Sid": "Allow-Read-Public-PlayerItems",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/*/public/items**"
+    },
+    {
+      "Sid": "Allow-Query-Public-PlayerData",
+      "Effect": "Allow",
+      "Action": ["Write"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/players/public/query**"
+    },
+    {
+      "Sid": "Allow-Read-GameData",
+      "Effect": "Allow",
+      "Action": ["Read"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-save:/**/custom/*/items**"
+    },
+    {
+      "Sid": "Allow-CloudCode-Modules",
+      "Effect": "Allow",
+      "Action": ["*"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-code:/**/modules/**"
+    },
+    {
+      "Sid": "Allow-CloudCode-Scripts",
+      "Effect": "Allow",
+      "Action": ["*"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-code:/**/scripts/**"
+    },
+    {
+      "Sid": "Allow-Subscription-Tokens",
+      "Effect": "Allow",
+      "Action": ["*"],
+      "Principal": "Player",
+      "Resource": "urn:ugs:cloud-code:/**/subscriptions/tokens/**"
+    }
+  ]
+}
+```
+
+This policy:
+- **Denies** all UGS access by default
+- **Allows** authentication (anonymous, external, session token sign-in; link external ID; read player info)
+- **Denies** identity unlinking and player deletion (inherited from blanket deny)
+- **Allows** economy reads (config, currencies, inventory) and purchases (virtual, Google Play, Apple App Store)
+- **Denies** direct currency/inventory writes (inherited from blanket deny — use Cloud Code for server grants)
+- **Allows** leaderboard reads
+- **Allows** Cloud Save player data reads/writes for own data (Default items), public data reads, game-wide data reads
+- **Denies** Cloud Save blanket writes (Protected data only writable via Cloud Code)
+- **Allows** Cloud Code module, script, and subscription token access
+
+---
+
+## Game Overrides
+
+Game Overrides are the A/B testing and audience targeting mechanism for UGS. They override **Remote Config** values for specific player segments (audiences). Remote Config itself does not provide A/B testing — Game Overrides layer on top of it.
+
+Use cases:
+- A/B test different XP multipliers for player segments
+- Roll out features gradually to targeted audiences
+- Run time-limited promotions with different reward values
+
+### `.ugo` File Format
+
+**Create via:** Right-click in Project window → **Create > Unity Gaming Services > Game Override**
+
+```json
+{
+  "GameOverrides": [
+    {
+      "id": "double-xp-weekend",
+      "name": "Double XP Weekend",
+      "enabled": true,
+      "audiences": ["high_engagement_players"],
+      "overrides": [
+        {
+          "key": "xp_multiplier",
+          "value": 2.0
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique override ID |
+| `name` | `string` | Human-readable name |
+| `enabled` | `bool` | Whether this override is active |
+| `audiences` | `string[]` | Segment IDs from Unity Segmentation |
+| `overrides[].key` | `string` | Remote Config key to override |
+| `overrides[].value` | `any` | Replacement value |
+
+---
+
+## Editor API Models
+
+### Access Control
+
+```csharp
+namespace Unity.Services.Tooling.Editor.AccessControl.Authoring.Core.Model
+{
+    interface IProjectAccessFile
+    {
+        string Path { get; }
+        string Name { get; }
+        List<IAccessControlStatement> Statements { get; }
+    }
+
+    interface IAccessControlStatement
+    {
+        string Sid { get; }          // Statement ID — unique within the file
+        string Effect { get; }       // "Allow" or "Deny" — Deny takes precedence
+        List<string> Action { get; } // "Read", "Write", or "*" (both)
+        List<string> Principal { get; } // "Player" or "ServiceAccount"
+        List<string> Resource { get; }  // URN pattern(s) the rule applies to
+    }
+}
+```
+
+### Game Overrides
+
+```csharp
+namespace Unity.Services.Tooling.Editor.GameOverrides.Authoring.Core.Model
+{
+    interface IGameOverride
+    {
+        string Id { get; }
+        string Name { get; }
+        bool Enabled { get; }
+        List<string> Audiences { get; }
+        List<OverrideConfig> Overrides { get; }
+    }
+
+    class GameOverridesConfigFile
+    {
+        public List<IGameOverride> GameOverrides { get; }
+    }
+}
+```
+
+Both file types are discovered automatically by the Deployment Window when `com.unity.services.deployment` is installed.


### PR DESCRIPTION
## Summary

- Adds `skills/build-live-game/` — a skill for building and operating a live game with Unity Gaming Services.
- Covers authentication, player accounts, cloud save, cloud code, remote config, achievements, battle pass, and deployment workflows.
- One `SKILL.md` plus 10 reference docs (authentication, player-account, cloud-save, cloud-code, remote-config, achievements, battlepass, apis, tooling, deployment).
- https://github.cds.internal.unity3d.com/unity/muse-skills/pull/97

## Test plan

- [ ] `SKILL.md` frontmatter parses cleanly in the skills.sh installer
- [ ] Skill triggers on live-ops / backend / UGS-flavored prompts ("add cloud save", "set up remote config", "build a battle pass")
- [ ] References load on demand per the skill's routing
- [ ] End-to-end run on a fresh Unity 6 project: link to UGS, init Auth, write a Cloud Save value, fetch a Remote Config

🤖 Generated with [Claude Code](https://claude.com/claude-code)