### PR TITLE
chore: add CODEOWNERS for Unity Hub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The Unity Hub team owns this repository.
+# See https://docs.github.com/articles/about-code-owners
+*    @Unity-Technologies/hub


### PR DESCRIPTION
## What

Adds a `.github/CODEOWNERS` file making the **Unity Hub team** (`@Unity-Technologies/hub`) the code owner for the entire repository.

```
*    @Unity-Technologies/hub
```

## Why

`main` already has branch protection with **require code owner reviews** enabled, but there was no `CODEOWNERS` file, so no owners were actually defined. This wires the Unity Hub team in as the owning team so future PRs automatically request their review.

## Notes

- The `hub` team already has admin access to this repo, so the owner reference resolves correctly.
- `.github/CODEOWNERS` is GitHub's recommended location and matches the convention used in the `unity-hub` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)