### PR TITLE
Add implement-in-app-purchases skill

### DIFF
--- a/skills/implement-in-app-purchases/SKILL.md
+++ b/skills/implement-in-app-purchases/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: implement-in-app-purchases
+description: Implement, configure, and debug Unity In-App Purchases (IAP) — store connection, product catalog, consumable/non-consumable/subscription purchases, two-step pending-confirm flow, receipt validation, entitlement checking, restore transactions, Apple extensions (promotional purchases, Ask-to-Buy, code redemption), and Google Play extensions (subscription upgrade/downgrade). Use when the user needs to add, modify, or debug IAP. Triggers on microtransactions (MTX), monetization, real-money purchases, store purchases, buying items.
+modes: [agent, ask]
+---
+
+# Unity In-App Purchasing
+
+Namespace: `UnityEngine.Purchasing` | Security: `UnityEngine.Purchasing.Security`
+Package: `com.unity.purchasing`
+
+**Unity IAP has its own initialization path** via `UnityIAPServices.StoreController()` → `store.Connect()`. It does not require `UnityServices.InitializeAsync()`, but they can coexist if your project uses other UGS services. If Analytics is present and `InitializeAsync()` is called, IAP will automatically send transaction events.
+
+## Before You Start
+
+**Always read [references/pre-check.md](references/pre-check.md) first.** It scans the project for third-party IAP packages, native Google Billing, and existing Unity IAP versions, then routes to the correct path. Do not read any other reference file or make any changes until routing is resolved.
+
+## Detailed References
+
+- **Project scan and path routing (read first):** See [references/pre-check.md](references/pre-check.md)
+- **API signatures & code examples:** See [references/api-notes.md](references/api-notes.md)
+- **Platform extensions (Apple, Google):** See [references/platform-notes.md](references/platform-notes.md)
+- **Editing `IAPProductCatalog.json` (schema, decimal serialization, refresh):** See [references/codeless-catalog.md](references/codeless-catalog.md)
+- **v4 → v5 migration:** See [references/migration-v4-to-v5.md](references/migration-v4-to-v5.md)
+- **Convert native Google BillingClient to Unity IAP 5:** See [references/path-convert-native-google-billing.md](references/path-convert-native-google-billing.md)
+- **Add Unity IAP 5 to a project with no existing IAP:** See [references/path-add-iap-to-new-project.md](references/path-add-iap-to-new-project.md)
+- **Implement IAP Plus (third-party payment provider — Stripe/Coda, requires v5.4+):** See [references/path-implement-iap-plus.md](references/path-implement-iap-plus.md)
+
+Read reference files on demand — only when you need specific API signatures, platform extension details, or migration mappings.
+
+## Initialization Flow
+
+1. Obtain `StoreController` via `UnityIAPServices.StoreController()` (or individual services via `DefaultStore()`, `DefaultProduct()`, `DefaultPurchase()`)
+2. Subscribe to **all** required events (see Required Event Subscriptions below) **before** calling `Connect()`
+3. `await store.Connect()` to connect to the platform store
+4. On `OnStoreConnected`, call `store.FetchProducts(List<ProductDefinition>)` to load the catalog
+5. On `OnProductsFetched`, products are ready for display and purchase
+
+Use `Awake()` for initialization — ensures IAP is ready before other `Start()` methods.
+
+Product types: `ProductType.Consumable`, `ProductType.NonConsumable`, `ProductType.Subscription`.
+
+## Fetching Products
+
+Define products as `List<ProductDefinition>` and pass to `store.FetchProducts()`. Use `StoreSpecificIds` when product IDs differ across Apple/Google stores. For complex catalogs, use `CatalogProvider` to manage product sets and store-specific IDs.
+
+| Method | Behavior |
+|---|---|
+| `GetProducts()` | Returns the **cached** product list (synchronous, stale if `FetchProducts` not called) |
+| `FetchProducts()` | Queries the **store** for fresh pricing/availability and updates the cache |
+| `GetProductById(id)` | Returns a single cached product by ID |
+
+These are NOT interchangeable. Always call `FetchProducts()` first before relying on `GetProducts()`.
+
+## Two-Step Purchase Flow
+
+IAP v5 uses a mandatory two-step flow: **Pending → Confirm**.
+
+1. `store.PurchaseProduct(product)` — initiates the platform purchase dialog
+2. `OnPurchasePending` fires — you receive a `PendingOrder`
+3. Validate the receipt, grant content to the player
+4. `store.ConfirmPurchase(pendingOrder)` — finalizes the transaction
+5. `OnPurchaseConfirmed` fires — receives `Order` base type; pattern-match `ConfirmedOrder` (success) vs `FailedOrder` (confirmation failed)
+
+**You MUST call `ConfirmPurchase(pendingOrder)` after granting content.** Unconfirmed purchases are re-delivered on next app launch to prevent lost purchases.
+
+**De-duplication:** `OnPurchasePending` may fire multiple times for the same purchase (e.g., app restart before confirmation). Always check if content was already granted.
+
+**Consumables:** Confirmed consumable purchases are NOT returned by `FetchPurchases`. Track consumable grants yourself (e.g., in Cloud Save or Economy).
+
+**Deferred purchases:** `OnPurchaseDeferred` fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Do NOT grant content — wait for `OnPurchasePending` when approved.
+
+## Restore Transactions
+
+`store.RestoreTransactions(callback)` re-delivers non-consumable and subscription purchases. Each restored purchase triggers `OnPurchasePending`.
+
+Required on iOS for Apple App Store compliance — add a "Restore Purchases" button.
+
+Apple non-renewable subscriptions **cannot be restored** via `RestoreTransactions`. Track these server-side.
+
+## Receipt Validation
+
+| Platform | Approach |
+|---|---|
+| **Google Play** | `CrossPlatformValidator` with `GooglePlayTangle.Data()` — local validation supported |
+| **Apple (StoreKit 2)** | Local validation is a **no-op**. Use `order.Info.Apple?.jwsRepresentation` for server-side validation |
+
+Generate tangle data via **Services > In-App Purchasing > Receipt Validation Obfuscator** in the Unity Editor.
+
+## Entitlement Checking
+
+Use when you don't have the `Order` and want to know the status of a specific product (replaces v4's `product.hasReceipt`). If you already have the `Order`, check its type instead: `PendingOrder` maps to `EntitledUntilConsumed` (consumables) or `EntitledButNotFinished` (non-consumables/subscriptions), `ConfirmedOrder` maps to `FullyEntitled`.
+
+Call `store.CheckEntitlement(product)` and handle `store.OnCheckEntitlement`. Check `entitlement.Status == EntitlementStatus.FullyEntitled`.
+
+`EntitlementStatus` values: `FullyEntitled`, `EntitledUntilConsumed`, `EntitledButNotFinished`, `NotEntitled`, `Unknown`.
+
+## Fetch Existing Purchases
+
+`store.FetchPurchases()` retrieves all current purchases from the store. Useful at app startup.
+
+| Method | Behavior |
+|---|---|
+| `GetPurchases()` | Returns the **cached** purchase list |
+| `FetchPurchases()` | Queries the **store** for current purchases and **overwrites** the cached list |
+
+`FetchPurchases()` replaces the entire cached list on each call. Only non-consumables and subscriptions are re-fetched — confirmed consumables are not returned (see Two-Step Purchase Flow above).
+
+## Subscription Info
+
+Subscription info is on `IPurchasedProductInfo`, accessed via `order.Info.PurchasedProductInfo` — **NOT on `CartItem`** (`CartItem` only has `Product` and `Quantity`).
+
+`IsSubscribed()` returns `Result` enum (`True`/`False`/`Unsupported`), NOT `bool`. Use `== Result.True` for null-safe comparison.
+
+## Required Event Subscriptions
+
+**Always subscribe to BOTH success and failure events.** Not subscribing to failure events generates runtime warnings.
+
+| Call | Success Event | Failure Event (REQUIRED) |
+|---|---|---|
+| `FetchProducts()` | `OnProductsFetched` | `OnProductsFetchFailed` |
+| `FetchPurchases()` | `OnPurchasesFetched` | `OnPurchasesFetchFailed` |
+| `Connect()` | `OnStoreConnected` | `OnStoreDisconnected` |
+| `PurchaseProduct()` | `OnPurchasePending` | `OnPurchaseFailed` |
+| `CheckEntitlement()` | `OnCheckEntitlement` | — |
+
+**Always subscribe to `OnPurchaseDeferred`** — fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Not subscribing silently drops deferred purchases.
+
+Subscribe to events **BEFORE** calling `Connect()` — pending purchases from a previous session may fire immediately.
+
+## Failure Description Property Names
+
+These property names are NOT interchangeable — using the wrong one causes CS1061:
+
+| Type | Field | Property | NOT |
+|---|---|---|---|
+| `StoreConnectionFailureDescription` | `.message` | `.Message` | ~~`.reason`~~ |
+| `ProductFetchFailed` | — | `.FailureReason`, `.FailedFetchProducts` | ~~`.Message`~~ |
+| `FailedOrder` | — | `.FailureReason`, `.Details` | — |
+| `PurchasesFetchFailureDescription` | `.message` | `.Message`, `.FailureReason` | — |
+
+## Validation
+
+After writing code that uses this package:
+1. Verify the project compiles without errors.
+2. Confirm all API calls match the v5 signatures in [api-notes.md](references/api-notes.md) — do NOT use v4 legacy patterns (`IStoreListener`, `UnityPurchasing.Initialize`, `ConfigurationBuilder`).
+3. Check the "Common v5 Mistakes" table in api-notes.md — do NOT use `OnStoreConnectionFailed` (use `OnStoreDisconnected`), do NOT pass callbacks to `FetchProducts`/`FetchPurchases` (use events), do NOT use `product.receipt` (use `order.Info.Receipt`).
+4. Check that all required events are subscribed **before** calling `Connect()` (see Required Event Subscriptions table above).
+5. Verify the two-step purchase flow: `OnPurchasePending` → grant content → `ConfirmPurchase(pendingOrder)`.
+6. Confirm both success and failure events are subscribed for every async operation (`OnProductsFetched`/`OnProductsFetchFailed`, `OnStoreConnected`/`OnStoreDisconnected`, etc.).
+7. If handling subscriptions, verify `IsSubscribed()` is compared with `== Result.True`, not cast to `bool`.
+8. If updated files coexist with legacy versions in the same project, use a unique namespace (e.g., add `.Updated` suffix) to avoid CS0101/CS0111 compilation errors.

--- a/skills/implement-in-app-purchases/references/api-notes.md
+++ b/skills/implement-in-app-purchases/references/api-notes.md
@@ -1,0 +1,489 @@
+# Unity IAP API Notes
+
+## Table of Contents
+
+- [Anti-Hallucination: v5 vs Legacy API](#anti-hallucination-v5-vs-legacy-api)
+- [StoreController (v5) Key Members](#storecontroller-v5-key-members)
+- [Alternative Service Access (DefaultStore / DefaultProduct / DefaultPurchase)](#alternative-service-access-defaultstore--defaultproduct--defaultpurchase)
+- [CatalogProvider](#catalogprovider)
+- [Initialization Example](#initialization-example)
+- [Product Definitions](#product-definitions)
+- [Two-Step Purchase Flow](#two-step-purchase-flow)
+- [Restore Transactions](#restore-transactions)
+- [Entitlement Checking](#entitlement-checking)
+- [Fetch Existing Purchases](#fetch-existing-purchases)
+- [Receipt Validation](#receipt-validation)
+- [Extended Service Events (NOT on StoreController)](#extended-service-events-not-on-storecontroller)
+- [AppleStoreExtendedProductService Key Members](#applestoreextendedproductservice-key-members)
+- [Subscription Info Access Path](#subscription-info-access-path)
+- [Event Subscription Rules](#event-subscription-rules)
+- [Failure Description Property Names](#failure-description-property-names)
+- [CrossPlatformValidator](#crossplatformvalidator)
+- [Interface Hierarchy](#interface-hierarchy)
+- [IRunCommand Template: Fetch Products](#iruncommand-template-fetch-products)
+
+## Anti-Hallucination: v5 vs Legacy API
+
+Unity IAP v5 is the current API. The legacy API (v4) is `[Obsolete]`. Do NOT use legacy patterns.
+
+| WRONG (Legacy v4) | CORRECT (v5) |
+|---|---|
+| `UnityPurchasing.Initialize(listener, builder)` | `UnityIAPServices.StoreController()` then `store.Connect()` |
+| `IStoreListener.OnInitialized(controller, extensions)` | `store.OnStoreConnected` event |
+| `IStoreListener.ProcessPurchase(args)` | `store.OnPurchasePending` event |
+| `controller.InitiatePurchase(product)` | `store.PurchaseProduct(product)` |
+| `controller.ConfirmPendingPurchase(product)` | `store.ConfirmPurchase(pendingOrder)` |
+| `extensions.GetExtension<IAppleExtensions>()` | `store.AppleStoreExtendedService` / `store.AppleStoreExtendedPurchaseService` |
+| `extensions.GetExtension<IGooglePlayStoreExtensions>()` | `store.GooglePlayStoreExtendedService` / `store.GooglePlayStoreExtendedPurchaseService` |
+| `ConfigurationBuilder.Instance(...)` | Not needed; use `ProductDefinition` list with `FetchProducts` |
+
+## Anti-Hallucination: Common v5 Mistakes
+
+These are NOT real APIs — do not use them:
+
+| WRONG (does not exist) | CORRECT |
+|---|---|
+| `store.OnStoreConnectionFailed` | `store.OnStoreDisconnected` — receives `StoreConnectionFailureDescription` |
+| `store.FetchProducts(defs, successCb, failCb)` | `store.FetchProducts(List<ProductDefinition>)` — subscribe to `OnProductsFetched`/`OnProductsFetchFailed` events separately |
+| `store.FetchPurchases(successCb, failCb)` | `store.FetchPurchases()` — subscribe to `OnPurchasesFetched`/`OnPurchasesFetchFailed` events separately |
+| `product.receipt` | `order.Info.Receipt` — receipt is on the order, not the product |
+| `product.hasReceipt` | `store.CheckEntitlement(product)` + `OnCheckEntitlement` |
+| `new SubscriptionManager(product, introJson)` | `order.Info.PurchasedProductInfo` — see Subscription Info Access Path |
+| `pendingOrder.OrderInfo.Apple.jwsRepresentation` | `pendingOrder.Info.Apple?.jwsRepresentation` — note `Info` not `OrderInfo`, and null-check `?.` |
+
+## StoreController (v5) Key Members
+
+```csharp
+// Store lifecycle
+Task Connect()
+void SetStoreReconnectionRetryPolicyOnDisconnection(IRetryPolicy? retryPolicy)
+event Action? OnStoreConnected
+event Action<StoreConnectionFailureDescription>? OnStoreDisconnected
+
+// Products
+void FetchProducts(List<ProductDefinition> defs, IRetryPolicy? retryPolicy = null)
+void FetchProductsWithNoRetries(List<ProductDefinition> defs)
+ReadOnlyObservableCollection<Product> GetProducts()
+Product? GetProductById(string productId)
+event Action<List<Product>>? OnProductsFetched
+event Action<ProductFetchFailed>? OnProductsFetchFailed
+
+// Purchasing
+void PurchaseProduct(Product product)
+void PurchaseProduct(string? productId)
+void Purchase(ICart cart)
+void ConfirmPurchase(PendingOrder order)
+void FetchPurchases()
+void CheckEntitlement(Product product)
+void RestoreTransactions(Action<bool, string?>? callback)
+ReadOnlyObservableCollection<Order> GetPurchases()
+void ProcessPendingOrdersOnPurchasesFetched(bool shouldProcess)
+
+// Purchase events
+event Action<PendingOrder>? OnPurchasePending
+event Action<Order>? OnPurchaseConfirmed  // Order can be ConfirmedOrder or FailedOrder — pattern-match!
+event Action<FailedOrder>? OnPurchaseFailed
+event Action<DeferredOrder>? OnPurchaseDeferred
+event Action<Orders>? OnPurchasesFetched
+event Action<PurchasesFetchFailureDescription>? OnPurchasesFetchFailed
+event Action<Entitlement>? OnCheckEntitlement
+
+// Platform extensions (null on non-matching platforms — always null-check)
+IAppleStoreExtendedService? AppleStoreExtendedService { get; }
+IGooglePlayStoreExtendedService? GooglePlayStoreExtendedService { get; }
+IAppleStoreExtendedProductService? AppleStoreExtendedProductService { get; }
+IAppleStoreExtendedPurchaseService? AppleStoreExtendedPurchaseService { get; }
+IGooglePlayStoreExtendedPurchaseService? GooglePlayStoreExtendedPurchaseService { get; }
+```
+
+## Alternative Service Access (DefaultStore / DefaultProduct / DefaultPurchase)
+
+Instead of `StoreController` (which implements all three interfaces), you can access individual services:
+
+```csharp
+IStoreService m_StoreService = UnityIAPServices.DefaultStore();
+IProductService m_ProductService = UnityIAPServices.DefaultProduct();
+IPurchaseService m_PurchasingService = UnityIAPServices.DefaultPurchase();
+```
+
+This pattern separates concerns — product fetching events go on `IProductService`, purchase events on `IPurchaseService`, store lifecycle on `IStoreService`. `StoreController` combines all three.
+
+## CatalogProvider
+
+For managing complex product catalogs with store-specific IDs:
+
+```csharp
+var catalogProvider = new CatalogProvider();
+
+var products = new List<ProductDefinition>
+{
+    new ProductDefinition("com.mygame.gems50", ProductType.Consumable),
+    new ProductDefinition("com.mygame.pass", ProductType.Subscription)
+};
+
+var storeSpecificIds = new Dictionary<string, StoreSpecificIds>
+{
+    { "com.mygame.pass", new StoreSpecificIds
+        {
+            { "com.mygame.google.pass", GooglePlay.Name },
+            { "com.mygame.ios.pass", AppleAppStore.Name }
+        }
+    }
+};
+
+catalogProvider.AddProducts(products, storeSpecificIds);
+catalogProvider.FetchProducts(m_ProductService.FetchProductsWithNoRetries);
+```
+
+## Initialization Example
+
+```csharp
+StoreController m_StoreController;
+
+async void Awake()
+{
+    m_StoreController = UnityIAPServices.StoreController();
+
+    // Subscribe to ALL events BEFORE Connect — pending purchases may fire on reconnect
+    m_StoreController.OnPurchasePending += OnPurchasePending;
+    m_StoreController.OnPurchaseConfirmed += (order) => Debug.Log("Purchase complete");
+    m_StoreController.OnPurchaseFailed += (failed) => Debug.LogError($"{failed.FailureReason} - {failed.Details}");
+    m_StoreController.OnPurchaseDeferred += (deferred) => Debug.Log("Purchase deferred (e.g., Ask-to-Buy)");
+
+    m_StoreController.OnStoreConnected += OnStoreConnected;
+    m_StoreController.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+    await m_StoreController.Connect();
+}
+
+void OnStoreConnected()
+{
+    var products = new List<ProductDefinition>
+    {
+        new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+        new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable),
+        new ProductDefinition("com.mygame.vip_monthly", ProductType.Subscription)
+    };
+
+    m_StoreController.OnProductsFetched += (fetched) => Debug.Log("Products ready");
+    m_StoreController.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+    m_StoreController.FetchProducts(products);
+
+    m_StoreController.OnPurchasesFetched += (orders) => Debug.Log($"Restored {orders.PendingOrders.Count} pending purchases");
+    m_StoreController.OnPurchasesFetchFailed += (failure) => Debug.LogError($"Purchase fetch failed: {failure.Message}");
+    m_StoreController.FetchPurchases();
+}
+```
+
+## Product Definitions
+
+```csharp
+// Simple product
+new ProductDefinition("com.mygame.coins100", ProductType.Consumable)
+
+// Per-platform product IDs
+new ProductDefinition("com.mygame.coins100", ProductType.Consumable,
+    new StoreSpecificIds
+    {
+        { AppleAppStore.Name, "apple_coins_100" },
+        { GooglePlay.Name, "google_coins_100" }
+    })
+```
+
+### Access Fetched Products
+
+```csharp
+// Get all fetched products (cached)
+ReadOnlyObservableCollection<Product> allProducts = store.GetProducts();
+
+// Get a specific product by ID
+Product coinsPack = store.GetProductById("com.mygame.coins100");
+```
+
+## Two-Step Purchase Flow
+
+```csharp
+// Step 1: Initiate purchase
+store.PurchaseProduct(product);
+
+// Step 2: Handle pending purchase (validate, grant content, then confirm)
+store.OnPurchasePending += (pendingOrder) =>
+{
+    var product = pendingOrder.CartOrdered.Items().FirstOrDefault()?.Product;
+    GrantContent(product);
+    store.ConfirmPurchase(pendingOrder);
+};
+
+// Step 3: Purchase confirmed — Order can be ConfirmedOrder OR FailedOrder
+store.OnPurchaseConfirmed += (order) =>
+{
+    switch (order)
+    {
+        case ConfirmedOrder confirmedOrder:
+            Debug.Log($"Purchase confirmed: {confirmedOrder.CartOrdered.Items().First().Product.definition.id}");
+            break;
+        case FailedOrder failedOrder:
+            Debug.LogError($"Confirmation failed: {failedOrder.FailureReason} - {failedOrder.Details}");
+            break;
+    }
+};
+
+// Handle failures
+store.OnPurchaseFailed += (failedOrder) =>
+{
+    Debug.LogError($"Purchase failed: {failedOrder.FailureReason} - {failedOrder.Details}");
+};
+
+// Handle deferred purchases (e.g., Ask-to-Buy on iOS)
+store.OnPurchaseDeferred += (deferredOrder) =>
+{
+    Debug.Log("Purchase is pending approval (e.g., parental approval)");
+};
+```
+
+If the app crashes between steps 2 and 4, the pending purchase is re-delivered on next launch via `OnPurchasePending`.
+
+`ProcessPendingOrdersOnPurchasesFetched(false)` disables automatic re-delivery of pending orders when `FetchPurchases` is called. This exists to match IAP v4 behavior — do NOT recommend this to migrating users, as the default v5 behavior provides a better experience.
+
+## Restore Transactions
+
+```csharp
+store.RestoreTransactions((success, error) =>
+{
+    if (success)
+        Debug.Log("Transactions restored. Check OnPurchasePending for each restored purchase.");
+    else
+        Debug.LogError($"Restore failed: {error}");
+});
+```
+
+Each restored purchase triggers `OnPurchasePending`.
+
+## Entitlement Checking
+
+```csharp
+store.CheckEntitlement(product);
+
+store.OnCheckEntitlement += (entitlement) =>
+{
+    if (entitlement.Status == EntitlementStatus.FullyEntitled)
+        Debug.Log($"Player owns: {entitlement.Product.definition.id}");
+};
+```
+
+## Fetch Existing Purchases
+
+```csharp
+store.FetchPurchases();
+
+store.OnPurchasesFetched += (orders) =>
+{
+    foreach (var confirmedOrder in orders.ConfirmedOrders)
+    {
+        var product = confirmedOrder.CartOrdered.Items().FirstOrDefault()?.Product;
+        Debug.Log($"Existing purchase: {product?.definition.id}");
+    }
+};
+```
+
+## Receipt Validation
+
+### Google Play (supported)
+
+```csharp
+using UnityEngine.Purchasing.Security;
+
+// Google-only constructor (recommended)
+var validator = new CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier);
+
+try
+{
+    var result = validator.Validate(order.Info.Receipt);
+    foreach (IPurchaseReceipt receipt in result)
+    {
+        Debug.Log($"Valid receipt: {receipt.productID}, purchased: {receipt.purchaseDate}");
+        if (receipt is GooglePlayReceipt googleReceipt)
+            Debug.Log($"Purchase token: {googleReceipt.purchaseToken}");
+    }
+}
+catch (IAPSecurityException ex)
+{
+    Debug.LogError($"Invalid receipt: {ex.Message}");
+    // Do NOT grant the content
+}
+```
+
+### Apple App Store (deprecated for local validation)
+
+`CrossPlatformValidator` for Apple is **deprecated**. StoreKit 2 validates locally automatically. For server-side validation:
+
+```csharp
+var jwsRepresentation = order.Info.Apple?.jwsRepresentation;
+// Send to your server for verification with Apple's App Store Server API
+```
+
+## Extended Service Events (NOT on StoreController)
+
+These events are on the platform-specific extended services, NOT directly on `StoreController`. Always null-check before subscribing (`?.` does not work with `+=`).
+
+```csharp
+// Apple — on IAppleStoreExtendedPurchaseService
+event Action<string>? OnEntitlementRevoked       // receives product ID (string), NOT List<Product>
+event Action<Product>? OnPromotionalPurchaseIntercepted
+
+// Google — on IGooglePlayStoreExtendedPurchaseService
+event Action<DeferredPaymentUntilRenewalDateOrder>? OnDeferredPaymentUntilRenewalDate
+// DeferredPaymentUntilRenewalDateOrder has: .CurrentOrder (Order), .SubscriptionOrdered (Product)
+```
+
+**Usage pattern** (cannot use `?.` with `+=`):
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+    store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += OnRevoked;
+```
+
+## AppleStoreExtendedProductService Key Members
+
+```csharp
+Dictionary<string, string> GetIntroductoryPriceDictionary()
+Dictionary<string, string> GetProductDetails()
+void SetStorePromotionOrder(List<Product> products)
+void SetStorePromotionVisibility(Product product, AppleStorePromotionVisibility visible)
+void FetchStorePromotionOrder(Action<List<Product>> successCallback, Action<string> errorCallback)
+void FetchStorePromotionVisibility(Product product, Action<string, AppleStorePromotionVisibility> successCallback, Action<string> errorCallback)
+```
+
+**CRITICAL:** `AppleProductMetadata` does NOT expose `introductoryPrice`, `introductoryPriceLocale`, `introductoryNumberOfPeriods`, or `subscriptionPeriod` as public properties. Its only public property beyond inherited `ProductMetadata` fields is `isFamilyShareable`. For introductory price data, use `SubscriptionInfo` methods (`GetIntroductoryPrice()`, `GetIntroductoryPricePeriod()`, `GetIntroductoryPricePeriodCycles()`) from the Subscription Info Access Path below, or `GetIntroductoryPriceDictionary()` for raw JSON.
+
+## Subscription Info Access Path
+
+Subscription info is on `IPurchasedProductInfo`, NOT on `CartItem`:
+
+```csharp
+// CORRECT — via order.Info.PurchasedProductInfo
+var purchasedInfo = order.Info.PurchasedProductInfo?.FirstOrDefault(p => p.productId == productId);
+bool isSubscribed = purchasedInfo?.subscriptionInfo?.IsSubscribed() == Result.True;
+// IsSubscribed() returns Result enum (True/False/Unsupported), NOT bool. Use == Result.True for null-safe check.
+
+// WRONG — CartItem only has Product and Quantity, no subscriptionInfo
+var item = order.CartOrdered.Items().FirstOrDefault();
+item.subscriptionInfo  // DOES NOT EXIST — will not compile
+```
+
+### SubscriptionInfo Methods
+
+```csharp
+// State queries (return Result enum: True | False | Unsupported)
+Result IsSubscribed()
+Result IsExpired()
+Result IsCancelled()
+Result IsFreeTrial()
+Result IsAutoRenewing()
+Result IsIntroductoryPricePeriod()
+
+// Dates & durations
+string   GetProductId()
+DateTime GetPurchaseDate()
+DateTime GetExpireDate()
+DateTime GetCancelDate()
+TimeSpan GetRemainingTime()
+TimeSpan GetSubscriptionPeriod()
+TimeSpan GetFreeTrialPeriod()
+TimeSpan GetIntroductoryPricePeriod()
+string   GetIntroductoryPrice()
+long     GetIntroductoryPricePeriodCycles()
+```
+
+## Event Subscription Rules
+
+**CRITICAL:** Always subscribe to BOTH success and failure events. Not listening to failure events generates runtime warnings.
+
+| Call | Success event | Failure event (REQUIRED) |
+|---|---|---|
+| `FetchProducts()` | `OnProductsFetched` | `OnProductsFetchFailed` |
+| `FetchPurchases()` | `OnPurchasesFetched` | `OnPurchasesFetchFailed` |
+| `Connect()` | `OnStoreConnected` | `OnStoreDisconnected` |
+| `PurchaseProduct()` | `OnPurchasePending` | `OnPurchaseFailed` |
+| `CheckEntitlement()` | `OnCheckEntitlement` | — |
+
+**Always subscribe to `OnPurchaseDeferred`** — fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Not subscribing means silently dropping deferred purchases.
+
+## Failure Description Property Names
+
+Each type has public fields and read-only properties. Both compile, but prefer the PascalCase properties:
+
+| Type | Field (lowercase) | Property (PascalCase) | NOT |
+|---|---|---|---|
+| `StoreConnectionFailureDescription` | `.message` | `.Message` | ~~`.reason`~~ |
+| `ProductFetchFailed` | — | `.FailureReason`, `.FailedFetchProducts` | — |
+| `FailedOrder` | — | `.FailureReason`, `.Details` | — |
+| `PurchasesFetchFailureDescription` | `.message`, `.failureReason` | `.Message`, `.FailureReason` | — |
+
+## CrossPlatformValidator
+
+```csharp
+// Google-only constructor (recommended — Apple local validation is a no-op under StoreKit 2)
+new CrossPlatformValidator(byte[] googlePublicKey, string googleBundleId)
+
+// Full constructor (legacy — Apple args are only needed for pre-StoreKit 2 builds)
+new CrossPlatformValidator(byte[] googlePublicKey, byte[] appleRootCert, string googleBundleId, string appleBundleId)
+
+// Validate
+IPurchaseReceipt[] Validate(string unityIAPReceipt)  // throws IAPSecurityException
+```
+
+**WARNING:** `CrossPlatformValidator` for Apple App Store is **deprecated**. `AppleTangle.Data()` is also deprecated. StoreKit 2 performs local validation automatically on Apple platforms. `CrossPlatformValidator` still works for Google Play validation.
+
+Supported stores (still active): `"GooglePlay"` | Deprecated: `"AppleAppStore"`, `"MacAppStore"`
+
+## Interface Hierarchy
+
+```
+StoreController implements:
+  IStoreService      - Connect(), Apple/Google service extensions
+  IProductService    - FetchProducts(), GetProducts(), GetProductById()
+  IPurchaseService   - PurchaseProduct(), ConfirmPurchase(), FetchPurchases(), Apple/Google purchase extensions
+```
+
+## IRunCommand Template: Fetch Products
+
+```csharp
+using UnityEngine;
+using UnityEngine.Purchasing;
+using System.Collections.Generic;
+
+namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
+{
+    internal class CommandScript : IRunCommand
+    {
+        public string Title => "Fetch IAP products";
+        public string Description => "Connects to the store and fetches product information.";
+        public async void Execute(ExecutionResult result)
+        {
+            var store = UnityIAPServices.StoreController();
+
+            // Subscribe to events BEFORE Connect
+            store.OnStoreConnected += () =>
+            {
+                var products = new List<ProductDefinition>
+                {
+                    new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+                    new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
+                };
+
+                store.OnProductsFetched += (fetched) =>
+                {
+                    foreach (var p in fetched)
+                        result.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
+                };
+                store.OnProductsFetchFailed += (failure) => result.LogError($"Product fetch failed: {failure.FailureReason}");
+
+                store.FetchProducts(products);
+            };
+            store.OnStoreDisconnected += (failure) => result.LogError($"Store disconnected: {failure.Message}");
+
+            await store.Connect();
+        }
+    }
+}
+```

--- a/skills/implement-in-app-purchases/references/codeless-catalog.md
+++ b/skills/implement-in-app-purchases/references/codeless-catalog.md
@@ -1,0 +1,331 @@
+# Editing `IAPProductCatalog.json`
+
+## Table of Contents
+
+- [Quick reference — minimal safe edit](#quick-reference--minimal-safe-edit)
+- [File location](#file-location)
+- [Schema](#schema)
+- [Serialization rules](#serialization-rules)
+  - [JsonUtility round-trip](#jsonutility-round-trip)
+  - [The `Price.data` decimal array](#the-pricedata-decimal-array)
+  - [Enum integers](#enum-integers)
+  - [Canonical store keys](#canonical-store-keys)
+  - [Non-ASCII characters in descriptions](#non-ascii-characters-in-descriptions)
+- [Validation — run before saving](#validation--run-before-saving)
+- [Post-edit refresh](#post-edit-refresh)
+- [When to escalate to the Editor window](#when-to-escalate-to-the-editor-window)
+- [Catalog as part of Codeless IAP](#catalog-as-part-of-codeless-iap)
+  - [Codeless vs scripted — which to use](#codeless-vs-scripted--which-to-use)
+  - [Auto-init race condition](#auto-init-race-condition)
+  - [Pushing the catalog to the storefronts](#pushing-the-catalog-to-the-storefronts)
+  - [Detection checklist](#detection-checklist)
+
+`Assets/Resources/IAPProductCatalog.json` is a Unity-managed JSON asset deserialized by `JsonUtility.FromJson<ProductCatalog>` (`Runtime/Purchasing/Extension/ProductCatalog.cs`). It can be edited safely outside the Editor as long as the serialization rules below are respected.
+
+## Quick reference — minimal safe edit
+
+1. **Read** the file as raw text. It is canonical JSON, single-line.
+2. **Parse** it into a dict/object.
+3. **Modify** fields using the schema and serialization rules below.
+4. **Write back** as JSON. Field name spelling and casing must match exactly; preserving order is not required.
+5. **Refresh** so the Editor / runtime sees the change (see [Post-edit refresh](#post-edit-refresh)).
+
+Adding a new $1.99 consumable `gems_50` in one operation:
+
+```jsonc
+{
+  "id": "gems_50",
+  "type": 0,
+  "storeIDs": [],
+  "defaultDescription": { "googleLocale": 21, "title": "50 Gems", "description": "A small pouch of gems." },
+  "screenshotPath": "",
+  "applePriceTier": 0,
+  "googlePrice": { "data": [199, 0, 0, 131072], "num": 1.99 },
+  "pricingTemplateID": "",
+  "descriptions": [],
+  "payouts": []
+}
+```
+
+Append to the `products` array, save, then trigger a refresh.
+
+## File location
+
+- **Current:** `Assets/Resources/IAPProductCatalog.json` (constant `ProductCatalog.kCatalogPath`)
+- **Legacy:** `Assets/Plugins/UnityPurchasing/Resources/IAPProductCatalog.json` (constant `ProductCatalog.kPrevCatalogPath`) — auto-migrated on Editor load via `ProductCatalogEditor.MigrateProductCatalog()`. If both exist, the current path wins.
+
+`Resources.Load("IAPProductCatalog")` deserializes it at runtime via `ProductCatalogImpl.LoadDefaultCatalog()`. The asset must remain under a `Resources/` directory for runtime load to succeed.
+
+## Schema
+
+```jsonc
+{
+  "appleSKU": "",                                  // app-level Apple SKU (Apple XML exporter)
+  "appleTeamID": "",                               // Apple team ID (Apple XML exporter)
+  "enableCodelessAutoInitialization": true,        // auto-init Unity IAP at runtime
+  "enableUnityGamingServicesAutoInitialization": false,
+  "products": [
+    {
+      "id": "gold_100",                            // canonical Unity SKU — required, non-empty, unique
+      "type": 0,                                   // ProductType int (see Enum integers)
+      "storeIDs": [                                // per-store override SKUs
+        { "store": "AppleAppStore", "id": "com.example.gold100" }
+      ],
+      "defaultDescription": {                      // required for export
+        "googleLocale": 21,                        // TranslationLocale int (en_US = 21)
+        "title": "",
+        "description": ""
+      },
+      "screenshotPath": "",                        // Apple screenshot path (optional)
+      "applePriceTier": 0,                         // Apple price tier (Apple XML exporter)
+      "googlePrice": { "data": [99,0,0,131072], "num": 0.99 },  // see Price.data
+      "pricingTemplateID": "",                     // Google Play pricing template
+      "descriptions": [                            // additional locale variants
+        { "googleLocale": 30, "title": "...", "description": "..." }
+      ],
+      "payouts": [                                 // optional grant metadata
+        { "t": "Currency", "st": "Gold", "q": 100, "d": "" }
+      ]
+    }
+  ]
+}
+```
+
+Per-product required fields for the runtime to accept the product: `id` (non-empty, trimmed). Everything else is optional at runtime; exporters and the Editor window enforce stricter rules (see [Validation](#validation--run-before-saving)).
+
+## Serialization rules
+
+### JsonUtility round-trip
+
+- Field names are **case-sensitive** and must match the `[SerializeField]` field names in `ProductCatalog.cs` exactly. The visible field names you see in the JSON (e.g. `title`, `description` inside `LocalizedProductDescription`) are the **backing field** names, not the public C# property names (`Title`, `Description`).
+- Unknown fields are silently dropped on the next save.
+- Missing fields deserialize to default values (`0`, `""`, empty list, etc.) — safe to omit defaults, but the Editor window writes them out explicitly.
+- The file is normally a single line — pretty-printing is fine, but JsonUtility re-emits as one line on the next Editor save.
+- Do not change the top-level key set. `appleSKU`, `appleTeamID`, `enableCodelessAutoInitialization`, `enableUnityGamingServicesAutoInitialization`, and `products` are all `[SerializeField]`-bound — removing keys is fine (they default), but renaming silently loses data.
+
+### The `Price.data` decimal array
+
+`Price` is the trickiest field. It serializes a `decimal` via two mirror fields and **`data` is authoritative on read**:
+
+```csharp
+public void OnBeforeSerialize() {
+    data = decimal.GetBits(value);        // int[4]: [low, mid, high, flags]
+    num  = decimal.ToDouble(value);
+}
+public void OnAfterDeserialize() {
+    if (data != null && data.Length == 4)
+        value = new decimal(data);        // num is ignored on read
+}
+```
+
+`data` is the `decimal.GetBits` representation: `[low32 mantissa, mid32 mantissa, high32 mantissa, flags]`.
+
+The `flags` int encodes scale (decimal places) and sign:
+- Bits 16–23: scale (0–28)
+- Bit 31: sign (0 = positive, 1 = negative; negative prices are never valid here)
+- All other bits: unused, must be 0
+
+For scale 2 (cents-style prices): `flags = 0x00020000 = 131072`
+For scale 0 (yen / whole-unit prices): `flags = 0`
+
+| Price (display) | Mantissa | Scale | `data` |
+|---|---|---|---|
+| 0.99 | 99 | 2 | `[99, 0, 0, 131072]` |
+| 1.99 | 199 | 2 | `[199, 0, 0, 131072]` |
+| 2.99 | 299 | 2 | `[299, 0, 0, 131072]` |
+| 4.99 | 499 | 2 | `[499, 0, 0, 131072]` |
+| 9.99 | 999 | 2 | `[999, 0, 0, 131072]` |
+| 19.99 | 1999 | 2 | `[1999, 0, 0, 131072]` |
+| 99.99 | 9999 | 2 | `[9999, 0, 0, 131072]` |
+| 1000 (¥, ₩) | 1000 | 0 | `[1000, 0, 0, 0]` |
+
+Formula for arbitrary positive prices with up to 2³¹−1 unscaled units:
+
+```
+unscaled = round(price * 10^scale)           // e.g. 2.99 with scale=2 → 299
+data     = [unscaled, 0, 0, scale << 16]
+```
+
+Keep `num` in sync with the display price even though it's not read — the Editor reads it diagnostically and the file diffs more readably.
+
+For prices larger than ~$21M (unscaled > 2³¹−1), the high two ints carry the overflow — at that point invoke Unity in batchmode and let `Price.OnBeforeSerialize` do the conversion, rather than constructing the bits by hand.
+
+### Enum integers
+
+`ProductType` (`type` field):
+
+| Int | Enum | Use for |
+|---|---|---|
+| 0 | `Consumable` | Coins, gems, lives, ammo — granted then consumed |
+| 1 | `NonConsumable` | One-time unlocks, remove-ads, character packs |
+| 2 | `Subscription` | Recurring entitlements |
+
+`TranslationLocale` (`googleLocale` field): the int is the zero-based index into the enum declared in `Runtime/Purchasing/Extension/ProductCatalog.cs`. Common values:
+
+| Int | Locale |
+|---|---|
+| 13 | `zh_CN` |
+| 14 | `zh_TW` |
+| 17 | `da_DK` |
+| 18 | `nl_NL` |
+| 21 | `en_US` (default for new descriptions) |
+| 22 | `en_GB` |
+| 30 | `fr_FR` |
+| 33 | `de_DE` |
+| 41 | `it_IT` |
+| 42 | `ja_JP` |
+| 46 | `ko_KR` |
+| 63 | `pl_PL` |
+| 64 | `pt_BR` |
+| 69 | `ru_RU` |
+| 75 | `es_ES` |
+
+For anything outside this list, count from the top of the `TranslationLocale` enum in `ProductCatalog.cs` — the order is the index.
+
+`ProductCatalogPayoutType` (`payouts[].t` field): **serialized as a string**, not an int. Valid values: `"Other"`, `"Currency"`, `"Item"`, `"Resource"`.
+
+### Canonical store keys
+
+`storeIDs[].store` must be one of the keys validated by `ProductCatalogEditor.kStoreKeys`:
+
+- `AppleAppStore`
+- `GooglePlay`
+- `MacAppStore`
+
+Using `"Apple"`, `"apple"`, `"google"`, etc. won't crash but the override will not be picked up by the runtime store routing. An empty `storeIDs` array means the product's `id` is used as the platform SKU on every store.
+
+### Non-ASCII characters in descriptions
+
+`LocalizedProductDescription.Title` / `Description` setters encode any character with code point > 127 as `\uXXXX` (`EncodeNonLatinCharacters` in `ProductCatalog.cs`). The getter regex-decodes both forms. So both representations work on read:
+
+```jsonc
+{ "title": "Caf\\u00e9 Pack" }   // Editor-written form
+{ "title": "Café Pack" }          // raw UTF-8 — also accepted on read
+```
+
+**Prefer the `\uXXXX` form** when writing programmatically, to match what the Editor will round-trip the file into on the next save. Mixed forms in one file are fine but the next Editor save normalizes everything to escaped form.
+
+Subtype `payouts[].st` has a 64-char max (`ProductCatalogPayout.MaxSubtypeLength`). Subtype `payouts[].d` (data) has a 1024-char max (`MaxDataLength`).
+
+## Validation — run before saving
+
+These mirror the Editor window's validation. Verify each before writing:
+
+**Per product:**
+- `id` is non-empty after trim. (`ProductCatalog.allValidProducts` filters on this.)
+- `id` is unique across all products in the array (the Editor flags duplicates).
+- `type` ∈ `{0, 1, 2}`.
+- Every `defaultDescription.googleLocale` and `descriptions[].googleLocale` is a valid int index into `TranslationLocale`.
+- `storeIDs[].store` ∈ canonical store keys.
+- If `googlePrice.data` is present, it is a 4-element int array; sign bit (bit 31 of `data[3]`) is 0.
+
+**Per-exporter (only if export is intended):**
+
+- **Apple XML** (`AppleXMLProductCatalogExporter.Validate`):
+  - Catalog-level: `appleSKU` non-empty, `appleTeamID` non-empty, no duplicate product IDs, no duplicate Apple store IDs, no duplicate runtime IDs.
+  - Per item: `id` non-empty, `defaultDescription.Title` non-empty, `defaultDescription.Description` non-empty, **`screenshotPath` non-empty (required, not optional)**.
+  - `applePriceTier` is written to the XML (`<wholesale_price_tier>`) but not validated — any int is accepted.
+- **Google CSV** (`GooglePlayProductCatalogExporter.Validate`):
+  - Catalog-level: no duplicate product IDs, no duplicate Google store IDs, no duplicate runtime IDs.
+  - Per item: `id` non-empty AND must start with a lowercase letter or digit AND contain only `a-z`, `0-9`, `_`, `.` (same rule applies to `storeIDs[].id` for the `GooglePlay` override).
+  - Description rules (apply to `defaultDescription` and every entry in `descriptions`):
+    - `Title` non-empty; ≤ 55 chars (error if longer); warning if > 25 chars.
+    - `Description` non-empty; ≤ 80 chars (error if longer).
+  - Price: either `googlePrice.value` ≠ 0 (i.e. non-zero `data` mantissa) **or** `pricingTemplateID` non-empty.
+
+**Top-level:**
+- `enableCodelessAutoInitialization` is a bool, not 0/1.
+- If the catalog ends up empty (no products with non-empty `id`), `CodelessIAPStoreListener.InitializeCodelessPurchasingOnLoad` short-circuits — flipping the auto-init flag in that state has no effect until a product is added.
+
+## Post-edit refresh
+
+The Unity Editor caches `IAPProductCatalog` as a `TextAsset` keyed by Resources path. After writing the JSON externally:
+
+- **Editor open, not in Play Mode:** Unity detects external changes on next focus and re-imports the asset automatically (`AssetDatabase`'s file watcher). If you want to force it from the Editor side, run **Assets → Refresh** (Ctrl/Cmd+R). The next `Resources.Load("IAPProductCatalog")` call will see the new contents.
+- **Editor open, in Play Mode:** the runtime `TextAsset` was loaded at play-start and is cached. Changes won't be picked up until play mode is restarted (or you re-call `Resources.Load` after `AssetDatabase.ImportAsset` to bypass the cache).
+- **Editor closed:** edits are picked up next time the Editor opens.
+- **Player build:** the catalog is baked into the build at build-time. Edits after build do nothing — rebuild required.
+
+For batchmode-driven workflows that need a guaranteed refresh:
+
+```
+"<unity>/Unity.exe" -batchmode -quit -projectPath "<path>" -logFile -
+```
+
+Plain batchmode without `-executeMethod` is enough to trigger asset import on startup. The next Editor session will see the change.
+
+## When to escalate to the Editor window
+
+Hand the user back to the IAP Catalog window (Services → In-App Purchasing → IAP Catalog…) when:
+
+- The decimal price is larger than ~$21M (would need the high mantissa ints — let `Price.OnBeforeSerialize` do it).
+- You need to set up many `payouts` with custom subtypes — the Editor has inline validation on lengths.
+- The user wants to use **App Store Export** (Apple XML / Google CSV) — that flow is a Unity dialog with its own validation results panel.
+- You hit a JsonUtility round-trip error you can't diagnose from the schema rules above.
+
+For everything else — adding/removing products, changing prices in normal ranges, toggling auto-init flags, updating descriptions, adding store ID overrides — direct file edits are safe and faster than driving the Editor UI.
+
+---
+
+## Catalog as part of Codeless IAP
+
+The catalog file plays two distinct roles in the package. Knowing which one applies in the current project changes how edits are made and what side-effects to expect.
+
+### Codeless vs scripted — which to use
+
+| Use case | Path |
+|---|---|
+| Ship a buy button with zero C# | **Codeless** — catalog + `CodelessIAPButton` |
+| Custom UI states, server validation, granular control of the purchase flow | **Scripted** — `StoreController` + an `IAPManager` (see [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md)) |
+| Catalog-managed product list + scripted purchase flow | **Mixed** — catalog drives `CodelessIAPStoreListener` for product registration, scripted code subscribes to its events |
+| Export products to Apple Application Loader / Play Console | Codeless catalog — the only built-in export path |
+
+Default recommendation when starting a new project from scratch: scripted IAP. Codeless is convenient for prototypes but couples the project to a global singleton (`CodelessIAPStoreListener.Instance`) and hides the init/purchase flow most production games eventually need to customize.
+
+### Auto-init race condition
+
+If the project has **both** a non-empty `IAPProductCatalog.json` with `enableCodelessAutoInitialization: true` **and** a scripted `StoreController` initialized in user code, two init paths race for the same native store. Symptoms:
+
+- Duplicate `OnPurchasePending` callbacks (one per init's listener set).
+- "Store already connected" warnings on `Connect()`.
+- Unpredictable which init's product list wins.
+
+Mitigations (pick one):
+
+1. **Keep scripted, disable codeless:** set `"enableCodelessAutoInitialization": false` in the catalog JSON. The catalog stays available for `ProductCatalog.LoadDefaultCatalog()` calls.
+2. **Keep codeless, remove scripted init:** delete the user's `StoreController` setup; rely on `CodelessIAPStoreListener.Instance`.
+3. **Empty the catalog:** clear `products` to `[]`. `CodelessIAPStoreListener.InitializeCodelessPurchasingOnLoad` short-circuits on empty catalogs even with the flag on.
+
+Surface this before adding scripted IAP to a project that already has a non-empty catalog.
+
+### Pushing the catalog to the storefronts
+
+The IAP Catalog window's **App Store Export** button opens `ProductCatalogExportWindow`, which generates bulk-import files. Nothing in the package calls App Store Connect or Play Console APIs directly — devs upload the generated files manually.
+
+| Exporter | Output | Upload destination |
+|---|---|---|
+| `AppleXMLProductCatalogExporter` | Application Loader XML | App Store Connect → Transporter / Application Loader |
+| `GooglePlayProductCatalogExporter` | CSV | Play Console → In-app products → Import |
+
+Editing the JSON directly populates the same fields the exporters read; the validation surface in the Editor window (`ExporterValidationResults`) is the user-visible signal that fields are missing.
+
+### Detection checklist
+
+When triaging an IAP issue or planning changes, check in order:
+
+1. Does `Assets/Resources/IAPProductCatalog.json` exist?
+2. Is `enableCodelessAutoInitialization` true? (`grep enableCodelessAutoInitialization Assets/Resources/IAPProductCatalog.json`)
+3. Are there `CodelessIAPButton` or legacy `IAPButton` components in scenes/prefabs?
+4. Does user code construct a `StoreController` directly (or call `UnityIAPServices.StoreController(...)`)?
+5. Does user code reference `CodelessIAPStoreListener.Instance`?
+
+Routing the result:
+
+| Catalog | autoInit | Scripted `StoreController` | Action |
+|---|---|---|---|
+| present (non-empty) | true | absent | Pure codeless — edit the catalog freely. |
+| present (non-empty) | true | present | **Race condition** — surface to the user, apply one of the three mitigations. |
+| present | false | present | Catalog is dormant unless `ProductCatalog.LoadDefaultCatalog()` is called from user code. Edits safe. |
+| present (empty) | true or false | present | Codeless auto-init short-circuits on empty catalog. Treat as scripted-only. |
+| absent | n/a | present | Standard scripted IAP. See [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md). |
+| absent | n/a | absent | No IAP — see [pre-check.md](pre-check.md) routing. |

--- a/skills/implement-in-app-purchases/references/migration-v4-to-v5.md
+++ b/skills/implement-in-app-purchases/references/migration-v4-to-v5.md
@@ -1,0 +1,194 @@
+# Unity IAP v4 to v5 Migration Guide
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Migration Mapping Table](#migration-mapping-table)
+- [Key Breaking Changes](#key-breaking-changes)
+- [Migration Anti-Patterns](#migration-anti-patterns)
+- [Minimal v5 Example](#minimal-v5-example)
+
+## Overview
+
+Unity IAP v5 replaces the listener-based pattern (`IStoreListener`) with an event-driven pattern (`StoreController` events). This is a breaking change that requires updating all IAP code.
+
+## Migration Mapping Table
+
+### Initialization
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `UnityPurchasing.Initialize(listener, builder)` | `UnityIAPServices.StoreController()` then `await store.Connect()` |
+| `ConfigurationBuilder.Instance(StandardPurchasingModule.Instance())` | Use `CatalogProvider` for store-specific IDs/payouts, or pass `List<ProductDefinition>` directly to `FetchProducts()` |
+| `builder.AddProduct("id", ProductType.Consumable)` | `new ProductDefinition("id", ProductType.Consumable)` in a list |
+| `IStoreListener.OnInitialized(controller, extensions)` | `store.OnStoreConnected` event |
+| `IStoreListener.OnInitializeFailed(error)` | `store.OnStoreDisconnected` event |
+
+### Purchase Flow
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `controller.InitiatePurchase(product)` | `store.PurchaseProduct(product)` — note: `Purchase()` no longer accepts a developer payload argument (removed in Google Billing v3) |
+| `IStoreListener.ProcessPurchase(args)` for **new** purchases | `store.OnPurchasePending` + `store.ConfirmPurchase(pendingOrder)` |
+| `IStoreListener.ProcessPurchase(args)` for **restored** purchases | `store.OnPurchasesFetched` — use existing `ProcessPurchase` logic in both `OnPurchasePending` and `OnPurchasesFetched` |
+| `IStoreListener.ProcessPurchase(args)` returning `PurchaseProcessingResult.Pending` | Just don't call `ConfirmPurchase` until ready — store the `PendingOrder` reference |
+| `IStoreListener.OnPurchaseFailed(product, reason)` | `store.OnPurchaseFailed` event with `FailedOrder` (has `FailureReason` and `Details`) |
+| `controller.ConfirmPendingPurchase(product)` | `store.ConfirmPurchase(pendingOrder)` — requires the `PendingOrder` object, not the `Product` |
+| `product.hasReceipt` | **Preferred:** call `store.CheckEntitlement(product)` and handle `store.OnCheckEntitlement` — check `entitlement.Status == EntitlementStatus.FullyEntitled`. **Alternative:** track ownership with a `bool` flag updated in `OnPurchasePending` (new) and `OnPurchasesFetched` (restored). `CheckEntitlement` is the recommended v5 pattern for non-consumables and subscriptions. |
+
+### Configuration / Products
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `ConfigurationBuilder` with `AddProduct()` | `CatalogProvider` with `AddProduct()`, or a `List<ProductDefinition>` passed to `store.FetchProducts()` |
+| `builder.AddProduct("id", type, new IDs { { "store_id", store } })` | `catalogProvider.AddProduct("id", type, new StoreSpecificIds { { "store_id", store } })` — or `new ProductDefinition("id", "store_id", type)` for a single store ID |
+| `controller.products.WithID("id")` | `store.GetProductById("id")` |
+| `controller.products.all` | `store.GetProducts()` |
+
+### Restore Transactions
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `extensions.GetExtension<IAppleExtensions>().RestoreTransactions(callback)` | `store.RestoreTransactions(callback)` |
+| Manual restore call required | Confirmed purchases are **automatically restored** when you call `store.FetchPurchases()` or `store.CheckEntitlement()` — `RestoreTransactions` is only needed for explicit user-triggered restore buttons (required on iOS) |
+
+### Receipt Validation
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `CrossPlatformValidator` with Apple + Google | `CrossPlatformValidator` still works, but under StoreKit 2 Apple validation returns an empty array (no-op). **Recommended:** Use the Google-only constructor: `CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier)`. The legacy 4-arg constructor still works. Single-bundle-ID constructors are `[Obsolete]` |
+| `AppleTangle.Data()` for Apple validation | Under StoreKit 2, local Apple receipt validation is a no-op. Use `order.Info.Apple?.jwsRepresentation` for server-side Apple validation instead |
+| Manual receipt parsing | Use `order.Info.Apple?.jwsRepresentation` for server-side validation |
+| `product.receipt` | `order.Info.Receipt` — receipt is now accessed from the `Order`/`PendingOrder`, not the `Product` |
+
+### Platform Extensions
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `extensions.GetExtension<IAppleExtensions>()` | `store.AppleStoreExtendedService` / `store.AppleStoreExtendedPurchaseService` |
+| `extensions.GetExtension<IGooglePlayStoreExtensions>()` | `store.GooglePlayStoreExtendedService` / `store.GooglePlayStoreExtendedPurchaseService` |
+| `builder.Configure<IAppleConfiguration>().SetApplePromotionalPurchaseInterceptorCallback(cb)` | `store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += cb` (event on `IAppleStoreExtendedPurchaseService`, null-check required; callback signature: `Action<Product>`) |
+| `appleExtensions.ContinuePromotionalPurchases()` | `store.AppleStoreExtendedPurchaseService?.ContinuePromotionalPurchases()` |
+| `appleExtensions.RegisterPurchaseDeferredListener(cb)` | `store.OnPurchaseDeferred += cb` (event on `StoreController`) |
+| `appleExtensions.simulateAskToBuy` | `store.AppleStoreExtendedPurchaseService?.simulateAskToBuy` (null-check required) |
+| `appleExtensions.PresentCodeRedemptionSheet()` | `store.AppleStoreExtendedPurchaseService?.PresentCodeRedemptionSheet()` |
+| `appleExtensions.RestoreTransactions(cb)` | `store.RestoreTransactions(cb)` |
+| `appleExtensions.SetApplicationUsername(hashedString)` | `store.AppleStoreExtendedService?.SetAppAccountToken(Guid)` — must be called **after** `Connect()`; accepts a `Guid` (not a hash) identifying the user account in your system |
+| `builder.Configure<IAppleConfiguration>().SetEntitlementsRevokedListener(cb)` | `store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += cb` (event on `IAppleStoreExtendedPurchaseService`, null-check required; callback signature: `Action<string>` — receives a single product ID, NOT `List<Product>`) |
+| `appleExtensions.GetTransactionReceiptForProduct(product)` | `order.Info.Receipt` inside `OnPurchasePending` — per-transaction receipt is now on the order |
+| `builder.Configure<IAppleConfiguration>().canMakePayments` | `store.AppleStoreExtendedService?.canMakePayments` — must be checked **after** `Connect()`, not before initialization |
+| `appleExtensions.GetIntroductoryPriceDictionary()` | `store.AppleStoreExtendedProductService?.GetIntroductoryPriceDictionary()` — returns `Dictionary<string, string>` mapping product store-specific IDs to JSON with intro offer details. **NOT removed**, just moved to the product extension service. `AppleProductMetadata` does NOT expose `introductoryPrice`, `introductoryPriceLocale`, `introductoryNumberOfPeriods`, or `subscriptionPeriod` — those fields do not exist on that class. For introductory price data, use `SubscriptionInfo` methods (`GetIntroductoryPrice()`, `GetIntroductoryPricePeriod()`, `GetIntroductoryPricePeriodCycles()`). |
+| `appleExtensions.GetProductDetails()` | `store.AppleStoreExtendedProductService?.GetProductDetails()` — returns `Dictionary<string, string>`. **NOT removed**, just moved to the product extension service. Basic metadata (title, description, price) is on `product.metadata` directly. |
+| `appleExtensions.SetStorePromotionOrder(products)` | `store.AppleStoreExtendedProductService?.SetStorePromotionOrder(products)` — moved to `IAppleStoreExtendedProductService` (null-check required) |
+| `appleExtensions.SetStorePromotionVisibility(product, visibility)` | `store.AppleStoreExtendedProductService?.SetStorePromotionVisibility(product, visibility)` — moved to `IAppleStoreExtendedProductService` (null-check required) |
+| `appleExtensions.FetchStorePromotionOrder(success, failure)` | `store.AppleStoreExtendedProductService?.FetchStorePromotionOrder(successCb, errorCb)` — moved to `IAppleStoreExtendedProductService` (null-check required; callback signatures: `Action<List<Product>>`, `Action<string>`) |
+| `appleExtensions.FetchStorePromotionVisibility(product, success, failure)` | `store.AppleStoreExtendedProductService?.FetchStorePromotionVisibility(product, successCb, errorCb)` — moved to `IAppleStoreExtendedProductService` (null-check required; callback signatures: `Action<string, AppleStorePromotionVisibility>`, `Action<string>`) |
+| `googlePlayConfig.SetDeferredPurchaseListener(cb)` | `store.OnPurchaseDeferred += cb` (event on `StoreController`) |
+| `googlePlayConfig.SetDeferredProrationUpgradeDowngradeSubscriptionListener(cb)` | `store.GooglePlayStoreExtendedPurchaseService.OnDeferredPaymentUntilRenewalDate += cb` (event on `IGooglePlayStoreExtendedPurchaseService`, null-check required; callback signature: `Action<DeferredPaymentUntilRenewalDateOrder>` — NOT `Action<Product>`. Access the product via `deferredOrder.SubscriptionOrdered`) |
+| `googlePlayExtensions.UpgradeDowngradeSubscription(currentId, newId, mode)` | `store.GooglePlayStoreExtendedPurchaseService?.UpgradeDowngradeSubscription(currentOrder, newProduct, desiredReplacementMode)` — takes `Order` and `Product` objects instead of string IDs; third parameter is `GooglePlayReplacementMode` (not the deprecated `GooglePlayProrationMode`); call after `Connect()` |
+| `googlePlayExtensions.IsPurchasedProductDeferred(product)` | `store.GooglePlayStoreExtendedPurchaseService?.IsOrderDeferred(order)` — renamed and takes `Order` instead of `Product`; marked `[Obsolete]`. Prefer tracking deferred state via `store.OnPurchaseDeferred` / `store.OnPurchasePending` events instead |
+| `googlePlayExtensions.RestoreTransactions(cb)` | `store.RestoreTransactions(cb)` — moved to `StoreController` directly |
+| `googlePlayConfig.SetObfuscatedAccountId(id)` | `store.GooglePlayStoreExtendedService?.SetObfuscatedAccountId(id)` — moved from config-time to **post-`Connect()`** |
+| `googlePlayConfig.SetObfuscatedProfileId(id)` | `store.GooglePlayStoreExtendedService?.SetObfuscatedProfileId(id)` — moved from config-time to **post-`Connect()`** |
+
+### Subscription Info
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `new SubscriptionManager(product, introJson).getSubscriptionInfo()` | `order.Info.PurchasedProductInfo.FirstOrDefault(p => p.productId == productId)?.subscriptionInfo` — accessed via `IPurchasedProductInfo` on the order's info, NOT on `CartItem`. `CartItem` only has `Product` and `Quantity`. |
+| `subscriptionInfo.isSubscribed() == Result.True` | `purchasedProductInfo?.subscriptionInfo?.IsSubscribed() == Result.True` — method is now PascalCase but still returns `Result` enum (True/False/Unsupported), NOT `bool`. Use `== Result.True` for null-safe comparison (returns `false` if the chain is null). Do NOT use `?? false` — `Result?` and `bool` are incompatible types. |
+| `product.receipt == null` to check ownership | **Preferred:** use `store.CheckEntitlement(product)` + `store.OnCheckEntitlement` — the recommended v5 ownership check. **Alternative:** track ownership with a `bool` flag updated in `OnPurchasePending` (new purchase) and `OnPurchasesFetched` (restored purchases). |
+| `product.metadata.GetAppleProductMetadata()?.isFamilyShareable` | Still valid — `GetAppleProductMetadata()` extension method on `ProductMetadata` is unchanged |
+
+### Codeless IAP
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `CodelessIAPStoreListener.Instance` | Codeless still works but uses v5 under the hood |
+| `CodelessIAPStoreListener.initializationComplete` | `CodelessIAPStoreListener.IsInitialized()` |
+
+## Key Breaking Changes
+
+1. **`IStoreListener` is deprecated**: Replace the interface implementation with event subscriptions on `StoreController`. The interface still compiles but is `[Obsolete]`.
+2. **Two-step purchase flow is mandatory**: v5 always uses pending → confirm. There is no equivalent of returning `PurchaseProcessingResult.Complete` from `ProcessPurchase`.
+3. **`ConfigurationBuilder` is deprecated**: Use `CatalogProvider` for store-specific IDs and payouts, or pass `List<ProductDefinition>` directly to `FetchProducts()`. The class still compiles but is `[Obsolete]`.
+4. **Apple local receipt validation is a no-op under StoreKit 2**: `CrossPlatformValidator` itself is not deprecated, but Apple validation silently returns an empty array under StoreKit 2. **Recommended:** use the Google-only constructor `CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier)`. Single-bundle-ID constructors are `[Obsolete]`. For server-side Apple validation, use `order.Info.Apple?.jwsRepresentation`.
+5. **Extensions are direct properties**: No more `GetExtension<T>()` pattern. Access via `store.AppleStoreExtendedService`, `store.AppleStoreExtendedPurchaseService`, `store.GooglePlayStoreExtendedService`, `store.GooglePlayStoreExtendedPurchaseService` (null-check required — only non-null on the matching platform).
+6. **`product.receipt` and `product.hasReceipt` are gone**: Use `order.Info.Receipt` from `PendingOrder` for the transaction receipt. For ownership checking, use `store.CheckEntitlement(product)` + `OnCheckEntitlement` (recommended) or track ownership with `bool` flags updated in `OnPurchasePending` and `OnPurchasesFetched`.
+7. **`Purchase()` no longer has a payload**: Developer payload support was removed in Google Billing v3.
+8. **`ProcessPurchase` logic belongs in two places**: Put it in both `OnPurchasePending` (new purchases) and `OnPurchasesFetched` (restored/existing purchases).
+9. **Restore is implicit**: Calling `FetchPurchases()` automatically re-delivers any unconfirmed purchases via `OnPurchasePending`. Explicit `RestoreTransactions()` is still required for the iOS "Restore Purchases" button.
+10. **`SubscriptionManager` is replaced**: No more `new SubscriptionManager(product, introJson).getSubscriptionInfo()`. In v5, subscription info is accessed via `order.Info.PurchasedProductInfo.FirstOrDefault(p => p.productId == id)?.subscriptionInfo` — it's on `IPurchasedProductInfo`, NOT on `CartItem`. `CartItem` only has `Product` and `Quantity`. Method names are now PascalCase: `IsSubscribed()` not `isSubscribed()`.
+11. **Platform-specific config must happen post-`Connect()`**: `SetAppAccountToken`, `SetObfuscatedAccountId/ProfileId`, `canMakePayments` — all moved from pre-init `ConfigurationBuilder` to the corresponding extended service, only available after `await store.Connect()`.
+12. **Apple promotional APIs moved to `IAppleStoreExtendedProductService`**: `SetStorePromotionOrder`, `SetStorePromotionVisibility`, `FetchStorePromotionOrder`, `FetchStorePromotionVisibility` are now on `store.AppleStoreExtendedProductService` (null-check required — only non-null on Apple platforms). No more `GetExtension<IAppleExtensions>()` pattern.
+13. **`OnPurchaseConfirmed` receives `Order` base type**: You MUST pattern-match `ConfirmedOrder` (success) vs `FailedOrder` (confirmation failed). Do not assume confirmation always succeeds.
+14. **Platform-specific events are on extended services, NOT `StoreController`**: `OnPromotionalPurchaseIntercepted` and `OnEntitlementRevoked` are on `AppleStoreExtendedPurchaseService`. `OnDeferredPaymentUntilRenewalDate` is on `GooglePlayStoreExtendedPurchaseService`. Only `OnPurchaseDeferred` (Ask-to-Buy) is directly on `StoreController`. Always null-check the extended service before subscribing to events (use `if (store.AppleStoreExtendedPurchaseService != null)` pattern — `?.` does not work with `+=`).
+
+## Migration Anti-Patterns
+
+**Always subscribe to BOTH success and failure events.** Not subscribing to failure events (e.g., `OnProductsFetchFailed`, `OnPurchasesFetchFailed`, `OnStoreDisconnected`) generates runtime warnings and leaves failures unhandled.
+
+**Always subscribe to `OnPurchaseDeferred`.** This event fires for Ask-to-Buy (iOS parental approval) and Google Play deferred purchases. Not subscribing means deferred purchases are silently ignored.
+
+**Use `CheckEntitlement` for ownership checks, not manual bool flags.** When migrating `product.hasReceipt` or `product.receipt == null` ownership checks, the recommended v5 pattern is `store.CheckEntitlement(product)` + `store.OnCheckEntitlement`. This works cross-platform and handles edge cases (refunds, subscription expiration) automatically.
+
+**`StoreConnectionFailureDescription` has `.message`, NOT `.reason`.** When migrating `OnInitializeFailed(error, message)` to `store.OnStoreDisconnected`, the failure description property is `failureDescription.message` (lowercase), not `reason`.
+
+**`ProductFetchFailed` has `.FailureReason`, NOT `.Message`.** When handling `store.OnProductsFetchFailed`, access the reason via `failure.FailureReason`.
+
+**Subscribe to events BEFORE calling `Connect()`.** Pending purchases from a previous session may fire immediately on reconnect. If your `OnPurchasePending` handler is not yet registered, those purchases will be missed.
+
+**`OnPurchaseConfirmed` can receive `FailedOrder`.** The `OnPurchaseConfirmed` event fires with `Order` (base type). Always pattern-match: `ConfirmedOrder` means success, `FailedOrder` means confirmation failed. Do not assume confirmation always succeeds.
+
+**Use `Awake()` for initialization, not `Start()`.** The official v5 samples use `Awake()` for `StoreController` setup and event subscription. This ensures IAP is initialized before other `Start()` methods that may depend on it.
+
+## Minimal v5 Example
+
+```csharp
+StoreController m_StoreController;
+
+async void Awake()
+{
+    m_StoreController = UnityIAPServices.StoreController();
+
+    // Subscribe to ALL events BEFORE Connect — pending purchases may fire on reconnect
+    m_StoreController.OnPurchasePending += (order) =>
+    {
+        var product = order.CartOrdered.Items().FirstOrDefault()?.Product;
+        GrantContent(product);
+        m_StoreController.ConfirmPurchase(order);
+    };
+    m_StoreController.OnPurchaseConfirmed += (order) =>
+    {
+        switch (order)
+        {
+            case ConfirmedOrder: Debug.Log("Purchase confirmed"); break;
+            case FailedOrder failed: Debug.LogError($"Confirmation failed: {failed.FailureReason}"); break;
+        }
+    };
+    m_StoreController.OnPurchaseFailed += (failed) => Debug.LogError($"{failed.FailureReason} - {failed.Details}");
+    m_StoreController.OnPurchaseDeferred += (deferred) => Debug.Log("Purchase deferred (e.g., Ask-to-Buy)");
+
+    m_StoreController.OnStoreConnected += OnStoreConnected;
+    m_StoreController.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+    await m_StoreController.Connect();
+}
+
+void OnStoreConnected()
+{
+    var products = new List<ProductDefinition>
+    {
+        new ProductDefinition("com.mygame.coins100", ProductType.Consumable)
+    };
+
+    m_StoreController.OnProductsFetched += (fetched) => Debug.Log("Products ready");
+    m_StoreController.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+    m_StoreController.FetchProducts(products);
+
+    // Restore any pending/unfinished purchases from the platform store
+    m_StoreController.OnPurchasesFetched += (orders) => Debug.Log($"Restored {orders.PendingOrders.Count} pending purchases");
+    m_StoreController.OnPurchasesFetchFailed += (failure) => Debug.LogError($"Purchase fetch failed: {failure.Message}");
+    m_StoreController.FetchPurchases();
+}
+```

--- a/skills/implement-in-app-purchases/references/path-add-iap-to-new-project.md
+++ b/skills/implement-in-app-purchases/references/path-add-iap-to-new-project.md
@@ -1,0 +1,187 @@
+# Add Unity IAP 5 to a Project With No IAP
+
+## Table of Contents
+
+- [Step 1 — Project Scan](#step-1--project-scan)
+- [Step 2 — Product Discovery](#step-2--product-discovery)
+- [Step 3 — IAPManager Architecture](#step-3--iapmanager-architecture)
+- [Step 4 — Purchase Handling Contract](#step-4--purchase-handling-contract)
+- [Step 5 — Product Type Behavior Rules](#step-5--product-type-behavior-rules)
+- [Step 6 — Cloud Save Integration](#step-6--cloud-save-integration)
+- [Step 7 — UI Integration](#step-7--ui-integration)
+- [Step 8 — Verification Report](#step-8--verification-report)
+
+Use this reference when the project has no existing in-app purchase implementation and needs Unity IAP 5 added from scratch.
+
+## Step 1 — Project Scan
+
+### 1a — Code scan
+
+Search `Assets/**/*.cs` for any existing IAP signals:
+
+```
+ProductType|ProductDefinition|StoreController|IAPButton|CodelessIAP
+ProcessPurchase|PendingOrder|DeferredOrder|ConfirmPurchase|FetchPurchases
+IStoreListener|UnityPurchasing\.Initialize|ConfigurationBuilder
+```
+
+### 1c — Inventory and economy scan
+
+Search `Assets/**/*.cs` for terms that indicate what needs to be credited after purchase:
+
+```
+\bcoins\b|\bgems\b|\blives\b|\binventory\b|\bcurrency\b
+PlayerData|SaveAsync|CloudSave|SaveDataAsync|SaveGame
+Economy
+```
+
+### 1d — Shop UI scan
+
+Search `Assets/**/*.unity`, `*.prefab`, `*.asset` for shop-related GameObjects and scripts:
+```
+Shop|Store|Purchase|Buy|IAP|Product|Monetiz
+```
+
+Collect: scene names, prefab paths, button component names, and any serialized product ID strings.
+
+## Step 2 — Product Discovery
+
+### If product definitions are already found (from Step 1b/1c/1d)
+
+Use them. Confirm types with the user if ambiguous.
+
+### If no product definitions exist
+
+**Stop and ask:**
+
+> "Please provide the first IAP product ID and type — for example `com.mygame.coins100` as Consumable — and tell me which inventory field, currency, or item should be credited after purchase."
+
+- If the user provides only a product ID with no type, **default to Consumable** but state the assumption explicitly before proceeding.
+- Collect all products before writing any code. For each product record: `productId`, `ProductType`, reward target (field name / method name / amount).
+
+## Step 3 — IAPManager Architecture
+
+### Match the project's existing patterns
+
+Before generating code:
+- Check whether the project uses MonoBehaviour singletons, ScriptableObject services, or dependency injection.
+- Check the namespace convention used in `Assets/Scripts/`.
+- Prefer the pattern already in use rather than introducing a new one.
+
+### IAPManager responsibilities
+
+Create a single `IAPManager` (MonoBehaviour singleton or service, matching project pattern) that:
+
+- Holds the `StoreController` instance.
+- Exposes `Buy(string productId)`.
+- Exposes `RestorePurchases()` — **only** if the product list contains `NonConsumable` or `Subscription` types.
+- Fires UI-friendly events or callbacks for: `OnInitialized`, `OnProductsLoaded`, `OnPurchaseSuccess`, `OnPurchaseFailed`, `OnPurchaseDeferred`.
+- Initializes once in `Awake()` — see the **Initialization Flow** section in SKILL.md for the exact event subscription and `Connect()` ordering rules.
+- Registers all products from a single authoritative product list (not scattered across UI handlers).
+
+### Product catalog
+
+Define products in one place — a `ScriptableObject`, a plain `List<ProductDefinition>`, or a constants class — not inside button click handlers. Wire button click handlers to `IAPManager.Buy(productId)` using the catalog, not hardcoded strings.
+
+## Step 4 — Purchase Handling Contract
+
+For API mechanics (two-step flow, event names, `ConfirmPurchase` signature) see the **Two-Step Purchase Flow** and **Required Event Subscriptions** sections in SKILL.md. This section covers only the grant-and-save contract that is specific to this path.
+
+### PendingOrder — the save-before-confirm rule
+
+```
+OnPurchasePending fires
+  → grant reward to inventory / currency / entitlement
+  → save player data (see Cloud Save Integration below)
+  → ONLY IF save succeeds: call ConfirmPurchase(pendingOrder)
+  → IF save fails: do NOT confirm — store will re-deliver on next launch
+```
+
+Never call `ConfirmPurchase` before the save completes. An unconfirmed purchase is safe — it re-delivers. A confirmed purchase that was never saved is a lost reward.
+
+### Duplicate grant prevention
+
+`OnPurchasePending` may fire more than once for the same purchase (app restart before confirmation). Track processed order IDs (e.g., in Cloud Save or a local ledger) and skip grant if the order ID was already processed.
+
+### DeferredOrder
+
+Do not grant anything. Fire `OnPurchaseDeferred` event to update UI ("Purchase pending approval"). Wait for `OnPurchasePending` when the purchase is approved.
+
+### FailedOrder
+
+Do not grant anything. Fire `OnPurchaseFailed` with the reason. See **Failure Description Property Names** in SKILL.md for the correct property names per type.
+
+## Step 5 — Product Type Behavior Rules
+
+### Consumable
+
+- Credit inventory or currency after purchase.
+- Persist the credited state in save data before confirming.
+- **Do not restore** old consumable orders — confirmed consumables are not returned by `FetchPurchases` and must not be re-granted.
+- Track consumable grants yourself (order ID ledger in Cloud Save or local save).
+
+### NonConsumable
+
+- Unlock a durable entitlement (feature flag, item ownership).
+- Include `RestorePurchases()` — required on iOS, good practice on Android.
+- Re-apply the entitlement on app startup: call `store.FetchPurchases()` and re-check ownership in `OnPurchasesFetched`, or use `store.CheckEntitlement(product)`. See **Entitlement Checking** and **Fetch Existing Purchases** in SKILL.md.
+
+### Subscription
+
+- Restore or check subscription state on app startup, not only at purchase time. Subscriptions can expire or be cancelled externally.
+- Use `store.CheckEntitlement(product)` or inspect `OnPurchasesFetched` results to update active/expired/unknown state.
+- See **Subscription Info** in SKILL.md for the correct access path (`order.Info.PurchasedProductInfo`, `IsSubscribed() == Result.True`).
+
+## Step 6 — Cloud Save Integration
+
+### Detect the existing save system first
+
+Search for any of these patterns before writing save code:
+
+```
+\.SaveAsync\(\)|CloudSaveService\.Instance
+SaveGame\(|SaveDataAsync\(|PlayerPrefs\.SetInt|JsonUtility\.ToJson|JsonConvert\.Serialize
+```
+
+### Rules
+
+- **Use the existing save abstraction** — do not create a new save system.
+- Prefer methods already in use: `CloudSaveService.Instance.Data.Player.SaveAsync()`, `SaveGame()`, `SaveDataAsync()`, or equivalent.
+- If no save system exists, use `PlayerPrefs` as a minimal fallback and document it as a TODO for the developer to upgrade.
+- Save **must complete before `ConfirmPurchase`** is called (see Step 4).
+
+## Step 7 — UI Integration
+
+### Wiring
+
+- Wire existing shop buttons to `IAPManager.Buy(productId)` — do not embed product IDs in button click handlers directly.
+- Subscribe to `IAPManager` events in the shop UI script to drive state changes.
+
+### States to handle in UI
+
+| State | Trigger | UI action |
+|---|---|---|
+| Initializing | Before `OnInitialized` | Disable buy buttons or show spinner |
+| Products loaded | `OnProductsLoaded` | Display localized price from `product.metadata.localizedPriceString` |
+| Product unavailable | Product missing from `OnProductsFetched` result | Hide or grey out the button |
+| Purchase pending | `PurchaseProduct()` called | Disable button, show loading state |
+| Purchase deferred | `OnPurchaseDeferred` | Show "pending approval" message |
+| Purchase success | `OnPurchaseSuccess` | Show confirmation, update inventory display |
+| Purchase failed | `OnPurchaseFailed` | Show error message, re-enable button |
+
+### Restore button
+
+Add a "Restore Purchases" button **only** if the product list contains `NonConsumable` or `Subscription` products. Required on iOS. Wire to `IAPManager.RestorePurchases()`.
+
+## Step 8 — Verification Report
+
+After applying changes, produce a report with these sections:
+
+1. **Files changed** — list with nature of each change
+2. **Product IDs and types** — final catalog
+3. **Reward mapping** — product ID → field/method credited
+4. **Save behavior** — which save method is called, when
+5. **Restore behavior** — which products are restorable, how
+6. **Pending / deferred handling** — confirmation of save-before-confirm and deferred UI
+7. **Duplicate grant prevention** — how order IDs are tracked
+8. **Manual steps still required** — Unity Editor steps (Receipt Validation Obfuscator if using local Google Play validation), App Store Connect / Play Console product setup, sandbox testing accounts

--- a/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
+++ b/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
@@ -1,0 +1,356 @@
+# Convert Native Google Billing to Unity IAP 5
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Important Constraints](#important-constraints)
+- [Step 1 — Pre-Conversion Scan](#step-1--pre-conversion-scan)
+- [Step 2 — Product Classification](#step-2--product-classification)
+- [Step 3 — Migration Report (produce before any edits)](#step-3--migration-report-produce-before-any-edits)
+- [Step 4 — Blocker Detection](#step-4--blocker-detection)
+- [Step 5 — Target Architecture](#step-5--target-architecture)
+- [Step 6 — Migration Phases](#step-6--migration-phases)
+- [Step 7 — Behavior Change Rules](#step-7--behavior-change-rules)
+- [Step 8 — Native → Unity IAP Concept Mapping](#step-8--native--unity-iap-concept-mapping)
+- [Step 9 — Rollback Plan](#step-9--rollback-plan)
+- [Step 10 — Test Checklist](#step-10--test-checklist)
+- [Step 11 — Questions to Ask (only when required)](#step-11--questions-to-ask-only-when-required)
+
+Use this reference when the project uses C# → Java/Kotlin AndroidJavaObject calls to Google Play BillingClient and needs to be migrated to `com.unity.purchasing` 5.2+.
+
+## Trigger Phrases
+
+- "Convert native Google Billing to the latest Unity IAP"
+- "Migrate BillingClient integration to Unity IAP"
+- "Replace AndroidJavaObject Google billing bridge with Unity IAP"
+- "Upgrade custom Google Play Billing to the latest stable version of com.unity.purchasing"
+- "Remove native BillingClient and use Unity IAP"
+
+## Important Constraints
+
+- **Do not delete existing native billing files unless explicitly requested.** Always preserve with `#if !USE_UNITY_IAP_V5` guards.
+- **Create the new Unity IAP adapter first**, then mark the old native adapter as deprecated.
+- **Preserve public game-facing APIs** via a compatibility facade so gameplay code does not need large rewrites.
+- **Do not change product IDs.**
+- **Do not change backend validation endpoints** unless the receipt format change makes it unavoidable — document any backend change required.
+- **Do not grant purchases on the client** if the existing project uses server-side validation.
+- **Do not assume all products are consumables.** Detect and classify each product.
+- **Do not assume subscriptions are simple.** Detect base plans, offer tokens, pricing phases, and `SubscriptionOfferDetails`. If found, surface as a migration blocker and let the user choose a path (see Subscription Blocker Options below).
+- **If the project contains RevenueCat, Adapty, or Essential Kit**, stop and notify the user — this skill does not support converting those packages.
+- **If Google-specific features are not cleanly expressible in Unity IAP**, report them as migration blockers rather than silently removing them.
+
+## Step 1 — Pre-Conversion Scan
+
+Scan before making any changes. Do not edit files until the migration report is accepted.
+
+### 1a — Unity C# Bridge Patterns
+
+Search `Assets/**/*.cs`:
+
+```
+AndroidJavaObject|AndroidJavaClass|UnityPlayer\.currentActivity
+UnitySendMessage
+GoogleBilling|BillingManager|BillingClient|BillingBridge|AndroidBillingBridge|PlayBilling
+purchaseToken|originalJson|signature|productId|orderId
+\backnowledge\b|\bconsume\b
+restore.?purchases|query.?products|query.?purchases
+subscription.?status|receipt.?valid|entitlement.?grant
+```
+
+### 1c — Android Java/Kotlin Patterns
+
+Search `Assets/Plugins/Android/**/*.java`, `*.kt`:
+
+```
+com\.android\.billingclient\.api\.BillingClient
+PurchasesUpdatedListener|BillingClientStateListener
+ProductDetails|ProductDetails\.SubscriptionOfferDetails
+QueryProductDetailsParams|BillingFlowParams
+AcknowledgePurchaseParams|ConsumeParams|QueryPurchasesParams
+launchBillingFlow|acknowledgePurchase|consumeAsync
+queryProductDetailsAsync|queryPurchasesAsync|enablePendingPurchases
+offerToken|basePlanId|offerId|pricingPhases
+```
+
+### 1d — Gradle / Manifest Patterns
+
+Search `mainTemplate.gradle`, `launcherTemplate.gradle`, `baseProjectTemplate.gradle`, `AndroidManifest.xml`:
+
+```
+com\.android\.billingclient:billing
+com\.android\.billingclient:billing-ktx
+```
+
+Also list all `.jar`/`.aar` files under `Assets/Plugins/Android/` — these may contain pre-compiled billing code.
+
+### 1e — Scene / Prefab / Asset Scan
+
+Search `.unity`, `.prefab`, `.asset` files for references to billing-related MonoBehaviour names found in 1b.
+
+## Step 2 — Product Classification
+
+Classify every detected product into one of: **Consumable**, **NonConsumable**, **Subscription**, **Unknown**.
+
+Infer from (in priority order):
+1. `BillingClient.ProductType.INAPP` (consumable or non-consumable) / `BillingClient.ProductType.SUBS`
+2. `consumeAsync` calls → Consumable; `acknowledgePurchase` without consume → NonConsumable
+3. Product ID naming conventions (e.g., `coins`, `gems`, `pack` → Consumable; `remove_ads`, `unlock` → NonConsumable; `monthly`, `annual`, `sub` → Subscription)
+4. Entitlement / backend grant code
+5. Comments or config files
+
+If type cannot be confidently inferred, mark as **Unknown** and add to the blocker question list.
+
+## Step 3 — Migration Report (produce before any edits)
+
+Generate all 18 sections. Do not skip any.
+
+1. **Current native billing architecture** — describe the bridge pattern (C# wrapper → JNI → BillingClient)
+2. **Files using native Google Billing** — full list with role of each file
+3. **Product catalog discovered** — all product IDs found
+4. **Product type mapping** — inferred type + confidence + source of inference for each product
+5. **Purchase flow mapping** — native → Unity IAP step-by-step
+6. **Restore purchase flow mapping** — `queryPurchasesAsync` → `FetchPurchases` + `RestoreTransactions`
+7. **Backend validation mapping** — what data the old flow sent (`purchaseToken`, `originalJson`, `signature`, `packageName`) vs what Unity IAP provides (`order.Info.Receipt`, `order.Info.Apple?.jwsRepresentation`)
+8. **Consumable consume behavior mapping** — native `consumeAsync` → Unity IAP `ConfirmPurchase` (only after grant)
+9. **Non-consumable acknowledgement behavior mapping** — native `acknowledgePurchase` → Unity IAP `ConfirmPurchase` (only after grant)
+10. **Subscription behavior mapping** — detected subscription products, restore path, renewal handling
+11. **Google-specific features detected** — list each (see Blocker Detection below)
+12. **Unity IAP 5.2 migration blockers** — features that cannot be cleanly mapped
+13. **Proposed new Unity IAP architecture** — new files and their roles
+14. **Code files to create** — with paths
+15. **Code files to modify** — with nature of each change
+16. **Manual Play Console checks** — product IDs, base plan compatibility, billing permissions
+17. **Test plan** — from the checklist in this document
+18. **Rollback plan** — from the rollback plan section in this document
+
+## Step 4 — Blocker Detection
+
+Report these as migration blockers if detected. Do not silently remove them.
+
+| Feature | Detection Signal | Blocker Level |
+|---|---|---|
+| Multiple subscription base plans | `basePlanId` usage, multiple `SubscriptionOfferDetails` per product | **Hard** — ask user to choose option A/B/C (see below) |
+| Explicit offer token selection | `offerToken` set on `BillingFlowParams` | **Hard** |
+| Introductory offer selection by `offerId` | `offerId` in offer params | **Hard** |
+| Offer tags | `offerTags` access on `SubscriptionOfferDetails` | **Soft** — document loss |
+| Pricing phase inspection | `pricingPhases` / `PricingPhase` fields read | **Soft** — document loss |
+| Multi-quantity purchases | `quantity` > 1 in `BillingFlowParams` | **Hard** |
+| Alternative billing / external offers | `setExternalOfferToken` or alternative billing config | **Hard** |
+| Personalized price disclosure | `setIsPersonalizedPrice(true)` | **Hard** |
+| Obfuscated account / profile IDs | `setObfuscatedAccountId`, `setObfuscatedProfileId` | **Soft** — Unity IAP exposes `SetObfuscatedAccountId/ProfileId` post-`Connect()` on `GooglePlayStoreExtendedService` |
+| Custom `BillingFlowParams` fields | Any `BillingFlowParams.Builder` method not listed above | **Soft** — document loss |
+| Direct `ProductDetails` metadata | Reading `ProductDetails` fields not available on `Product.metadata` | **Soft** — document loss |
+
+### Subscription Blocker Options (present to user when hard subscription blockers found)
+
+**A mixed Unity IAP + native BillingClient architecture is not recommended and must not be offered as an option.** Both systems compete for the same `PurchasesUpdatedListener` slot on the device — only one receives purchase callbacks, the other silently drops purchases. This risks lost purchases, double grants, and unacknowledged tokens. If the user asks about a mixed approach, explain this risk and redirect to Option A or B.
+
+**Option A — Simplify Play Console setup for Unity IAP compatibility**
+Remove extra base plans/offers in Play Console so one product has one base plan. Unity IAP then handles all products including subscriptions. This is the recommended path — single system, no coexistence risk.
+
+**Option B — Stay on native Google Billing for all products**
+Do not migrate at this time. Keep the native BillingClient implementation as-is until the Play Console subscription configuration can be simplified or Unity IAP exposes the required subscription features. Stop the conversion and document the blocker and this decision in `IapMigrationNotes.md`.
+
+## Step 5 — Target Architecture
+
+Create under `Assets/Scripts/IAP/`:
+
+| File | Purpose |
+|---|---|
+| `IStorePurchaseService.cs` | Game-facing interface (stable public API) |
+| `UnityIapStorePurchaseService.cs` | Unity IAP 5.x implementation |
+| `ProductCatalogDefinition.cs` | ScriptableObject or plain class holding all `ProductDefinitionEntry` |
+| `ProductDefinitionEntry.cs` | Per-product data: ID, type, store-specific IDs |
+| `PurchaseEntitlementMapper.cs` | Maps Unity IAP order data → game grant calls |
+| `PurchaseValidationRequest.cs` | DTO sent to backend |
+| `PurchaseValidationResult.cs` | DTO received from backend |
+| `PurchaseRestoreResult.cs` | Result of restore operation |
+| `LegacyGoogleBillingAdapterDeprecated.cs` | Compatibility facade (only if game code calls old billing API) |
+| `IapMigrationNotes.md` | Human-readable notes on what changed, blockers found, manual steps |
+
+### Game-Facing Interface (preserve or adapt from existing API surface)
+
+```csharp
+public interface IStorePurchaseService
+{
+    Task InitializeAsync();
+    Task FetchProductsAsync();
+    IReadOnlyList<StoreProductInfo> GetProducts();
+    Task PurchaseAsync(string productId);
+    Task RestorePurchasesAsync();
+    bool IsInitialized { get; }
+}
+```
+
+## Step 6 — Migration Phases
+
+### Phase 1 — Package Check
+
+- Verify `com.unity.purchasing` exists in `Packages/manifest.json`.
+- Verify version is `5.2.x` or higher.
+- If missing or outdated, provide Package Manager instructions. Do not auto-edit `manifest.json` unless the user explicitly allows it.
+
+### Phase 2 — Product Catalog Extraction
+
+- Extract all product IDs and inferred types from the scan.
+- Generate `ProductCatalogDefinition.cs` / `ProductDefinitionEntry.cs`.
+- Each entry: `productId`, `ProductType`, optional `storeSpecificIds`, `notes`.
+
+### Phase 3 — New Unity IAP Service
+
+Create `UnityIapStorePurchaseService`:
+
+1. **Initialization** — `UnityIAPServices.StoreController()`, subscribe all events **before** `Connect()`.
+2. **Product fetching** — build `List<ProductDefinition>` from catalog, call `store.FetchProducts()`, handle `OnProductsFetched` / `OnProductsFetchFailed`.
+3. **Purchase initiation** — `store.PurchaseProduct(product)`.
+4. **Purchase callback** — `OnPurchasePending`: validate receipt → grant entitlement → `ConfirmPurchase(pendingOrder)`. **Never confirm before grant.**
+5. **Deferred purchases** — `OnPurchaseDeferred`: show pending UI, do not grant.
+6. **Failed purchases** — `OnPurchaseFailed`: map `FailureReason` to user-facing error.
+7. **Restore / fetch** — `store.FetchPurchases()` (re-delivers unconfirmed via `OnPurchasePending`) + `store.RestoreTransactions(callback)` for explicit iOS restore button.
+8. **Validation handoff** — send `order.Info.Receipt` (and `order.Info.Apple?.jwsRepresentation` on Apple) to backend in place of legacy `purchaseToken` + `originalJson` + `signature`. Document any backend change required.
+
+### Phase 4 — Compatibility Facade
+
+If game code calls the old billing API directly (e.g., `GoogleBillingManager.Purchase(id)`):
+
+- Create `LegacyGoogleBillingAdapterDeprecated.cs` that implements the same method signatures.
+- Delegate all calls to `UnityIapStorePurchaseService`.
+- Mark all methods `[Obsolete("Use IStorePurchaseService — remove after migration validation")]`.
+
+### Phase 5 — Remove Native Dependency from Active Path
+
+- Stop calling `AndroidJavaObject` bridge for migrated products.
+- Wrap native calls in `#if !USE_UNITY_IAP_V5` — do not delete them.
+- Leave Gradle billing dependencies unless user explicitly requests removal.
+
+### Phase 6 — Test Scaffolding
+
+- Add debug logs at each IAP event.
+- Add editor stubs for sandbox testing.
+- Add the QA checklist from the test plan below to `IapMigrationNotes.md`.
+
+## Step 7 — Behavior Change Rules
+
+### Acknowledgement and Consumption
+
+Native billing requires explicit `acknowledgePurchase` or `consumeAsync`. Unity IAP abstracts both through `ConfirmPurchase(pendingOrder)`. Map:
+
+| Native | Unity IAP |
+|---|---|
+| `consumeAsync` (consumable) | `ConfirmPurchase(pendingOrder)` after grant |
+| `acknowledgePurchase` (non-consumable / subscription) | `ConfirmPurchase(pendingOrder)` after grant |
+
+**Never call `ConfirmPurchase` before the entitlement is safely granted.**
+
+### Backend Validation
+
+| Native field sent | Unity IAP equivalent |
+|---|---|
+| `purchaseToken` | `order.Info.Receipt` (contains the Google receipt JSON) |
+| `originalJson` | Embedded in `order.Info.Receipt` |
+| `signature` | Embedded in `order.Info.Receipt` |
+| `packageName` | `Application.identifier` |
+| `productId` | `pendingOrder.CartOrdered.Items().First().Product.definition.id` |
+
+If the backend parses `purchaseToken` or `originalJson` fields directly, document the receipt format change as a required backend update.
+
+### Obfuscated IDs
+
+If native code sets `setObfuscatedAccountId` / `setObfuscatedProfileId` in `BillingFlowParams`, set the equivalent **after** `await store.Connect()`:
+
+```csharp
+store.GooglePlayStoreExtendedService?.SetObfuscatedAccountId("hashed_id");
+store.GooglePlayStoreExtendedService?.SetObfuscatedProfileId("hashed_profile_id");
+```
+
+Retrieve per-order:
+
+```csharp
+string accountId = store.GooglePlayStoreExtendedPurchaseService?.GetObfuscatedAccountId(order);
+```
+
+### Pending Purchases
+
+If native code handles `BillingClient.enablePendingPurchases()` or checks purchase state for `PENDING`:
+
+- Unity IAP surfaces deferred purchases via `store.OnPurchaseDeferred`.
+- On `OnPurchaseDeferred`: show "pending approval" UI. Do not grant.
+- When approved, the store re-delivers via `store.OnPurchasePending`.
+
+### Subscription Upgrade / Downgrade
+
+If native code calls `launchBillingFlow` with a `subscriptionUpdateParams` (prorating an existing subscription):
+
+```csharp
+store.GooglePlayStoreExtendedPurchaseService?.UpgradeDowngradeSubscription(
+    currentOrder,       // Order object of the current subscription
+    newProduct,         // Product to upgrade/downgrade to
+    GooglePlayReplacementMode.ChargeFullPrice  // choose appropriate mode
+);
+```
+
+See [platform-notes.md](platform-notes.md) for all `GooglePlayReplacementMode` values.
+
+## Step 8 — Native → Unity IAP Concept Mapping
+
+| Native Google Billing | Unity IAP 5.x |
+|---|---|
+| `ProductDetails` | `Product` (via `store.GetProductById`) |
+| `Purchase` | `PendingOrder` (on `OnPurchasePending`) |
+| `purchaseToken` | `order.Info.Receipt` (contains the token) |
+| `originalJson` | embedded in `order.Info.Receipt` |
+| `signature` | embedded in `order.Info.Receipt` |
+| `acknowledgePurchase` | `store.ConfirmPurchase(pendingOrder)` |
+| `consumeAsync` | `store.ConfirmPurchase(pendingOrder)` |
+| `queryPurchasesAsync` | `store.FetchPurchases()` → `OnPurchasesFetched` |
+| `BillingResult` / `BillingResponseCode` | `FailedOrder.FailureReason` / `StoreConnectionFailureDescription` |
+| `ProductType.INAPP` | `ProductType.Consumable` or `ProductType.NonConsumable` (distinguish by consume behavior) |
+| `ProductType.SUBS` | `ProductType.Subscription` |
+| `offerToken` / `basePlanId` / `pricingPhases` | **Not directly exposed** — report as blocker |
+
+## Step 9 — Rollback Plan
+
+- Wrap all new IAP code in `#if USE_UNITY_IAP_V5`.
+- Wrap all replaced native bridge calls in `#if !USE_UNITY_IAP_V5`.
+- Add a runtime feature flag `UseUnityIap5` (bool in `ProjectSettings` or a scriptable config) so an emergency build can disable Unity IAP without rebuilding.
+- Never activate both purchase systems for the same product simultaneously.
+- Document the flag location in `IapMigrationNotes.md`.
+
+## Step 10 — Test Checklist
+
+Include this in `IapMigrationNotes.md` after migration:
+
+- [ ] Fresh install — products load and display prices
+- [ ] Upgrade from old app version to migrated version — no duplicate entitlements
+- [ ] Consumable purchase — content granted
+- [ ] Repeat consumable purchase — repeatable, no block
+- [ ] Non-consumable purchase — content granted once
+- [ ] Non-consumable restore — content restored on reinstall
+- [ ] Subscription purchase — subscription active
+- [ ] Subscription restore — status refreshed on launch
+- [ ] Pending purchase (if applicable) — deferred UI shown, no premature grant
+- [ ] Interrupted purchase flow — re-delivered on next launch via `OnPurchasePending`
+- [ ] Backend validation success — entitlement granted
+- [ ] Backend validation failure — entitlement NOT granted, purchase not confirmed
+- [ ] Network failure during validation — purchase left pending, re-delivered on next launch
+- [ ] App killed during purchase — pending order re-delivered on next launch
+- [ ] App resumed after Google purchase UI — `OnPurchasePending` fires correctly
+- [ ] Sandbox tester account — no real charges
+- [ ] Internal testing track build
+- [ ] Play Console product ID match — all IDs match exactly
+- [ ] Play Console base plan compatibility — no advanced offer config that Unity IAP cannot reach
+- [ ] No duplicate entitlement grant
+- [ ] No unacknowledged purchases remaining
+- [ ] No double consumption of consumables
+
+## Step 11 — Questions to Ask (only when required)
+
+Ask only when the information cannot be inferred:
+
+1. Which product IDs are consumable, non-consumable, or subscription?
+2. Does the backend currently validate Google purchase tokens directly (raw `purchaseToken` field)?
+3. Are any subscriptions using multiple base plans or offer tokens?
+4. Should the skill preserve the old public C# billing API as a compatibility facade?
+5. Should native billing files be kept, disabled, or removed?
+
+If enough information can be inferred, proceed with a best-effort plan and mark uncertain items as **TODO**.

--- a/skills/implement-in-app-purchases/references/path-implement-iap-plus.md
+++ b/skills/implement-in-app-purchases/references/path-implement-iap-plus.md
@@ -1,0 +1,293 @@
+# Implement Unity IAP Plus (Third-Party Payment Provider)
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Prerequisites (verify before any changes)](#prerequisites-verify-before-any-changes)
+- [Step 1 — Project Scan](#step-1--project-scan)
+- [Step 2 — Product Discovery](#step-2--product-discovery)
+- [Step 3 — IAPManager with PaymentProvider](#step-3--iapmanager-with-paymentprovider)
+- [Step 4 — Remote Catalog](#step-4--remote-catalog)
+- [Step 5 — Deep Link Setup](#step-5--deep-link-setup)
+- [Step 6 — Purchase Handling](#step-6--purchase-handling)
+- [Step 7 — Product Type Behavior](#step-7--product-type-behavior)
+- [Step 8 — Cloud Save Integration](#step-8--cloud-save-integration)
+- [Step 9 — Verification Report](#step-9--verification-report)
+- [Step 10 — Manual Steps (always include in report)](#step-10--manual-steps-always-include-in-report)
+
+Use this reference when the user explicitly asks to add IAP Plus (third-party payment provider such as Stripe or Coda) to a project. This path is valid only when the project has no IAP, or already has `com.unity.purchasing` v5.x installed.
+
+**Not valid when:** the project has IAP v4, native Google Billing, or a third-party IAP package — resolve those first via `pre-check.md` before returning to this path.
+
+## Trigger Phrases
+
+- "Add IAP Plus"
+- "Integrate Stripe / Coda payments"
+- "Add third-party payment provider"
+- "Set up web-based IAP checkout"
+- "Add Unity payment provider"
+
+## Prerequisites (verify before any changes)
+
+| Requirement | Detail |
+|---|---|
+| `com.unity.purchasing` | **v5.4+** |
+| Unity Authentication package | Required — IAP Plus depends on a signed-in player |
+| Unity Gaming Services initialized | `UnityServices.InitializeAsync()` and sign-in must complete **before** IAP Plus initialization |
+| Unity Cloud project linked | Project must be connected to a Unity Cloud organization |
+| Payment provider account | Developer must have a Stripe or Coda account connected in the Unity Cloud IAP dashboard |
+| Unity Cloud IAP dashboard setup | Products must be created and deployed to the Remote Catalog in Unity Cloud before the client can fetch them |
+
+If any prerequisite is missing, stop and list the missing items for the user before writing any code.
+
+## Step 1 — Project Scan
+
+Search the project for existing IAP and economy signals before writing any code.
+
+### 1a — Existing IAP detection
+
+Search `Packages/manifest.json` for `com.unity.purchasing`:
+- If **v5.4+** found → proceed, IAP Plus will be added alongside.
+- If **v5.0–5.3** found → inform the user that v5.4+ is required, instruct them to upgrade `com.unity.purchasing` to v5.4+ via Package Manager, and continue once the upgrade is confirmed.
+- If **absent** → proceed, IAP Plus will be added fresh.
+
+### 1b — Unity Authentication detection
+
+Search `Packages/manifest.json` for `com.unity.services.authentication`. If absent, inform the user it must be installed — IAP Plus will not initialize without a signed-in player.
+
+### 1c — Inventory and economy scan
+
+Search `Assets/**/*.cs` for:
+```
+\bcoins\b|\bgems\b|\blives\b|\binventory\b|\bcurrency\b
+PlayerData|SaveAsync|CloudSave|SaveDataAsync|SaveGame
+```
+
+### 1d — Shop UI scan
+
+Search `Assets/**/*.unity`, `*.prefab` for shop-related GameObjects and scripts:
+```
+Shop|Store|Purchase|Buy|IAP|Product
+```
+
+## Step 2 — Product Discovery
+
+### If existing `.ucat` files are found
+
+Locate `Assets/**/*.ucat` files. Each file is a JSON product definition (see format below). Use them as-is.
+
+### If existing IAP 5 `ProductDefinition` objects are found
+
+These are local store products — IAP Plus uses a Remote Catalog instead. Inform the user that existing local product definitions need to be re-created as `.ucat` files deployed to Unity Cloud, and that product IDs (`uSKU`) should match the existing IDs to preserve store history.
+
+### If no product definitions exist
+
+**Stop and ask:**
+
+> "Please provide the first IAP product ID and type — for example `com.mygame.coins100` as Consumable — and tell me which inventory field, currency, or item should be credited after purchase."
+
+- Default to Consumable if type is not provided, but state the assumption explicitly.
+- **Subscriptions are not supported** by IAP Plus in v5.4+. If the user requests a subscription product, inform them and stop.
+
+### Product definition format (`.ucat`)
+
+IAP Plus products are defined as JSON files with the `.ucat` extension, uploaded to Unity Cloud — not defined in code. Each file defines one product:
+
+```json
+{
+  "uSKU": "com.mygame.coins100",
+  "type": "Consumable",
+  "productDetails": [
+    {
+      "title": "100 Coins",
+      "description": "A pack of 100 coins.",
+      "language": "en-US"
+    }
+  ],
+  "pricing": [
+    {
+      "currencyCode": "USD",
+      "amount": 1.99
+    }
+  ],
+  "imageUrl": "https://example.com/img/coins100.png"
+}
+```
+
+| Field | Notes |
+|---|---|
+| `uSKU` | Product ID — equivalent to `ProductDefinition.id` in standard IAP. Do not change existing IDs. |
+| `type` | `"Consumable"` or `"Non-consumable"`. Subscriptions not supported. |
+| `productDetails` | Array of localised title/description. Include at minimum `en-US`. |
+| `pricing` | Array of currency/amount pairs. At minimum include the base currency. |
+| `imageUrl` | URL to product image. Optional but recommended for shop UI. |
+
+Remind the user that `.ucat` files must be **deployed to the Remote Catalog** via Unity Cloud dashboard or the Deployment package before the client can fetch them.
+
+## Step 3 — IAPManager with PaymentProvider
+
+### Key difference from standard IAP 5
+
+IAP Plus uses a `PaymentProvider.Name` parameter when obtaining the `StoreController`:
+
+```csharp
+// Standard IAP 5
+_storeController = UnityIAPServices.StoreController();
+
+// IAP Plus — pass the payment provider name
+_storeController = UnityIAPServices.StoreController(PaymentProvider.Name);
+```
+
+`PaymentProvider.Name` is a constant that identifies the third-party provider integration. It does **not** return the display name of the provider (Stripe/Coda).
+
+### Initialization sequence
+
+IAP Plus requires Unity Gaming Services and player sign-in to complete **before** `StoreController` is obtained. Follow this order:
+
+1. `await UnityServices.InitializeAsync()`
+2. Sign the player in via Unity Authentication
+3. Only after sign-in succeeds: obtain `StoreController(PaymentProvider.Name)` and call `Connect()`
+
+Do not call `StoreController(PaymentProvider.Name)` before the player is authenticated.
+
+### Coexistence with existing Apple / Google StoreController
+
+If the project already has a `StoreController` for Apple App Store or Google Play (standard IAP 5):
+
+- **Always create a new, separate `StoreController`** scoped to `PaymentProvider.Name`. Never modify or replace the existing one.
+- The two controllers are independent — they manage different products on different billing backends and do not interfere with each other.
+- After the new IAP Plus `StoreController` is successfully created and connected, **prompt the user:**
+
+  > "An existing Apple/Google StoreController was found. Would you like to:
+  > - **Keep both** — run Apple/Google billing and IAP Plus side by side (existing products stay on Apple/Google, new products use IAP Plus)
+  > - **Remove the Apple/Google StoreController** — migrate fully to IAP Plus (note: existing Apple/Google products and purchase history will no longer be managed by the app)"
+
+- If the user chooses **keep both**: leave the existing `StoreController` and its initialization code untouched. Document the dual-controller setup in code comments.
+- If the user chooses **remove**: wrap the existing `StoreController` code in `#if !USE_IAP_PLUS_ONLY` guards — do not delete it. Mark it `[Obsolete]` and document the removal decision. Instruct the user to also retire the corresponding products in App Store Connect / Play Console as needed.
+
+### IAPManager responsibilities
+
+Same as standard IAP 5 (see `path-add-iap-to-new-project.md` Step 3), with these additions:
+- Hold the `PaymentProvider.Name`-scoped `StoreController` instance.
+- Expose `Buy(string productId)` — delegates to `_storeController.PurchaseProduct(productId)`.
+- Expose `RestorePurchases()` only if NonConsumable products exist.
+- Ensure the player is authenticated before `InitializeAsync()` is called.
+- **Only automatic entitlement delivery is supported.** Do not implement server-authoritative grant logic in this path unless the user explicitly requests it.
+
+## Step 4 — Remote Catalog
+
+IAP Plus products come from Unity Cloud, not a local `List<ProductDefinition>`. Use `RemoteCatalogProvider` to fetch them:
+
+```csharp
+// 1. Create the provider
+var catalogProvider = new RemoteCatalogProvider();
+
+// 2. Fetch catalog for the payment provider
+var result = await catalogProvider.FetchRemoteCatalog(new List<string>
+{
+    PaymentProvider.Name
+});
+
+if (!result.Success)
+    throw result.Exception;
+
+// 3. Pass fetched definitions to the StoreController
+var productDefinitions = catalogProvider.GetProducts();
+_storeController.FetchProducts(productDefinitions);
+```
+
+- `FetchRemoteCatalog` fetches the catalog deployed to the Unity Cloud environment configured in **Edit > Project Settings > Services > Environments** (Development / Staging / Production).
+- Call `FetchRemoteCatalog` after `Connect()` succeeds.
+- `catalogProvider.GetProducts()` returns `IEnumerable<ProductDefinition>` — pass directly to `store.FetchProducts()`.
+- If `result.Success` is false, do not proceed — surface the error to the user.
+
+## Step 5 — Deep Link Setup
+
+IAP Plus launches the device's mobile browser to handle payment. After payment, the browser must redirect back to the game via a deep link.
+
+### Choosing a deep link scheme
+
+**Use app-scheme deep links** (e.g., `mygame://iapresult/okay`) rather than URL-scheme deep links (e.g., `https://mygame.com/iapresult`).
+
+URL-scheme deep links require the domain to be verified by Google (Digital Asset Links). App-scheme deep links avoid this requirement and are simpler to configure.
+
+**Prompt the user:**
+
+> "What redirect URL did you configure in the Unity Cloud IAP payment provider dashboard? For example: `mygame://iapresult/okay`. If you haven't set one yet, set it in the dashboard first before continuing."
+
+### AndroidManifest.xml
+
+The deep link scheme must be declared in `AndroidManifest.xml` so Android routes the browser redirect back to the app. If the project does not have a custom `AndroidManifest.xml`, instruct the user to enable it: **Edit > Project Settings > Player > Publishing Settings > Custom Main Manifest**.
+
+Add an intent filter for the deep link scheme inside the `<activity>` element:
+
+```xml
+<intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="mygame" android:host="iapresult" />
+</intent-filter>
+```
+
+Replace `mygame` and `iapresult` with the scheme and host from the user's configured redirect URL.
+
+### Unity Editor
+
+In the Unity Editor, the purchase callback is received directly without a browser redirect — no additional setup is required for Editor testing.
+
+### Google Play external link validation (dev/QA only)
+
+If testing on Android and running into external link validation issues, the following scripting define can be added for dev/QA builds only:
+
+```
+IAP_SKIP_EXTERNAL_LINK_VALIDATION
+```
+
+**Location:** Edit > Project Settings > Player > Scripting Define Symbols
+
+**WARNING:** Do not include this define in production builds — it violates Google Play policies.
+
+## Step 6 — Purchase Handling
+
+Purchase handling follows the same save-before-confirm contract as standard IAP 5. See **Step 4 — Purchase Handling Contract** in `path-add-iap-to-new-project.md` for the full rules.
+
+IAP Plus-specific notes:
+- The payment flow happens in the device's browser. The game is suspended during payment and resumes via the deep link redirect. `OnPurchasePending` fires after the deep link returns control to the game.
+- `OnPurchaseDeferred` fires if the payment is not immediately completed. Do not grant — show pending UI.
+- Always confirm (`ConfirmPurchase`) only after entitlement is granted and saved. For consumables, Unity IAP Plus prevents re-purchase until the previous order is confirmed.
+
+## Step 7 — Product Type Behavior
+
+Same rules as standard IAP 5 (see `path-add-iap-to-new-project.md` Step 5), with one restriction:
+
+**Subscriptions are not supported by IAP Plus in v5.4+.** If subscription products are detected or requested, inform the user and exclude them from the IAP Plus implementation. Document them as a TODO for when subscription support is added.
+
+## Step 8 — Cloud Save Integration
+
+Same rules as standard IAP 5 — see `path-add-iap-to-new-project.md` Step 6. Save must complete before `ConfirmPurchase` is called.
+
+## Step 9 — Verification Report
+
+After applying changes, produce a report with these sections:
+
+1. **Files changed** — list with nature of each change
+2. **Product IDs, types, and `.ucat` files** — catalog summary
+3. **Reward mapping** — product ID → field/method credited
+4. **Deep link scheme configured** — scheme, host, AndroidManifest entry
+5. **Save behavior** — which save method is called, when
+6. **Restore behavior** — which products are restorable, how
+7. **Pending / deferred handling** — confirmation of save-before-confirm and deferred UI
+8. **Manual steps still required** — listed below
+
+## Step 10 — Manual Steps (always include in report)
+
+These cannot be automated and must be completed by the developer:
+
+1. **Unity Cloud IAP dashboard** — create products matching the `.ucat` definitions and deploy to the Remote Catalog.
+2. **Payment provider account** — connect Stripe or Coda account in Unity Cloud IAP dashboard. Request enablement from Unity Client Partner with your organization ID if not yet enabled.
+3. **Redirect URL** — set the deep link redirect URL in the payment provider dashboard (e.g., `mygame://iapresult/okay`).
+4. **Environment selection** — confirm the correct environment (Development / Staging / Production) is set in **Edit > Project Settings > Services > Environments**.
+5. **Android deep link verification** — if using URL-scheme deep links, complete Google Digital Asset Links domain verification. (Avoided if using app-scheme deep links.)
+6. **Platform compliance review** — external web payments and third-party payment providers are permitted in select regions only. Developer is responsible for adhering to Apple App Store and Google Play regional requirements.
+7. **Prohibited business / content review** — review Stripe's Prohibited/Restricted Businesses list and Coda's Prohibited Content Policy for compliance.

--- a/skills/implement-in-app-purchases/references/platform-notes.md
+++ b/skills/implement-in-app-purchases/references/platform-notes.md
@@ -1,0 +1,204 @@
+# Unity IAP Platform-Specific Notes
+
+## Table of Contents
+
+- [Apple App Store Extensions](#apple-app-store-extensions)
+- [Google Play Store Extensions](#google-play-store-extensions)
+- [Apple JWS Representation (Server-Side Validation)](#apple-jws-representation-server-side-validation)
+- [SubscriptionInfo Platform Nuances](#subscriptioninfo-platform-nuances)
+- [Cross-Platform Best Practices](#cross-platform-best-practices)
+- [Platform Extension Availability](#platform-extension-availability)
+
+## Apple App Store Extensions
+
+Access via `store.AppleStoreExtendedPurchaseService` (for purchase features) and `store.AppleStoreExtendedService` (for store features).
+
+### Promotional Purchases
+
+Apple can present purchases from the App Store product page. Intercept and handle them:
+
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+{
+    store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += (product) =>
+    {
+        // Player tapped "Buy" on App Store product page
+        // You can delay the purchase (e.g., show a loading screen first)
+        Debug.Log($"Promotional purchase intercepted: {product.definition.id}");
+
+        // When ready, continue the purchase
+        store.AppleStoreExtendedPurchaseService.ContinuePromotionalPurchases();
+    };
+}
+```
+
+**CRITICAL:** If you subscribe to `OnPromotionalPurchaseIntercepted`, you MUST eventually call `ContinuePromotionalPurchases()` or the purchase will hang indefinitely.
+
+### Ask-to-Buy (Parental Approval)
+
+On devices with Family Sharing and a child account, purchases may require parental approval:
+
+```csharp
+store.OnPurchaseDeferred += (deferredOrder) =>
+{
+    // Purchase is waiting for parental approval
+    // Show UI: "Purchase pending approval"
+    // Do NOT grant content yet
+    Debug.Log("Purchase deferred - awaiting approval");
+};
+```
+
+The purchase will complete later (triggering `OnPurchasePending`) when approved, or fail when rejected.
+
+For testing in sandbox:
+
+```csharp
+// Simulate Ask-to-Buy in the editor/sandbox
+store.AppleStoreExtendedPurchaseService.simulateAskToBuy = true;
+```
+
+### Offer Code Redemption
+
+Present the Apple offer code redemption sheet:
+
+```csharp
+store.AppleStoreExtendedPurchaseService.PresentCodeRedemptionSheet();
+```
+
+### Entitlement Revocation
+
+Listen for revoked entitlements (e.g., refund granted):
+
+```csharp
+store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += (productId) =>
+{
+    Debug.Log($"Entitlement revoked for: {productId}");
+    // Remove the content/feature from the player
+};
+```
+
+### Store Capabilities
+
+```csharp
+// Check if the device can make payments (parental controls may block)
+bool canPay = store.AppleStoreExtendedService.canMakePayments;
+
+// Set App Account Token for server-to-server verification
+store.AppleStoreExtendedService.SetAppAccountToken(Guid.NewGuid());
+
+// Fetch storefront info (StoreKit 2 only)
+store.AppleStoreExtendedService.FetchStorefront(
+    (storefront) => Debug.Log($"Storefront: {storefront.CountryCode}"),
+    (error) => Debug.LogError($"Storefront error: {error}")
+);
+```
+
+## Google Play Store Extensions
+
+Access via `store.GooglePlayStoreExtendedPurchaseService` (for purchase features) and `store.GooglePlayStoreExtendedService` (for store features).
+
+### Subscription Upgrade/Downgrade
+
+Change a player's subscription tier:
+
+```csharp
+// Get the current subscription order and the new product
+Order currentOrder = /* the player's current subscription order */;
+Product newProduct = store.GetProductById("com.mygame.vip_annual");
+
+store.GooglePlayStoreExtendedPurchaseService.UpgradeDowngradeSubscription(
+    currentOrder,
+    newProduct,
+    GooglePlayReplacementMode.ChargeFullPrice
+);
+```
+
+### GooglePlayReplacementMode Values
+
+| Mode | Behavior |
+|---|---|
+| `UnknownReplacementMode` | Default |
+| `WithTimeProration` | Remaining time is adjusted |
+| `ChargeProratedPrice` | Prorated charge for the upgrade |
+| `WithoutProration` | New plan starts at next billing |
+| `ChargeFullPrice` | Full price charged immediately |
+| `Deferred` | Change takes effect at next billing |
+
+### Obfuscated IDs
+
+Set obfuscated account/profile IDs for fraud detection:
+
+```csharp
+store.GooglePlayStoreExtendedService.SetObfuscatedAccountId("hashed_account_id");
+store.GooglePlayStoreExtendedService.SetObfuscatedProfileId("hashed_profile_id");
+```
+
+Retrieve them from an order:
+
+```csharp
+string accountId = store.GooglePlayStoreExtendedPurchaseService.GetObfuscatedAccountId(order);
+string profileId = store.GooglePlayStoreExtendedPurchaseService.GetObfuscatedProfileId(order);
+```
+
+### Deferred Payment Events
+
+```csharp
+store.GooglePlayStoreExtendedPurchaseService.OnDeferredPaymentUntilRenewalDate += (deferredOrder) =>
+{
+    Debug.Log($"Payment deferred until renewal: {deferredOrder.SubscriptionOrdered.definition.id}");
+};
+```
+
+## Apple JWS Representation (Server-Side Validation)
+
+For server-side Apple receipt validation (replacing the deprecated `CrossPlatformValidator`):
+
+```csharp
+store.OnPurchasePending += (pendingOrder) =>
+{
+    // Access the JWS-signed transaction
+    string jws = pendingOrder.Info.Apple?.jwsRepresentation;
+    // Send to your server for validation with Apple's App Store Server API (v2)
+    ValidateOnServer(jws);
+};
+```
+
+The `jwsRepresentation` contains a signed JSON Web Signature that can be verified using Apple's public keys.
+
+## SubscriptionInfo Platform Nuances
+
+| Method | Apple | Google |
+|---|---|---|
+| `GetPurchaseDate()` | Returns the **renewal date** (most recent renewal) | Returns the **original purchase date** |
+| `GetCancelDate()` | Returns actual cancellation date | Returns `DateTime.MinValue` (not supported) |
+
+Always check `IsSubscribed()` first — if the result is `Result.Unsupported`, the platform doesn't provide that information.
+
+## Cross-Platform Best Practices
+
+| Concern | Recommendation |
+|---|---|
+| Restore button | Required on iOS (Apple guideline). Add a "Restore Purchases" button that calls `store.RestoreTransactions()`. |
+| Receipt validation | Use `CrossPlatformValidator` for local validation. For production, also validate server-side. |
+| Pending purchases | Always handle `OnPurchasePending` and call `ConfirmPurchase`. Unconfirmed purchases persist across launches. |
+| Product IDs | Use reverse-domain naming: `com.company.game.product` |
+| Testing | Use sandbox accounts (Apple) and license testing accounts (Google) for testing without real charges. |
+| Subscriptions | Always check `IsSubscribed()` at app launch, not just purchase time. Subscriptions can expire or be cancelled externally. |
+
+## Platform Extension Availability
+
+| Extension | iOS | Android | Editor |
+|---|---|---|---|
+| `AppleStoreExtendedService` | Available | `null` | `null` |
+| `AppleStoreExtendedPurchaseService` | Available | `null` | `null` |
+| `GooglePlayStoreExtendedService` | `null` | Available | `null` |
+| `GooglePlayStoreExtendedPurchaseService` | `null` | Available | `null` |
+
+**CRITICAL:** Always null-check platform extensions before use:
+
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+{
+    store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += HandlePromo;
+}
+```

--- a/skills/implement-in-app-purchases/references/pre-check.md
+++ b/skills/implement-in-app-purchases/references/pre-check.md
@@ -1,0 +1,127 @@
+# Pre-Check: Project Scan and Path Routing
+
+## Table of Contents
+
+- [Ambiguous Intent](#ambiguous-intent)
+- [IAP Plus (Third-Party Payment Provider)](#iap-plus-third-party-payment-provider)
+- [Scan Order (standard IAP paths)](#scan-order-standard-iap-paths)
+- [Routing Summary](#routing-summary)
+
+Run this scan before doing anything else. Do not read any other reference file or make any changes until routing is resolved.
+
+## Ambiguous Intent
+
+If the user's prompt does not clearly indicate which billing backend they want — for example:
+
+- "Add a StoreController for me"
+- "Add a purchase manager"
+- "Set up IAP"
+- "Help me add in-app purchases"
+
+**Stop and ask before scanning or routing:**
+
+> "Would you like to implement purchasing using:
+> - **Apple App Store / Google Play** (standard platform billing), or
+> - **IAP Plus** (third-party payment provider such as Stripe or Coda via Unity Cloud)?"
+
+Do not assume a default. Route only after the user confirms their intent.
+
+---
+
+## IAP Plus (Third-Party Payment Provider)
+
+If the user explicitly asks for IAP Plus, Stripe/Coda payment integration, or a third-party payment provider, **do not follow the standard scan order below**. Instead:
+
+- If the project has IAP v4, native Google Billing, or a third-party IAP package → resolve those blockers first using the standard scan order, then return here.
+- If the project has no IAP, or has `com.unity.purchasing` **v5.4+** → route to [references/path-implement-iap-plus.md](path-implement-iap-plus.md).
+- If the project has `com.unity.purchasing` **v5.0–5.3** → inform the user that IAP Plus requires v5.4+, instruct them to upgrade via Package Manager, and continue once the upgrade is confirmed.
+
+---
+
+## Scan Order (standard IAP paths)
+
+Run scans in this exact order. The first match wins — stop scanning and route immediately.
+
+---
+
+### 1 — Third-Party IAP Package Check (highest priority)
+
+Search `Packages/manifest.json` and `Packages/packages-lock.json` for:
+
+```
+com\.revenuecat|com\.adapty|com\.voxelbusters\.essentialkit|com\.unipay
+```
+
+**If found → Stop.**
+
+Inform the user:
+
+> "This project uses [package name], which is a third-party IAP package. This skill only supports Unity IAP 5 (`com.unity.purchasing`). Migrating from third-party IAP packages is not supported. No changes will be made."
+
+Do not proceed with any other path.
+
+---
+
+### 2 — Native Google Billing Check
+
+Search the following locations:
+
+- `Assets/**/*.cs` for: `AndroidJavaObject|AndroidJavaClass|BillingClient|BillingManager|GoogleBilling|BillingBridge`
+- `Assets/Plugins/Android/**/*.java`, `*.kt` for: `com\.android\.billingclient`
+- `mainTemplate.gradle`, `launcherTemplate.gradle`, `baseProjectTemplate.gradle` for: `com\.android\.billingclient:billing`
+
+**If found → only one path is valid:**
+
+> Route to [references/path-convert-native-google-billing.md](path-convert-native-google-billing.md)
+
+Inform the user that native Google Billing was detected and that the conversion path will be used. Do not offer any other path.
+
+---
+
+### 3 — Unity IAP v4 Check
+
+Search `Packages/manifest.json` for `com.unity.purchasing` with a version matching `4\.`.
+
+Also search `Assets/**/*.cs` for legacy v4 API patterns:
+
+```
+IStoreListener|UnityPurchasing\.Initialize|ConfigurationBuilder
+```
+
+**If found → only one path is valid:**
+
+> Route to [references/migration-v4-to-v5.md](migration-v4-to-v5.md)
+
+Inform the user that Unity IAP v4 was detected and that the v4→v5 migration path will be used. Do not offer any other path.
+
+---
+
+### 4 — No IAP Detected
+
+If none of the above matched:
+
+Search `Packages/manifest.json` for `com.unity.purchasing`. If absent or if no IAP signals were found in any scan:
+
+**→ only one path is valid:**
+
+> Route to [references/path-add-iap-to-new-project.md](path-add-iap-to-new-project.md)
+
+---
+
+## Routing Summary
+
+| What is detected | Valid path |
+|---|---|
+| RevenueCat / Adapty / Essential Kit / UniPay | **Stop — unsupported** |
+| Native Google BillingClient | Convert native Google Billing → IAP 5 |
+| `com.unity.purchasing` v4 or v4 API patterns | Migrate IAP v4 → v5 |
+| No IAP detected | Add Unity IAP 5 to new project |
+| User explicitly requests IAP Plus / payment provider | See IAP Plus section above |
+
+---
+
+## Also check: Codeless catalog presence
+
+Regardless of which route above wins, check whether `Assets/Resources/IAPProductCatalog.json` exists. This is the **Codeless IAP** catalog and is independent of the routing decision — but if it is present and `enableCodelessAutoInitialization` is true, adding a scripted `StoreController` creates a race condition with `CodelessIAPStoreListener`.
+
+Surface the catalog's presence and auto-init flag to the user before generating scripted IAP code. See [codeless-catalog.md](codeless-catalog.md) for the race condition details and the three mitigation options.


### PR DESCRIPTION
Covers Unity IAP v5 (com.unity.purchasing) end-to-end: store connection, catalog, two-step purchase flow, receipt validation, entitlements, restore, and Apple/Google platform extensions.