### PR TITLE
Add implement-in-app-purchases skill (IAP 5.4)

### DIFF
--- a/skills/implement-in-app-purchases/README.md
+++ b/skills/implement-in-app-purchases/README.md
@@ -1,0 +1,233 @@
+# Unity In-App Purchases Skill
+
+This skill helps you implement, configure, debug, and migrate Unity In-App Purchases (IAP) using `com.unity.purchasing` v5. It covers standard Apple App Store / Google Play billing, IAP D2C Capabilities (Direct-to-Customer — Stripe/Coda via Unity Cloud), and conversion from a wide range of third-party and native billing implementations.
+
+---
+
+## What This Skill Covers
+
+| Path | When to use |
+|---|---|
+| **Add IAP to a new project** | No existing IAP — start from scratch with Unity IAP 5 |
+| **Migrate v4 → v5** | Project uses `IStoreListener`, `UnityPurchasing.Initialize`, or `ConfigurationBuilder` |
+| **Convert native Google BillingClient** | Project calls Android BillingClient via `AndroidJavaObject` / JNI bridge |
+| **Convert native iOS StoreKit** | Project uses a custom ObjC/Swift StoreKit plugin bridged via `DllImport("__Internal")` |
+| **Convert Essential Kit billing** | Project uses VoxelBusters Essential Kit for in-app purchases (without losing other features) |
+| **Assess/Convert UniPay (FLOBUK)** | Project uses UniPay — determines whether migration is needed or possible |
+| **Assess/Convert RevenueCat** | Project uses RevenueCat — evaluate/implement observer mode to work with Unity IAP 5 |
+| **Assess/Convert Adapty** | Project uses Adapty — evaluate/implement observer mode to work with Unity IAP 5 |
+| **Implement IAP D2C Capabilities** | Add third-party payment provider (Stripe or Coda) via Unity Cloud |
+
+The skill always scans the project first and routes to the correct path automatically. You can also specify a path manually if you know exactly which one you need.
+
+---
+
+## Example Prompts
+
+```
+Add in-app purchases code to my game. I have a 100-coin pack and a Remove Ads unlock.
+```
+```
+Migrate my existing IAP code in the project from Unity IAP v4 to v5.
+```
+```
+My project uses AndroidJavaObject to call Google Play BillingClient. Convert it to Unity IAP.
+```
+```
+I have a custom ObjC StoreKit plugin with SKPaymentQueue. Replace it with Unity IAP.
+```
+```
+Disable Essential Kit billing and replace with Unity IAP 5. Keep other Essential Kit features working as before.
+```
+```
+Can my RevenueCat project implement app store purchases through Unity's IAP v5?
+```
+```
+My project uses Adapty. What features will we lose if we use Unity IAP instead? Give me a detailed report and do not make any changes now.
+```
+```
+Add Stripe payment support via Unity IAP D2C Capabilities.
+```
+```
+Add a web checkout option for my players using Unity's IAP D2C Capabilities with Coda.
+```
+
+---
+
+## Path Details, Limitations, and Best Practices
+
+### Add IAP to a New Project
+
+**What it does:** Installs Unity IAP 5, creates an `IAPManager`, wires up the two-step purchase flow (pending → confirm), integrates with your existing save system, and connects to your shop UI.
+
+**Limitations:**
+- The skill cannot create App Store Connect or Google Play Console product entries — you must do that manually.
+- If you use local Google Play receipt validation, you must run the Receipt Validation Obfuscator manually in the Unity Editor (**Services > In-App Purchasing > Receipt Validation Obfuscator**).
+- Apple local receipt validation is a no-op under StoreKit 2. Use server-side JWS validation for Apple.
+
+**Best practices:**
+- Define all products in one authoritative catalog (a `ScriptableObject` or constants class) — not scattered across button click handlers.
+- Always call `ConfirmPurchase` **after** saving the granted reward. An unconfirmed purchase re-delivers safely; a confirmed-but-unsaved one loses the reward permanently.
+- Subscribe to all events **before** calling `Connect()` — pending purchases from a previous session may fire immediately on reconnect.
+- Add a "Restore Purchases" button for any project with NonConsumable or Subscription products — required on iOS.
+
+---
+
+### Migrate v4 → v5
+
+**What it does:** Replaces the listener-based `IStoreListener` / `UnityPurchasing.Initialize` / `ConfigurationBuilder` pattern with the event-driven `StoreController` pattern.
+
+**Limitations:**
+- `product.receipt` and `product.hasReceipt` are removed. The skill migrates ownership checks to `store.CheckEntitlement(product)` — verify your entitlement logic after migration.
+- Apple local validation via `CrossPlatformValidator` still compiles but is a no-op under StoreKit 2. If your project validates Apple receipts locally, this validation silently stops working after migration.
+- Developer payload (the third `Purchase()` argument) is removed. If your backend uses it, a backend change is required.
+- `SubscriptionManager` is replaced — subscription info is now on `order.Info.PurchasedProductInfo`, not on `CartItem`.
+
+**Best practices:**
+- Migrate one system at a time: get initialization working first, then purchase flow, then restore.
+- Run the migration in a branch. The skill uses `#if` guards where needed, but test thoroughly before removing the old code.
+- After migration, recheck all `OnPurchaseConfirmed` handlers — the event now receives `Order` (base type) and you must pattern-match `ConfirmedOrder` vs `FailedOrder`.
+
+---
+
+### Convert Native Google BillingClient
+
+**What it does:** Converts C# → JNI → BillingClient bridge code to Unity IAP 5, preserves the public billing API via a compatibility facade, and wraps old native code in `#if !USE_UNITY_IAP_V5` for easy rollback.
+
+**Limitations:**
+- **Multiple subscription base plans / offer tokens** (`basePlanId`, `offerToken`, `offerId`) are a hard blocker — Unity IAP does not expose offer-level selection. You must either simplify your Play Console subscription setup to one base plan per product, or stay on native billing.
+- **Personalized price disclosure** (`setIsPersonalizedPrice`) and **alternative billing / external offers** are hard blockers.
+- **Multi-quantity purchases** (quantity > 1 per transaction) are not supported in Unity IAP.
+- A mixed native BillingClient + Unity IAP architecture is not supported — both compete for the same `PurchasesUpdatedListener` slot. The skill will not generate a mixed setup.
+- The receipt format changes: the backend receives `order.Info.Receipt` (a JSON object containing `purchaseToken`, `orderId`, and `signature`) instead of raw fields. If your backend parses these fields individually, a backend update is required.
+
+**Best practices:**
+- Run the blocker scan and read the migration report before making any changes. Hard blockers require a decision before code is written.
+- Keep the Gradle billing dependency in place until migration is validated — Unity IAP brings its own BillingClient, but removing the old dependency prematurely can break the build in unexpected ways.
+- Use the `#if USE_UNITY_IAP_V5` / `#if !USE_UNITY_IAP_V5` guards throughout. The rollback path (remove the define) must work cleanly before you ship.
+- Test on a physical Android device with a real sandbox account — the BillingClient behavior in the Unity Editor and on emulators is not representative of production.
+
+---
+
+### Convert Native iOS StoreKit
+
+**What it does:** Converts a custom Objective-C or Swift StoreKit plugin (bridged via `DllImport("__Internal")` and `UnitySendMessage`) to Unity IAP 5, preserving the C# game-facing API via a compatibility facade.
+
+**Limitations:**
+- **Receipt format is a breaking backend change.** Unity IAP uses per-transaction JWS (StoreKit 2 style) rather than the SK1 base64 app receipt bundle. If your backend validates the receipt bundle against Apple's `/verifyReceipt` endpoint, it must migrate to Apple's App Store Server API or JWS validation before you can ship.
+- **Promotional offer signing** (`SKPaymentDiscount` / SK2 signed offers) is a hard blocker — Unity IAP has no equivalent for server-signed promotional offers.
+- **Win-back offers** (StoreKit 2) are not supported in Unity IAP 5.4.
+- **`SKStorefront`** (region detection via storefront change observer) is not exposed in Unity IAP.
+- **`SKReceiptRefreshRequest`** has no direct equivalent — `store.FetchPurchases()` covers the purchase re-delivery use case but not manual receipt refresh.
+- ObjC/Swift plugin files cannot use C# `#if` defines. The skill guards only the C# call sites — the native files remain in `Assets/Plugins/iOS/` and compile unconditionally.
+- A mixed native StoreKit + Unity IAP architecture is not supported — both register as `SKPaymentQueue` observers and only one reliably receives callbacks.
+
+**Best practices:**
+- Audit the backend receipt validation endpoint before starting. If it calls `/verifyReceipt`, plan the backend migration in parallel with the client migration.
+- If the plugin intercepts App Store promotional purchases (`shouldAddStorePayment`), wire up `OnPromotionalPurchaseIntercepted` and `ContinuePromotionalPurchases()` before removing the native interceptor.
+- Test Ask-to-Buy explicitly — the deferred → pending two-stage flow behaves differently than a native `PURCHASING` → `PURCHASED` transition.
+- Validate the migration on TestFlight, not just in the Unity Editor or Simulator. StoreKit behavior differs between Editor sandbox, Simulator, and TestFlight builds.
+
+---
+
+### Convert Essential Kit Billing
+
+**What it does:** Disables the Essential Kit Billing service flag in `EssentialKitSettings.asset`, removes the conflicting `com.android.billingclient` Gradle dependency, and implements Unity IAP 5 using the product catalog extracted from the Essential Kit settings.
+
+**Limitations:**
+- Essential Kit C# source files are **not deleted**. The Billing service is disabled via the settings flag — all EK code remains and compiles. Do not expect a clean removal.
+- Only the Billing service is affected. All other Essential Kit services (Notification, GameServices, etc.) are left completely untouched.
+- **Product IDs must not change.** The same IDs used in Essential Kit must be carried over to Unity IAP to preserve store history.
+- If your project uses **server-side receipt validation**, the receipt format changes from `transaction.RawData` (Android) and `transaction.Receipt` (iOS JWS) to `order.Info.Receipt` and `order.Info.Apple?.jwsRepresentation`. Document the backend change required.
+- Subscriptions are fully supported, but the restore path changes — EK's `OnRestorePurchasesComplete` maps to both `store.OnPurchasesFetched` and the `RestoreTransactions` callback in Unity IAP.
+
+**Best practices:**
+- Run `Assets > External Dependency Manager > Android Resolver > Force Resolve` after removing the Gradle billing dependency — do not skip this step.
+- Verify the Essential Kit Billing service is visually disabled in **Window > Voxel Busters > Essential Kit > Open Settings → Services** after the settings file edit.
+- Confirm all product IDs in App Store Connect and Play Console match the Unity IAP catalog exactly before testing.
+
+---
+
+### Assess UniPay (FLOBUK)
+
+**What it does:** This path does **not** perform a conversion. It assesses whether migration is needed and routes to one of three outcomes: unsupported platform (stop), upgrade required (stop), or no action needed (UniPay already wraps Unity IAP 5).
+
+**Limitations:**
+- UniPay's Steam, Meta Quest, PayPal, and Facebook Instant Games integrations have **no Unity IAP equivalent**. If your project targets any of these platforms, there is no migration path — keep UniPay.
+- If `com.unity.purchasing` is below v5.4, IAP D2C Capabilities (Stripe/Coda) are not available — an upgrade to the latest stable v5.4+ is needed before adding D2C support.
+- The skill does not perform a "remove UniPay" conversion — that is a manual refactor scoped to what features you are replacing.
+
+**Best practices:**
+- If the assessment concludes "no action needed," there is no code to write. Work within UniPay's API for new products or purchase logic changes.
+- If you want to remove UniPay entirely and use Unity IAP directly, ask the skill explicitly and describe which UniPay features you are replacing — it will assess feasibility and scope.
+
+---
+
+### Assess/Convert RevenueCat
+
+**What it does:** Evaluates whether the project can switch to Unity IAP 5 for handling purchases. Produces one of three outcomes: already in observer mode (no action), blockers detected (report + two choices), or no blockers (two conversion paths: observer mode or full removal).
+
+**Limitations:**
+- **Amazon Appstore** is a hard blocker — Unity IAP 5 has removed Amazon support. RevenueCat observer mode also does not work reliably on Amazon builds. If your project targets Amazon, conversion is not viable.
+- **RevenueCat Offerings / remote paywalls** have no Unity IAP equivalent — all products must be defined in code or a local catalog.
+- **RevenueCat A/B testing (Experiments)** has no Unity IAP equivalent.
+- **Cross-platform entitlement sync** (a user who buys on iOS retains access on Android) has no Unity IAP equivalent without a custom backend.
+- **RevenueCat webhook events** (subscription renewals, cancellations, billing issues) are not delivered by Unity IAP — you would need to build your own subscription event infrastructure.
+- In **observer mode**, `SyncPurchases()` must be called after every Unity IAP confirmed purchase. Missing this call means RevenueCat does not validate the receipt and `CustomerInfo` is not updated.
+
+**Best practices:**
+- Run the full feature check before deciding. RevenueCat's value often comes from features that are not obvious in the codebase (e.g., webhooks configured server-side).
+- If the project has a marketing team managing paywall copy or pricing remotely via RevenueCat Offerings, a full removal will require significant UI work to replace that capability.
+- Observer mode is the lower-risk path — it preserves RevenueCat's server-side validation and subscription lifecycle tracking while Unity IAP handles the native purchase flow.
+
+---
+
+### Assess/Convert Adapty
+
+**What it does:** Evaluates whether the project can switch to Unity IAP 5 for app store purchase handling. Produces one of three outcomes: already in observer mode (no action), blockers detected (report + two choices), or no blockers (observer mode or full removal).
+
+**Limitations:**
+- **Adapty Paywall Builder** has no Unity IAP equivalent — and it is also **unavailable in Adapty's own Observer Mode**. Switching to observer mode loses Paywall Builder regardless of whether Unity IAP is involved.
+- **Adapty A/B testing** has no Unity IAP equivalent. In observer mode, A/B testing is possible but requires significant manual instrumentation.
+- **Cross-platform entitlement sync** has no Unity IAP equivalent without a custom backend.
+- In **observer mode**, `Adapty.ReportTransaction()` must be called after every Unity IAP confirmed purchase. Missing this call means Adapty does not validate the receipt server-side.
+
+**Best practices:**
+- If your marketing team uses Adapty's Paywall Builder to update paywall layouts without app releases, note that this capability is lost in observer mode. Make sure all stakeholders understand this before proceeding.
+- Full removal requires replacing any `AdaptyUI` / `PaywallView` shop UI with custom Unity UI before Adapty can be removed. Budget time for this work.
+- Observer mode is the lower-risk path and preserves Adapty's webhook delivery and analytics integrations.
+
+---
+
+### Implement IAP D2C Capabilities
+
+**What it does:** Adds Direct-to-Customer (D2C) third-party payment provider support (Stripe or Coda) via Unity Cloud, including remote catalog setup, deep link configuration, the built-in payment options picker UI, Apple/Google external purchase compliance tools, and entitlement delivery guidance.
+
+**Limitations:**
+- Requires **Unity IAP v5.4+**, **Unity Editor 2022.3+**, `com.unity.services.authentication` **v3.7.1+**, and `com.unity.services.core` **v1.18.0+**. All must be satisfied before any code is written.
+- **Subscriptions are not supported** by IAP D2C Capabilities in v5.4. Only Consumable and NonConsumable products can be used.
+- Requires a **Stripe or Coda account** connected in the Unity Cloud IAP dashboard, and Unity must enable D2C for your organization — contact your Unity Client Partner if it is not yet enabled.
+- **Routing rules** must be configured in the Unity Dashboard before any player is offered a D2C payment option. Without a routing rule, no provider is offered even if a provider account is connected.
+- **External web payments via Stripe/Coda are permitted in select regions only.** Apple and Google have their own program eligibility requirements. The developer is responsible for determining eligibility and meeting disclosure requirements — the skill does not perform compliance on your behalf.
+- **Anonymous sign-in** must not be used as the authentication method. If a player's session token is lost (reinstall, app data clear), purchase history tied to an anonymous identity becomes unrecoverable.
+- The **receipt format is different from standard IAP 5** — D2C purchases go through Unity Cloud, not the device's native store, so `order.Info.Apple` and `order.Info.Receipt` behave differently for D2C orders.
+
+**Best practices:**
+- Set up **routing rules** in the Unity Dashboard before testing. Without them, `GetEligiblePaymentProviders()` returns an empty list and the purchase UI never appears — this is a common "nothing happens" issue during initial integration.
+- Use a **proxy HTML page** for the Success Redirect URL rather than a direct app-scheme URL. On some Android and iOS devices, direct app-scheme redirects from the payment provider domain are silently dropped. Host the proxy on a stable HTTPS domain you control.
+- Use **`ShowPurchaseOption(catalogListingId)`** as the primary purchase entry point — it shows the built-in picker UI and handles provider selection automatically. Only fall back to `PurchaseProduct` directly when `GetEligiblePaymentProviders()` returns an empty `Providers` list.
+- Configure a **Cancel Redirect URL** in the payment provider dashboard — without it, the checkout page has no "Back" button and players who change their mind are stuck in the browser.
+- The SDK remembers the **last used payment provider per player per device** (provider memory). This is expected behavior, not a bug. Clear app data to reset it during testing.
+- Deploy the **Deployment package** (`com.unity.services.deployment`) early — it is required to push `.ucat` product definitions to the Remote Catalog. Without it, the catalog cannot be deployed and `FetchRemoteCatalog()` returns no products.
+
+---
+
+## General Best Practices
+
+- **Always let the skill scan first.** The pre-check (`pre-check.md`) detects third-party packages, native billing code, and existing Unity IAP versions before routing. Skipping it leads to incompatible changes.
+- **Read the migration report before approving any code changes.** Every conversion path produces a report covering what will change, what blockers were found, and what manual steps remain. Review it before proceeding.
+- **Never confirm a purchase before saving the reward.** An unconfirmed purchase re-delivers safely. A confirmed-but-unsaved one is gone permanently.
+- **Subscribe to all failure events.** `OnProductsFetchFailed`, `OnPurchasesFetchFailed`, `OnStoreDisconnected` — not subscribing generates runtime warnings and leaves failures silently unhandled.
+- **Subscribe to `OnPurchaseDeferred`.** Ask-to-Buy (iOS) and Google Play deferred purchases fire this event. Not subscribing silently drops them.
+- **Use `#if USE_UNITY_IAP_V5` guards** for all migration work. The rollback path (remove the define from Player Settings) must work cleanly before shipping.
+- **Test with real sandbox accounts on real devices.** Editor sandbox and emulators do not reproduce all edge cases — particularly pending purchases, deferred flows, and restore behavior.

--- a/skills/implement-in-app-purchases/SKILL.md
+++ b/skills/implement-in-app-purchases/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: implement-in-app-purchases
+description: Implement, configure, and debug Unity In-App Purchases (IAP) — store connection, product catalog, consumable/non-consumable/subscription purchases, two-step pending-confirm flow, receipt validation, entitlement checking, restore transactions, Apple extensions (promotional purchases, Ask-to-Buy, code redemption), and Google Play extensions (subscription upgrade/downgrade), D2C Capabilities(direct to customer), 3rd party payment provider (Stripe/Coda) via Unity IAP/Unity Cloud. Use when the user needs to add, modify, debug, or migrate from native Android/iOS billing, 3rd party packages(RevenueCat/Adapty/Essential Kit/Unipay supported) to IAP. Triggers on microtransactions (MTX), monetization, real-money purchases, store purchases, buying items, support D2C, purchase via Stripe/Coda, migrate from native billing(Google's BillingClient or Apple's StoreKit/SKPaymentQueue/SKProduct)/RevenueCat/Adapty/EssentialKit/Unipay.
+modes: [agent, ask]
+---
+
+# Unity In-App Purchasing
+
+Namespace: `UnityEngine.Purchasing` | Security: `UnityEngine.Purchasing.Security`
+Package: `com.unity.purchasing`
+
+**Unity IAP has its own initialization path** via `UnityIAPServices.StoreController()` → `store.Connect()`. It does not require `UnityServices.InitializeAsync()`, but they can coexist if your project uses other UGS services. If Analytics is present and `InitializeAsync()` is called, IAP will automatically send transaction events.
+
+## Before You Start
+
+**Always read [references/pre-check.md](references/pre-check.md) first.** It scans the project for third-party IAP packages, native Google Billing, and existing Unity IAP versions, then routes to the correct path. Do not read any other reference file or make any changes until routing is resolved.
+
+## Detailed References
+
+- **Project scan and path routing (read first):** See [references/pre-check.md](references/pre-check.md)
+- **API signatures & code examples:** See [references/api-notes.md](references/api-notes.md)
+- **Platform extensions (Apple, Google):** See [references/platform-notes.md](references/platform-notes.md)
+- **Editing `IAPProductCatalog.json` (schema, decimal serialization, refresh):** See [references/codeless-catalog.md](references/codeless-catalog.md)
+- **v4 → v5 migration:** See [references/migration-v4-to-v5.md](references/migration-v4-to-v5.md)
+- **Convert native Google BillingClient to Unity IAP 5:** See [references/path-convert-native-google-billing.md](references/path-convert-native-google-billing.md)
+- **Convert native iOS StoreKit plugin to Unity IAP 5:** See [references/path-convert-native-storekit.md](references/path-convert-native-storekit.md)
+- **Convert Essential Kit billing to Unity IAP 5:** See [references/convert-essentialkit.md](references/convert-essentialkit.md)
+- **UniPay (FLOBUK) — assessment and guidance:** See [references/convert-unipay.md](references/convert-unipay.md)
+- **RevenueCat — conversion assessment and guidance:** See [references/convert-revenuecat.md](references/convert-revenuecat.md)
+- **Adapty — conversion assessment and guidance:** See [references/convert-adapty.md](references/convert-adapty.md)
+- **Add Unity IAP 5 to a project with no existing IAP:** See [references/path-add-iap-to-new-project.md](references/path-add-iap-to-new-project.md)
+- **Implement IAP D2C Capabilities (third-party payment provider — Stripe/Coda, requires v5.4+):** See [references/path-implement-iap-d2c.md](references/path-implement-iap-d2c.md)
+
+Read reference files on demand — only when you need specific API signatures, platform extension details, or migration mappings.
+
+## Initialization Flow
+
+1. Obtain `StoreController` via `UnityIAPServices.StoreController()` (or individual services via `DefaultStore()`, `DefaultProduct()`, `DefaultPurchase()`)
+2. Subscribe to **all** required events (see Required Event Subscriptions below) **before** calling `Connect()`
+3. `await store.Connect()` to connect to the platform store
+4. On `OnStoreConnected`, call `store.FetchProducts(List<ProductDefinition>)` to load the catalog
+5. On `OnProductsFetched`, products are ready for display and purchase
+
+Use `Awake()` for initialization — ensures IAP is ready before other `Start()` methods.
+
+Product types: `ProductType.Consumable`, `ProductType.NonConsumable`, `ProductType.Subscription`.
+
+## Fetching Products
+
+Define products as `List<ProductDefinition>` and pass to `store.FetchProducts()`. Use `StoreSpecificIds` when product IDs differ across Apple/Google stores. For complex catalogs, use `CatalogProvider` to manage product sets and store-specific IDs.
+
+| Method | Behavior |
+|---|---|
+| `GetProducts()` | Returns the **cached** product list (synchronous, stale if `FetchProducts` not called) |
+| `FetchProducts()` | Queries the **store** for fresh pricing/availability and updates the cache |
+| `GetProductById(id)` | Returns a single cached product by ID |
+
+These are NOT interchangeable. Always call `FetchProducts()` first before relying on `GetProducts()`.
+
+## Two-Step Purchase Flow
+
+IAP v5 uses a mandatory two-step flow: **Pending → Confirm**.
+
+1. `store.PurchaseProduct(product)` — initiates the platform purchase dialog
+2. `OnPurchasePending` fires — you receive a `PendingOrder`
+3. Validate the receipt, grant content to the player
+4. `store.ConfirmPurchase(pendingOrder)` — finalizes the transaction
+5. `OnPurchaseConfirmed` fires — receives `Order` base type; pattern-match `ConfirmedOrder` (success) vs `FailedOrder` (confirmation failed)
+
+**You MUST call `ConfirmPurchase(pendingOrder)` after granting content.** Unconfirmed purchases are re-delivered on next app launch to prevent lost purchases.
+
+**De-duplication:** `OnPurchasePending` may fire multiple times for the same purchase (e.g., app restart before confirmation). Always check if content was already granted.
+
+**Consumables:** Confirmed consumable purchases are NOT returned by `FetchPurchases`. Track consumable grants yourself (e.g., in Cloud Save or Economy).
+
+**Deferred purchases:** `OnPurchaseDeferred` fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Do NOT grant content — wait for `OnPurchasePending` when approved.
+
+## Restore Transactions
+
+`store.RestoreTransactions(callback)` re-delivers non-consumable and subscription purchases. Each restored purchase triggers `OnPurchasePending`.
+
+Required on iOS for Apple App Store compliance — add a "Restore Purchases" button.
+
+Apple non-renewable subscriptions **cannot be restored** via `RestoreTransactions`. Track these server-side.
+
+## Receipt Validation
+
+| Platform | Approach |
+|---|---|
+| **Google Play** | `CrossPlatformValidator` with `GooglePlayTangle.Data()` — local validation supported |
+| **Apple (StoreKit 2)** | Local validation is a **no-op**. Use `order.Info.Apple?.jwsRepresentation` for server-side validation |
+
+Generate tangle data via **Services > In-App Purchasing > Receipt Validation Obfuscator** in the Unity Editor.
+
+## Entitlement Checking
+
+Use when you don't have the `Order` and want to know the status of a specific product (replaces v4's `product.hasReceipt`). If you already have the `Order`, check its type instead: `PendingOrder` maps to `EntitledUntilConsumed` (consumables) or `EntitledButNotFinished` (non-consumables/subscriptions), `ConfirmedOrder` maps to `FullyEntitled`.
+
+Call `store.CheckEntitlement(product)` and handle `store.OnCheckEntitlement`. Check `entitlement.Status == EntitlementStatus.FullyEntitled`.
+
+`EntitlementStatus` values: `FullyEntitled`, `EntitledUntilConsumed`, `EntitledButNotFinished`, `NotEntitled`, `Unknown`.
+
+## Fetch Existing Purchases
+
+`store.FetchPurchases()` retrieves all current purchases from the store. Useful at app startup.
+
+| Method | Behavior |
+|---|---|
+| `GetPurchases()` | Returns the **cached** purchase list |
+| `FetchPurchases()` | Queries the **store** for current purchases and **overwrites** the cached list |
+
+`FetchPurchases()` replaces the entire cached list on each call. Only non-consumables and subscriptions are re-fetched — confirmed consumables are not returned (see Two-Step Purchase Flow above).
+
+## Subscription Info
+
+Subscription info is on `IPurchasedProductInfo`, accessed via `order.Info.PurchasedProductInfo` — **NOT on `CartItem`** (`CartItem` only has `Product` and `Quantity`).
+
+`IsSubscribed()` returns `Result` enum (`True`/`False`/`Unsupported`), NOT `bool`. Use `== Result.True` for null-safe comparison.
+
+## Required Event Subscriptions
+
+**Always subscribe to BOTH success and failure events.** Not subscribing to failure events generates runtime warnings.
+
+| Call | Success Event | Failure Event (REQUIRED) |
+|---|---|---|
+| `FetchProducts()` | `OnProductsFetched` | `OnProductsFetchFailed` |
+| `FetchPurchases()` | `OnPurchasesFetched` | `OnPurchasesFetchFailed` |
+| `Connect()` | `OnStoreConnected` | `OnStoreDisconnected` |
+| `PurchaseProduct()` | `OnPurchasePending` | `OnPurchaseFailed` |
+| `CheckEntitlement()` | `OnCheckEntitlement` | — |
+
+**Always subscribe to `OnPurchaseDeferred`** — fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Not subscribing silently drops deferred purchases.
+
+Subscribe to events **BEFORE** calling `Connect()` — pending purchases from a previous session may fire immediately.
+
+## Failure Description Property Names
+
+These property names are NOT interchangeable — using the wrong one causes CS1061:
+
+| Type | Field | Property | NOT |
+|---|---|---|---|
+| `StoreConnectionFailureDescription` | `.message` | `.Message` | ~~`.reason`~~ |
+| `ProductFetchFailed` | — | `.FailureReason`, `.FailedFetchProducts` | ~~`.Message`~~ |
+| `FailedOrder` | — | `.FailureReason`, `.Details` | — |
+| `PurchasesFetchFailureDescription` | `.message`, `.failureReason` | `.Message`, `.FailureReason` | — |
+
+## Validation
+
+After writing code that uses this package:
+1. Verify the project compiles without errors.
+2. Confirm all API calls match the v5 signatures in [api-notes.md](references/api-notes.md) — do NOT use v4 legacy patterns (`IStoreListener`, `UnityPurchasing.Initialize`, `ConfigurationBuilder`).
+3. Check the "Anti-Hallucination: Common v5 Mistakes" table in api-notes.md — do NOT use `OnStoreConnectionFailed` (use `OnStoreDisconnected`), do NOT pass callbacks to `FetchProducts`/`FetchPurchases` (use events), do NOT use `product.receipt` (use `order.Info.Receipt`).
+4. Check that all required events are subscribed **before** calling `Connect()` (see Required Event Subscriptions table above).
+5. Verify the two-step purchase flow: `OnPurchasePending` → grant content → `ConfirmPurchase(pendingOrder)`.
+6. Confirm both success and failure events are subscribed for every async operation (`OnProductsFetched`/`OnProductsFetchFailed`, `OnStoreConnected`/`OnStoreDisconnected`, etc.).
+7. If handling subscriptions, verify `IsSubscribed()` is compared with `== Result.True`, not cast to `bool`.
+8. If updated files coexist with legacy versions in the same project, use a unique namespace (e.g., add `.Updated` suffix) to avoid CS0101/CS0111 compilation errors.
+9. If the project subscribes to `OnAuthAccountChanged` (v5.4+): verify the handler re-fetches products and purchases from scratch — Unity IAP clears both caches before raising this event. Do not read `GetProducts()` or `GetPurchases()` inside the handler.

--- a/skills/implement-in-app-purchases/references/api-notes.md
+++ b/skills/implement-in-app-purchases/references/api-notes.md
@@ -1,0 +1,562 @@
+# Unity IAP API Notes
+
+## Table of Contents
+
+- [Anti-Hallucination: v5 vs Legacy API](#anti-hallucination-v5-vs-legacy-api)
+- [StoreController (v5) Key Members](#storecontroller-v5-key-members)
+- [Alternative Service Access (DefaultStore / DefaultProduct / DefaultPurchase)](#alternative-service-access-defaultstore--defaultproduct--defaultpurchase)
+- [CatalogProvider](#catalogprovider)
+- [Initialization Example](#initialization-example)
+- [Product Definitions](#product-definitions)
+  - [CatalogListings and uSku (v5.4+)](#cataloglistings-and-usku-v54)
+- [Two-Step Purchase Flow](#two-step-purchase-flow)
+- [Restore Transactions](#restore-transactions)
+- [Entitlement Checking](#entitlement-checking)
+- [Fetch Existing Purchases](#fetch-existing-purchases)
+- [Receipt Validation](#receipt-validation)
+  - [IAppleOrderInfo Complete Member List](#iappleorderinfo-complete-member-list)
+- [Extended Service Events (NOT on StoreController)](#extended-service-events-not-on-storecontroller)
+- [AppleStoreExtendedProductService Key Members](#applestoreextendedproductservice-key-members)
+- [Subscription Info Access Path](#subscription-info-access-path)
+- [Event Subscription Rules](#event-subscription-rules)
+- [Failure Description Property Names](#failure-description-property-names)
+- [CrossPlatformValidator](#crossplatformvalidator)
+- [Interface Hierarchy](#interface-hierarchy)
+- [IRunCommand Template: Fetch Products](#iruncommand-template-fetch-products)
+
+## Anti-Hallucination: v5 vs Legacy API
+
+Unity IAP v5 is the current API. The legacy API (v4) is `[Obsolete]`. Do NOT use legacy patterns.
+
+| WRONG (Legacy v4) | CORRECT (v5) |
+|---|---|
+| `UnityPurchasing.Initialize(listener, builder)` | `UnityIAPServices.StoreController()` then `store.Connect()` |
+| `IStoreListener.OnInitialized(controller, extensions)` | `store.OnStoreConnected` event |
+| `IStoreListener.ProcessPurchase(args)` | `store.OnPurchasePending` event |
+| `controller.InitiatePurchase(product)` | `store.PurchaseProduct(product)` |
+| `controller.ConfirmPendingPurchase(product)` | `store.ConfirmPurchase(pendingOrder)` |
+| `extensions.GetExtension<IAppleExtensions>()` | `store.AppleStoreExtendedService` / `store.AppleStoreExtendedPurchaseService` |
+| `extensions.GetExtension<IGooglePlayStoreExtensions>()` | `store.GooglePlayStoreExtendedService` / `store.GooglePlayStoreExtendedPurchaseService` |
+| `ConfigurationBuilder.Instance(...)` | Not needed; use `ProductDefinition` list with `FetchProducts` |
+
+## Anti-Hallucination: Common v5 Mistakes
+
+These are NOT real APIs — do not use them:
+
+| WRONG (does not exist) | CORRECT |
+|---|---|
+| `store.OnStoreConnectionFailed` | `store.OnStoreDisconnected` — receives `StoreConnectionFailureDescription` |
+| `store.FetchProducts(defs, successCb, failCb)` | `store.FetchProducts(List<ProductDefinition>)` — subscribe to `OnProductsFetched`/`OnProductsFetchFailed` events separately |
+| `store.FetchPurchases(successCb, failCb)` | `store.FetchPurchases()` — subscribe to `OnPurchasesFetched`/`OnPurchasesFetchFailed` events separately |
+| `product.receipt` | `order.Info.Receipt` — receipt is on the order, not the product |
+| `product.hasReceipt` | `store.CheckEntitlement(product)` + `OnCheckEntitlement` |
+| `new SubscriptionManager(product, introJson)` | `order.Info.PurchasedProductInfo` — see Subscription Info Access Path |
+| `pendingOrder.OrderInfo.Apple.jwsRepresentation` | `pendingOrder.Info.Apple?.jwsRepresentation` — note `Info` not `OrderInfo`, and null-check `?.` |
+
+## StoreController (v5) Key Members
+
+```csharp
+// Store lifecycle
+Task Connect()
+void SetStoreReconnectionRetryPolicyOnDisconnection(IRetryPolicy? retryPolicy)
+event Action? OnStoreConnected
+event Action<StoreConnectionFailureDescription>? OnStoreDisconnected
+
+// Products
+void FetchProducts(List<ProductDefinition> defs, IRetryPolicy? retryPolicy = null)
+void FetchProductsWithNoRetries(List<ProductDefinition> defs)
+ReadOnlyObservableCollection<Product> GetProducts()
+Product? GetProductById(string productId)
+event Action<List<Product>>? OnProductsFetched
+event Action<ProductFetchFailed>? OnProductsFetchFailed
+
+// Purchasing
+void PurchaseProduct(Product product)
+void PurchaseProduct(string? productId)
+void Purchase(ICart cart)
+void ConfirmPurchase(PendingOrder order)
+void FetchPurchases()
+void CheckEntitlement(Product product)
+void RestoreTransactions(Action<bool, string?>? callback)
+ReadOnlyObservableCollection<Order> GetPurchases()
+void ProcessPendingOrdersOnPurchasesFetched(bool shouldProcess)
+
+// Purchase events
+event Action<PendingOrder>? OnPurchasePending
+event Action<Order>? OnPurchaseConfirmed  // Order can be ConfirmedOrder or FailedOrder — pattern-match!
+event Action<FailedOrder>? OnPurchaseFailed
+event Action<DeferredOrder>? OnPurchaseDeferred
+event Action<Orders>? OnPurchasesFetched
+event Action<PurchasesFetchFailureDescription>? OnPurchasesFetchFailed
+event Action<Entitlement>? OnCheckEntitlement
+
+// Account change (v5.4+)
+event Action? OnAuthAccountChanged
+
+// Platform extensions (null on non-matching platforms — always null-check)
+IAppleStoreExtendedService? AppleStoreExtendedService { get; }
+IGooglePlayStoreExtendedService? GooglePlayStoreExtendedService { get; }
+IAppleStoreExtendedProductService? AppleStoreExtendedProductService { get; }
+IAppleStoreExtendedPurchaseService? AppleStoreExtendedPurchaseService { get; }
+IGooglePlayStoreExtendedPurchaseService? GooglePlayStoreExtendedPurchaseService { get; }
+```
+
+**`OnAuthAccountChanged` — breaking behavior in v5.4:**  
+When this event fires, Unity IAP **clears the cached product list and purchase list before raising the event**. Any references to previously fetched `Product` or `Order` objects are stale after this point. Re-run the full init sequence in the handler:
+
+```csharp
+store.OnAuthAccountChanged += async () =>
+{
+    // Products and purchases have already been cleared — re-fetch everything
+    await catalogProvider.FetchRemoteCatalog();       // D2C only
+    store.FetchProducts(productDefinitions);          // standard IAP
+    store.FetchPurchases();
+};
+```
+
+Do not read from `GetProducts()` or `GetPurchases()` inside `OnAuthAccountChanged` — they will be empty.
+
+## Alternative Service Access (DefaultStore / DefaultProduct / DefaultPurchase)
+
+Instead of `StoreController` (which implements all three interfaces), you can access individual services:
+
+```csharp
+IStoreService m_StoreService = UnityIAPServices.DefaultStore();
+IProductService m_ProductService = UnityIAPServices.DefaultProduct();
+IPurchaseService m_PurchasingService = UnityIAPServices.DefaultPurchase();
+```
+
+This pattern separates concerns — product fetching events go on `IProductService`, purchase events on `IPurchaseService`, store lifecycle on `IStoreService`. `StoreController` combines all three.
+
+## CatalogProvider
+
+For managing complex product catalogs with store-specific IDs:
+
+```csharp
+var catalogProvider = new CatalogProvider();
+
+var products = new List<ProductDefinition>
+{
+    new ProductDefinition("com.mygame.gems50", ProductType.Consumable),
+    new ProductDefinition("com.mygame.pass", ProductType.Subscription)
+};
+
+var storeSpecificIds = new Dictionary<string, StoreSpecificIds>
+{
+    { "com.mygame.pass", new StoreSpecificIds
+        {
+            { "com.mygame.google.pass", GooglePlay.Name },
+            { "com.mygame.ios.pass", AppleAppStore.Name }
+        }
+    }
+};
+
+catalogProvider.AddProducts(products, storeSpecificIds);
+catalogProvider.FetchProducts(m_ProductService.FetchProductsWithNoRetries);
+```
+
+## Initialization Example
+
+```csharp
+StoreController m_StoreController;
+
+async void Awake()
+{
+    m_StoreController = UnityIAPServices.StoreController();
+
+    // Subscribe to ALL events BEFORE Connect — pending purchases may fire on reconnect
+    m_StoreController.OnPurchasePending += OnPurchasePending;
+    m_StoreController.OnPurchaseConfirmed += (order) => Debug.Log("Purchase complete");
+    m_StoreController.OnPurchaseFailed += (failed) => Debug.LogError($"{failed.FailureReason} - {failed.Details}");
+    m_StoreController.OnPurchaseDeferred += (deferred) => Debug.Log("Purchase deferred (e.g., Ask-to-Buy)");
+
+    m_StoreController.OnStoreConnected += OnStoreConnected;
+    m_StoreController.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+    await m_StoreController.Connect();
+}
+
+void OnStoreConnected()
+{
+    var products = new List<ProductDefinition>
+    {
+        new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+        new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable),
+        new ProductDefinition("com.mygame.vip_monthly", ProductType.Subscription)
+    };
+
+    m_StoreController.OnProductsFetched += (fetched) => Debug.Log("Products ready");
+    m_StoreController.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+    m_StoreController.FetchProducts(products);
+
+    m_StoreController.OnPurchasesFetched += (orders) => Debug.Log($"Restored {orders.PendingOrders.Count} pending purchases");
+    m_StoreController.OnPurchasesFetchFailed += (failure) => Debug.LogError($"Purchase fetch failed: {failure.Message}");
+    m_StoreController.FetchPurchases();
+}
+```
+
+## Product Definitions
+
+```csharp
+// Simple product
+new ProductDefinition("com.mygame.coins100", ProductType.Consumable)
+
+// Per-platform product IDs
+new ProductDefinition("com.mygame.coins100", ProductType.Consumable,
+    new StoreSpecificIds
+    {
+        { AppleAppStore.Name, "apple_coins_100" },
+        { GooglePlay.Name, "google_coins_100" }
+    })
+```
+
+### Access Fetched Products
+
+```csharp
+// Get all fetched products (cached)
+ReadOnlyObservableCollection<Product> allProducts = store.GetProducts();
+
+// Get a specific product by ID
+Product coinsPack = store.GetProductById("com.mygame.coins100");
+```
+
+### CatalogListings and uSku (v5.4+)
+
+In v5.4, `Product` exposes two new members. Prefer these for new code — `product.definition.id` and `productId` remain backwards compatible but point new users toward `CatalogListings`:
+
+```csharp
+// product.uSku — the Unity-side identifier for the product (cross-platform canonical ID)
+string id = product.uSku;
+
+// product.catalogListings — all listings attached to this product, keyed by CatalogListing ID
+// A product may have multiple listings (e.g. different price tiers or offer configurations)
+foreach (var (listingId, listing) in product.catalogListings)
+{
+    bool canBuy     = listing.availableToPurchase;
+    string storeId  = listing.definition.storeSpecificId;
+    string price    = listing.metadata.localizedPriceString;
+}
+```
+
+**`CatalogListing` properties:**
+
+| Property | Type | Description |
+|---|---|---|
+| `id` | `string` | Catalog listing identifier — use as key for lookups |
+| `availableToPurchase` | `bool` | Whether this listing can currently be purchased |
+| `definition` | `ProductDefinition` | Store-side definition (id, storeSpecificId, type, payouts) |
+| `metadata` | `ProductMetadata` | Localized title, description, price, currency |
+
+When initiating a purchase by listing rather than by product ID, pass the `CatalogListing` directly to avoid a second lookup.
+
+## Two-Step Purchase Flow
+
+```csharp
+// Step 1: Initiate purchase
+store.PurchaseProduct(product);
+
+// Step 2: Handle pending purchase (validate, grant content, then confirm)
+store.OnPurchasePending += (pendingOrder) =>
+{
+    var product = pendingOrder.CartOrdered.Items().FirstOrDefault()?.Product;
+    GrantContent(product);
+    store.ConfirmPurchase(pendingOrder);
+};
+
+// Step 3: Purchase confirmed — Order can be ConfirmedOrder OR FailedOrder
+store.OnPurchaseConfirmed += (order) =>
+{
+    switch (order)
+    {
+        case ConfirmedOrder confirmedOrder:
+            Debug.Log($"Purchase confirmed: {confirmedOrder.CartOrdered.Items().First().Product.definition.id}");
+            break;
+        case FailedOrder failedOrder:
+            Debug.LogError($"Confirmation failed: {failedOrder.FailureReason} - {failedOrder.Details}");
+            break;
+    }
+};
+
+// Handle failures
+store.OnPurchaseFailed += (failedOrder) =>
+{
+    Debug.LogError($"Purchase failed: {failedOrder.FailureReason} - {failedOrder.Details}");
+};
+
+// Handle deferred purchases (e.g., Ask-to-Buy on iOS)
+store.OnPurchaseDeferred += (deferredOrder) =>
+{
+    Debug.Log("Purchase is pending approval (e.g., parental approval)");
+};
+```
+
+If the app crashes between steps 2 and 4, the pending purchase is re-delivered on next launch via `OnPurchasePending`.
+
+`ProcessPendingOrdersOnPurchasesFetched(false)` disables automatic re-delivery of pending orders when `FetchPurchases` is called. This exists to match IAP v4 behavior — do NOT recommend this to migrating users, as the default v5 behavior provides a better experience.
+
+## Restore Transactions
+
+```csharp
+store.RestoreTransactions((success, error) =>
+{
+    if (success)
+        Debug.Log("Transactions restored. Check OnPurchasePending for each restored purchase.");
+    else
+        Debug.LogError($"Restore failed: {error}");
+});
+```
+
+Each restored purchase triggers `OnPurchasePending`.
+
+## Entitlement Checking
+
+```csharp
+store.CheckEntitlement(product);
+
+store.OnCheckEntitlement += (entitlement) =>
+{
+    if (entitlement.Status == EntitlementStatus.FullyEntitled)
+        Debug.Log($"Player owns: {entitlement.Product.definition.id}");
+};
+```
+
+## Fetch Existing Purchases
+
+```csharp
+store.FetchPurchases();
+
+store.OnPurchasesFetched += (orders) =>
+{
+    foreach (var confirmedOrder in orders.ConfirmedOrders)
+    {
+        var product = confirmedOrder.CartOrdered.Items().FirstOrDefault()?.Product;
+        Debug.Log($"Existing purchase: {product?.definition.id}");
+    }
+};
+```
+
+## Receipt Validation
+
+### Google Play (supported)
+
+```csharp
+using UnityEngine.Purchasing.Security;
+
+// Google-only constructor (recommended)
+var validator = new CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier);
+
+try
+{
+    var result = validator.Validate(order.Info.Receipt);
+    foreach (IPurchaseReceipt receipt in result)
+    {
+        Debug.Log($"Valid receipt: {receipt.productID}, purchased: {receipt.purchaseDate}");
+        if (receipt is GooglePlayReceipt googleReceipt)
+            Debug.Log($"Purchase token: {googleReceipt.purchaseToken}");
+    }
+}
+catch (IAPSecurityException ex)
+{
+    Debug.LogError($"Invalid receipt: {ex.Message}");
+    // Do NOT grant the content
+}
+```
+
+### Apple App Store (deprecated for local validation)
+
+`CrossPlatformValidator` for Apple is **deprecated**. StoreKit 2 validates locally automatically. For server-side validation:
+
+```csharp
+var jwsRepresentation = order.Info.Apple?.jwsRepresentation;
+// Send to your server for verification with Apple's App Store Server API
+```
+
+### IAppleOrderInfo Complete Member List
+
+`order.Info.Apple` returns `IAppleOrderInfo?` (null on non-Apple platforms). Full member list:
+
+| Member | Type | Description |
+|---|---|---|
+| `jwsRepresentation` | `string?` | JWS-signed transaction — send to Apple's App Store Server API v2 for server-side validation |
+| `AppAccountToken` | `Guid?` | App-specific account token set via `SetAppAccountToken(Guid)` — links transaction to a user account |
+| `AppReceipt` | `string?` | Latest App Receipt (base64). May be null on reinstall; requires refreshing. Null on iOS ≤ 6. Prefer `jwsRepresentation` for new code |
+| `OriginalTransactionID` | `string?` | Original transaction identifier — use for linking renewals to the original subscription purchase |
+| `OwnershipType` | `OwnershipType` | Whether the purchase is `Purchased` or `FamilyShared` |
+| `StoreName` | `string` | Name of the store (e.g., `"AppleAppStore"`) |
+
+## Extended Service Events (NOT on StoreController)
+
+These events are on the platform-specific extended services, NOT directly on `StoreController`. Always null-check before subscribing (`?.` does not work with `+=`).
+
+```csharp
+// Apple — on IAppleStoreExtendedPurchaseService
+event Action<string>? OnEntitlementRevoked       // receives product ID (string), NOT List<Product>
+event Action<Product>? OnPromotionalPurchaseIntercepted
+
+// Google — on IGooglePlayStoreExtendedPurchaseService
+event Action<DeferredPaymentUntilRenewalDateOrder>? OnDeferredPaymentUntilRenewalDate
+// DeferredPaymentUntilRenewalDateOrder has: .CurrentOrder (Order), .SubscriptionOrdered (Product)
+```
+
+**Usage pattern** (cannot use `?.` with `+=`):
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+    store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += OnRevoked;
+```
+
+## AppleStoreExtendedProductService Key Members
+
+```csharp
+Dictionary<string, string> GetIntroductoryPriceDictionary()
+Dictionary<string, string> GetProductDetails()
+
+// Promotion order — prefer the CatalogListing ID overload for new code (v5.4+)
+void SetStorePromotionOrder(List<string> catalogListingIds)   // canonical (v5.4+)
+void SetStorePromotionOrder(List<Product> products)           // convenience wrapper
+
+// Promotion visibility — prefer the CatalogListing ID overload for new code (v5.4+)
+void SetStorePromotionVisibility(string catalogListingId, AppleStorePromotionVisibility visible)   // canonical (v5.4+)
+void SetStorePromotionVisibility(Product product, AppleStorePromotionVisibility visible)           // convenience wrapper
+
+// Fetch promotion order
+void FetchStorePromotionOrder(Action<List<Product>> successCallback, Action<string> errorCallback)
+
+// Fetch promotion visibility — prefer the CatalogListing ID overload for new code (v5.4+)
+void FetchStorePromotionVisibility(string catalogListingId, Action<string, AppleStorePromotionVisibility> successCallback, Action<string> errorCallback)  // canonical (v5.4+)
+void FetchStorePromotionVisibility(Product product, Action<string, AppleStorePromotionVisibility> successCallback, Action<string> errorCallback)          // convenience wrapper
+```
+
+**CRITICAL:** `AppleProductMetadata` does NOT expose `introductoryPrice`, `introductoryPriceLocale`, `introductoryNumberOfPeriods`, or `subscriptionPeriod` as public properties. Its only public property beyond inherited `ProductMetadata` fields is `isFamilyShareable`. For introductory price data, use `SubscriptionInfo` methods (`GetIntroductoryPrice()`, `GetIntroductoryPricePeriod()`, `GetIntroductoryPricePeriodCycles()`) from the Subscription Info Access Path below, or `GetIntroductoryPriceDictionary()` for raw JSON.
+
+## Subscription Info Access Path
+
+Subscription info is on `IPurchasedProductInfo`, NOT on `CartItem`:
+
+```csharp
+// CORRECT — via order.Info.PurchasedProductInfo
+var purchasedInfo = order.Info.PurchasedProductInfo?.FirstOrDefault(p => p.productId == productId);
+bool isSubscribed = purchasedInfo?.subscriptionInfo?.IsSubscribed() == Result.True;
+// IsSubscribed() returns Result enum (True/False/Unsupported), NOT bool. Use == Result.True for null-safe check.
+
+// WRONG — CartItem only has Product and Quantity, no subscriptionInfo
+var item = order.CartOrdered.Items().FirstOrDefault();
+item.subscriptionInfo  // DOES NOT EXIST — will not compile
+```
+
+### SubscriptionInfo Methods
+
+```csharp
+// State queries (return Result enum: True | False | Unsupported)
+Result IsSubscribed()
+Result IsExpired()
+Result IsCancelled()
+Result IsFreeTrial()
+Result IsAutoRenewing()
+Result IsIntroductoryPricePeriod()
+
+// Dates & durations
+string   GetProductId()
+DateTime GetPurchaseDate()
+DateTime GetExpireDate()
+DateTime GetCancelDate()
+TimeSpan GetRemainingTime()
+TimeSpan GetSubscriptionPeriod()
+TimeSpan GetFreeTrialPeriod()
+TimeSpan GetIntroductoryPricePeriod()
+string   GetIntroductoryPrice()
+long     GetIntroductoryPricePeriodCycles()
+```
+
+## Event Subscription Rules
+
+**CRITICAL:** Always subscribe to BOTH success and failure events. Not listening to failure events generates runtime warnings.
+
+| Call | Success event | Failure event (REQUIRED) |
+|---|---|---|
+| `FetchProducts()` | `OnProductsFetched` | `OnProductsFetchFailed` |
+| `FetchPurchases()` | `OnPurchasesFetched` | `OnPurchasesFetchFailed` |
+| `Connect()` | `OnStoreConnected` | `OnStoreDisconnected` |
+| `PurchaseProduct()` | `OnPurchasePending` | `OnPurchaseFailed` |
+| `CheckEntitlement()` | `OnCheckEntitlement` | — |
+
+**Always subscribe to `OnPurchaseDeferred`** — fires for Ask-to-Buy (iOS) and Google Play deferred purchases. Not subscribing means silently dropping deferred purchases.
+
+## Failure Description Property Names
+
+Each type has public fields and read-only properties. Both compile, but prefer the PascalCase properties:
+
+| Type | Field (lowercase) | Property (PascalCase) | NOT |
+|---|---|---|---|
+| `StoreConnectionFailureDescription` | `.message` | `.Message` | ~~`.reason`~~ |
+| `ProductFetchFailed` | — | `.FailureReason`, `.FailedFetchProducts` | — |
+| `FailedOrder` | — | `.FailureReason`, `.Details` | — |
+| `PurchasesFetchFailureDescription` | `.message`, `.failureReason` | `.Message`, `.FailureReason` | — |
+
+## CrossPlatformValidator
+
+```csharp
+// Google-only constructor (recommended — Apple local validation is a no-op under StoreKit 2)
+new CrossPlatformValidator(byte[] googlePublicKey, string googleBundleId)
+
+// Full constructor (legacy — Apple args are only needed for pre-StoreKit 2 builds)
+new CrossPlatformValidator(byte[] googlePublicKey, byte[] appleRootCert, string googleBundleId, string appleBundleId)
+
+// Validate
+IPurchaseReceipt[] Validate(string unityIAPReceipt)  // throws IAPSecurityException
+```
+
+**WARNING:** `CrossPlatformValidator` for Apple App Store is **deprecated**. `AppleTangle.Data()` is also deprecated. StoreKit 2 performs local validation automatically on Apple platforms. `CrossPlatformValidator` still works for Google Play validation.
+
+Supported stores (still active): `"GooglePlay"` | Deprecated: `"AppleAppStore"`, `"MacAppStore"`
+
+## Interface Hierarchy
+
+```
+StoreController implements:
+  IStoreService      - Connect(), Apple/Google service extensions
+  IProductService    - FetchProducts(), GetProducts(), GetProductById()
+  IPurchaseService   - PurchaseProduct(), ConfirmPurchase(), FetchPurchases(), Apple/Google purchase extensions
+```
+
+## IRunCommand Template: Fetch Products
+
+```csharp
+using UnityEngine;
+using UnityEngine.Purchasing;
+using System.Collections.Generic;
+
+namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
+{
+    internal class CommandScript : IRunCommand
+    {
+        public string Title => "Fetch IAP products";
+        public string Description => "Connects to the store and fetches product information.";
+        public async void Execute(ExecutionResult result)
+        {
+            var store = UnityIAPServices.StoreController();
+
+            // Subscribe to events BEFORE Connect
+            store.OnStoreConnected += () =>
+            {
+                var products = new List<ProductDefinition>
+                {
+                    new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+                    new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
+                };
+
+                store.OnProductsFetched += (fetched) =>
+                {
+                    foreach (var p in fetched)
+                        result.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
+                };
+                store.OnProductsFetchFailed += (failure) => result.LogError($"Product fetch failed: {failure.FailureReason}");
+
+                store.FetchProducts(products);
+            };
+            store.OnStoreDisconnected += (failure) => result.LogError($"Store disconnected: {failure.Message}");
+
+            await store.Connect();
+        }
+    }
+}
+```

--- a/skills/implement-in-app-purchases/references/codeless-catalog.md
+++ b/skills/implement-in-app-purchases/references/codeless-catalog.md
@@ -1,0 +1,331 @@
+# Editing `IAPProductCatalog.json`
+
+## Table of Contents
+
+- [Quick reference — minimal safe edit](#quick-reference--minimal-safe-edit)
+- [File location](#file-location)
+- [Schema](#schema)
+- [Serialization rules](#serialization-rules)
+  - [JsonUtility round-trip](#jsonutility-round-trip)
+  - [The `Price.data` decimal array](#the-pricedata-decimal-array)
+  - [Enum integers](#enum-integers)
+  - [Canonical store keys](#canonical-store-keys)
+  - [Non-ASCII characters in descriptions](#non-ascii-characters-in-descriptions)
+- [Validation — run before saving](#validation--run-before-saving)
+- [Post-edit refresh](#post-edit-refresh)
+- [When to escalate to the Editor window](#when-to-escalate-to-the-editor-window)
+- [Catalog as part of Codeless IAP](#catalog-as-part-of-codeless-iap)
+  - [Codeless vs scripted — which to use](#codeless-vs-scripted--which-to-use)
+  - [Auto-init race condition](#auto-init-race-condition)
+  - [Pushing the catalog to the storefronts](#pushing-the-catalog-to-the-storefronts)
+  - [Detection checklist](#detection-checklist)
+
+`Assets/Resources/IAPProductCatalog.json` is a Unity-managed JSON asset deserialized by `JsonUtility.FromJson<ProductCatalog>` (`Runtime/Purchasing/Extension/ProductCatalog.cs`). It can be edited safely outside the Editor as long as the serialization rules below are respected.
+
+## Quick reference — minimal safe edit
+
+1. **Read** the file as raw text. It is canonical JSON, single-line.
+2. **Parse** it into a dict/object.
+3. **Modify** fields using the schema and serialization rules below.
+4. **Write back** as JSON. Field name spelling and casing must match exactly; preserving order is not required.
+5. **Refresh** so the Editor / runtime sees the change (see [Post-edit refresh](#post-edit-refresh)).
+
+Adding a new $1.99 consumable `gems_50` in one operation:
+
+```jsonc
+{
+  "id": "gems_50",
+  "type": 0,
+  "storeIDs": [],
+  "defaultDescription": { "googleLocale": 21, "title": "50 Gems", "description": "A small pouch of gems." },
+  "screenshotPath": "",
+  "applePriceTier": 0,
+  "googlePrice": { "data": [199, 0, 0, 131072], "num": 1.99 },
+  "pricingTemplateID": "",
+  "descriptions": [],
+  "payouts": []
+}
+```
+
+Append to the `products` array, save, then trigger a refresh.
+
+## File location
+
+- **Current:** `Assets/Resources/IAPProductCatalog.json` (constant `ProductCatalog.kCatalogPath`)
+- **Legacy:** `Assets/Plugins/UnityPurchasing/Resources/IAPProductCatalog.json` (constant `ProductCatalog.kPrevCatalogPath`) — auto-migrated on Editor load via `ProductCatalogEditor.MigrateProductCatalog()`. If both exist, the current path wins.
+
+`Resources.Load("IAPProductCatalog")` deserializes it at runtime via `ProductCatalogImpl.LoadDefaultCatalog()`. The asset must remain under a `Resources/` directory for runtime load to succeed.
+
+## Schema
+
+```jsonc
+{
+  "appleSKU": "",                                  // app-level Apple SKU (Apple XML exporter)
+  "appleTeamID": "",                               // Apple team ID (Apple XML exporter)
+  "enableCodelessAutoInitialization": true,        // auto-init Unity IAP at runtime
+  "enableUnityGamingServicesAutoInitialization": false,
+  "products": [
+    {
+      "id": "gold_100",                            // canonical Unity SKU — required, non-empty, unique
+      "type": 0,                                   // ProductType int (see Enum integers)
+      "storeIDs": [                                // per-store override SKUs
+        { "store": "AppleAppStore", "id": "com.example.gold100" }
+      ],
+      "defaultDescription": {                      // required for export
+        "googleLocale": 21,                        // TranslationLocale int (en_US = 21)
+        "title": "",
+        "description": ""
+      },
+      "screenshotPath": "",                        // Apple screenshot path (optional)
+      "applePriceTier": 0,                         // Apple price tier (Apple XML exporter)
+      "googlePrice": { "data": [99,0,0,131072], "num": 0.99 },  // see Price.data
+      "pricingTemplateID": "",                     // Google Play pricing template
+      "descriptions": [                            // additional locale variants
+        { "googleLocale": 30, "title": "...", "description": "..." }
+      ],
+      "payouts": [                                 // optional grant metadata
+        { "t": "Currency", "st": "Gold", "q": 100, "d": "" }
+      ]
+    }
+  ]
+}
+```
+
+Per-product required fields for the runtime to accept the product: `id` (non-empty, trimmed). Everything else is optional at runtime; exporters and the Editor window enforce stricter rules (see [Validation](#validation--run-before-saving)).
+
+## Serialization rules
+
+### JsonUtility round-trip
+
+- Field names are **case-sensitive** and must match the `[SerializeField]` field names in `ProductCatalog.cs` exactly. The visible field names you see in the JSON (e.g. `title`, `description` inside `LocalizedProductDescription`) are the **backing field** names, not the public C# property names (`Title`, `Description`).
+- Unknown fields are silently dropped on the next save.
+- Missing fields deserialize to default values (`0`, `""`, empty list, etc.) — safe to omit defaults, but the Editor window writes them out explicitly.
+- The file is normally a single line — pretty-printing is fine, but JsonUtility re-emits as one line on the next Editor save.
+- Do not change the top-level key set. `appleSKU`, `appleTeamID`, `enableCodelessAutoInitialization`, `enableUnityGamingServicesAutoInitialization`, and `products` are all `[SerializeField]`-bound — removing keys is fine (they default), but renaming silently loses data.
+
+### The `Price.data` decimal array
+
+`Price` is the trickiest field. It serializes a `decimal` via two mirror fields and **`data` is authoritative on read**:
+
+```csharp
+public void OnBeforeSerialize() {
+    data = decimal.GetBits(value);        // int[4]: [low, mid, high, flags]
+    num  = decimal.ToDouble(value);
+}
+public void OnAfterDeserialize() {
+    if (data != null && data.Length == 4)
+        value = new decimal(data);        // num is ignored on read
+}
+```
+
+`data` is the `decimal.GetBits` representation: `[low32 mantissa, mid32 mantissa, high32 mantissa, flags]`.
+
+The `flags` int encodes scale (decimal places) and sign:
+- Bits 16–23: scale (0–28)
+- Bit 31: sign (0 = positive, 1 = negative; negative prices are never valid here)
+- All other bits: unused, must be 0
+
+For scale 2 (cents-style prices): `flags = 0x00020000 = 131072`
+For scale 0 (yen / whole-unit prices): `flags = 0`
+
+| Price (display) | Mantissa | Scale | `data` |
+|---|---|---|---|
+| 0.99 | 99 | 2 | `[99, 0, 0, 131072]` |
+| 1.99 | 199 | 2 | `[199, 0, 0, 131072]` |
+| 2.99 | 299 | 2 | `[299, 0, 0, 131072]` |
+| 4.99 | 499 | 2 | `[499, 0, 0, 131072]` |
+| 9.99 | 999 | 2 | `[999, 0, 0, 131072]` |
+| 19.99 | 1999 | 2 | `[1999, 0, 0, 131072]` |
+| 99.99 | 9999 | 2 | `[9999, 0, 0, 131072]` |
+| 1000 (¥, ₩) | 1000 | 0 | `[1000, 0, 0, 0]` |
+
+Formula for arbitrary positive prices with up to 2³¹−1 unscaled units:
+
+```
+unscaled = round(price * 10^scale)           // e.g. 2.99 with scale=2 → 299
+data     = [unscaled, 0, 0, scale << 16]
+```
+
+Keep `num` in sync with the display price even though it's not read — the Editor reads it diagnostically and the file diffs more readably.
+
+For prices larger than ~$21M (unscaled > 2³¹−1), the high two ints carry the overflow — at that point invoke Unity in batchmode and let `Price.OnBeforeSerialize` do the conversion, rather than constructing the bits by hand.
+
+### Enum integers
+
+`ProductType` (`type` field):
+
+| Int | Enum | Use for |
+|---|---|---|
+| 0 | `Consumable` | Coins, gems, lives, ammo — granted then consumed |
+| 1 | `NonConsumable` | One-time unlocks, remove-ads, character packs |
+| 2 | `Subscription` | Recurring entitlements |
+
+`TranslationLocale` (`googleLocale` field): the int is the zero-based index into the enum declared in `Runtime/Purchasing/Extension/ProductCatalog.cs`. Common values:
+
+| Int | Locale |
+|---|---|
+| 13 | `zh_CN` |
+| 14 | `zh_TW` |
+| 17 | `da_DK` |
+| 18 | `nl_NL` |
+| 21 | `en_US` (default for new descriptions) |
+| 22 | `en_GB` |
+| 30 | `fr_FR` |
+| 33 | `de_DE` |
+| 41 | `it_IT` |
+| 42 | `ja_JP` |
+| 46 | `ko_KR` |
+| 63 | `pl_PL` |
+| 64 | `pt_BR` |
+| 69 | `ru_RU` |
+| 75 | `es_ES` |
+
+For anything outside this list, count from the top of the `TranslationLocale` enum in `ProductCatalog.cs` — the order is the index.
+
+`ProductCatalogPayoutType` (`payouts[].t` field): **serialized as a string**, not an int. Valid values: `"Other"`, `"Currency"`, `"Item"`, `"Resource"`.
+
+### Canonical store keys
+
+`storeIDs[].store` must be one of the keys validated by `ProductCatalogEditor.kStoreKeys`:
+
+- `AppleAppStore`
+- `GooglePlay`
+- `MacAppStore`
+
+Using `"Apple"`, `"apple"`, `"google"`, etc. won't crash but the override will not be picked up by the runtime store routing. An empty `storeIDs` array means the product's `id` is used as the platform SKU on every store.
+
+### Non-ASCII characters in descriptions
+
+`LocalizedProductDescription.Title` / `Description` setters encode any character with code point > 127 as `\uXXXX` (`EncodeNonLatinCharacters` in `ProductCatalog.cs`). The getter regex-decodes both forms. So both representations work on read:
+
+```jsonc
+{ "title": "Caf\\u00e9 Pack" }   // Editor-written form
+{ "title": "Café Pack" }          // raw UTF-8 — also accepted on read
+```
+
+**Prefer the `\uXXXX` form** when writing programmatically, to match what the Editor will round-trip the file into on the next save. Mixed forms in one file are fine but the next Editor save normalizes everything to escaped form.
+
+Subtype `payouts[].st` has a 64-char max (`ProductCatalogPayout.MaxSubtypeLength`). Subtype `payouts[].d` (data) has a 1024-char max (`MaxDataLength`).
+
+## Validation — run before saving
+
+These mirror the Editor window's validation. Verify each before writing:
+
+**Per product:**
+- `id` is non-empty after trim. (`ProductCatalog.allValidProducts` filters on this.)
+- `id` is unique across all products in the array (the Editor flags duplicates).
+- `type` ∈ `{0, 1, 2}`.
+- Every `defaultDescription.googleLocale` and `descriptions[].googleLocale` is a valid int index into `TranslationLocale`.
+- `storeIDs[].store` ∈ canonical store keys.
+- If `googlePrice.data` is present, it is a 4-element int array; sign bit (bit 31 of `data[3]`) is 0.
+
+**Per-exporter (only if export is intended):**
+
+- **Apple XML** (`AppleXMLProductCatalogExporter.Validate`):
+  - Catalog-level: `appleSKU` non-empty, `appleTeamID` non-empty, no duplicate product IDs, no duplicate Apple store IDs, no duplicate runtime IDs.
+  - Per item: `id` non-empty, `defaultDescription.Title` non-empty, `defaultDescription.Description` non-empty, **`screenshotPath` non-empty (required, not optional)**.
+  - `applePriceTier` is written to the XML (`<wholesale_price_tier>`) but not validated — any int is accepted.
+- **Google CSV** (`GooglePlayProductCatalogExporter.Validate`):
+  - Catalog-level: no duplicate product IDs, no duplicate Google store IDs, no duplicate runtime IDs.
+  - Per item: `id` non-empty AND must start with a lowercase letter or digit AND contain only `a-z`, `0-9`, `_`, `.` (same rule applies to `storeIDs[].id` for the `GooglePlay` override).
+  - Description rules (apply to `defaultDescription` and every entry in `descriptions`):
+    - `Title` non-empty; ≤ 55 chars (error if longer); warning if > 25 chars.
+    - `Description` non-empty; ≤ 80 chars (error if longer).
+  - Price: either `googlePrice.value` ≠ 0 (i.e. non-zero `data` mantissa) **or** `pricingTemplateID` non-empty.
+
+**Top-level:**
+- `enableCodelessAutoInitialization` is a bool, not 0/1.
+- If the catalog ends up empty (no products with non-empty `id`), `CodelessIAPStoreListener.InitializeCodelessPurchasingOnLoad` short-circuits — flipping the auto-init flag in that state has no effect until a product is added.
+
+## Post-edit refresh
+
+The Unity Editor caches `IAPProductCatalog` as a `TextAsset` keyed by Resources path. After writing the JSON externally:
+
+- **Editor open, not in Play Mode:** Unity detects external changes on next focus and re-imports the asset automatically (`AssetDatabase`'s file watcher). If you want to force it from the Editor side, run **Assets → Refresh** (Ctrl/Cmd+R). The next `Resources.Load("IAPProductCatalog")` call will see the new contents.
+- **Editor open, in Play Mode:** the runtime `TextAsset` was loaded at play-start and is cached. Changes won't be picked up until play mode is restarted (or you re-call `Resources.Load` after `AssetDatabase.ImportAsset` to bypass the cache).
+- **Editor closed:** edits are picked up next time the Editor opens.
+- **Player build:** the catalog is baked into the build at build-time. Edits after build do nothing — rebuild required.
+
+For batchmode-driven workflows that need a guaranteed refresh:
+
+```
+"<unity>/Unity.exe" -batchmode -quit -projectPath "<path>" -logFile -
+```
+
+Plain batchmode without `-executeMethod` is enough to trigger asset import on startup. The next Editor session will see the change.
+
+## When to escalate to the Editor window
+
+Hand the user back to the IAP Catalog window (Services → In-App Purchasing → IAP Catalog…) when:
+
+- The decimal price is larger than ~$21M (would need the high mantissa ints — let `Price.OnBeforeSerialize` do it).
+- You need to set up many `payouts` with custom subtypes — the Editor has inline validation on lengths.
+- The user wants to use **App Store Export** (Apple XML / Google CSV) — that flow is a Unity dialog with its own validation results panel.
+- You hit a JsonUtility round-trip error you can't diagnose from the schema rules above.
+
+For everything else — adding/removing products, changing prices in normal ranges, toggling auto-init flags, updating descriptions, adding store ID overrides — direct file edits are safe and faster than driving the Editor UI.
+
+---
+
+## Catalog as part of Codeless IAP
+
+The catalog file plays two distinct roles in the package. Knowing which one applies in the current project changes how edits are made and what side-effects to expect.
+
+### Codeless vs scripted — which to use
+
+| Use case | Path |
+|---|---|
+| Ship a buy button with zero C# | **Codeless** — catalog + `CodelessIAPButton` |
+| Custom UI states, server validation, granular control of the purchase flow | **Scripted** — `StoreController` + an `IAPManager` (see [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md)) |
+| Catalog-managed product list + scripted purchase flow | **Mixed** — catalog drives `CodelessIAPStoreListener` for product registration, scripted code subscribes to its events |
+| Export products to Apple Application Loader / Play Console | Codeless catalog — the only built-in export path |
+
+Default recommendation when starting a new project from scratch: scripted IAP. Codeless is convenient for prototypes but couples the project to a global singleton (`CodelessIAPStoreListener.Instance`) and hides the init/purchase flow most production games eventually need to customize.
+
+### Auto-init race condition
+
+If the project has **both** a non-empty `IAPProductCatalog.json` with `enableCodelessAutoInitialization: true` **and** a scripted `StoreController` initialized in user code, two init paths race for the same native store. Symptoms:
+
+- Duplicate `OnPurchasePending` callbacks (one per init's listener set).
+- "Store already connected" warnings on `Connect()`.
+- Unpredictable which init's product list wins.
+
+Mitigations (pick one):
+
+1. **Keep scripted, disable codeless:** set `"enableCodelessAutoInitialization": false` in the catalog JSON. The catalog stays available for `ProductCatalog.LoadDefaultCatalog()` calls.
+2. **Keep codeless, remove scripted init:** delete the user's `StoreController` setup; rely on `CodelessIAPStoreListener.Instance`.
+3. **Empty the catalog:** clear `products` to `[]`. `CodelessIAPStoreListener.InitializeCodelessPurchasingOnLoad` short-circuits on empty catalogs even with the flag on.
+
+Surface this before adding scripted IAP to a project that already has a non-empty catalog.
+
+### Pushing the catalog to the storefronts
+
+The IAP Catalog window's **App Store Export** button opens `ProductCatalogExportWindow`, which generates bulk-import files. Nothing in the package calls App Store Connect or Play Console APIs directly — devs upload the generated files manually.
+
+| Exporter | Output | Upload destination |
+|---|---|---|
+| `AppleXMLProductCatalogExporter` | Application Loader XML | App Store Connect → Transporter / Application Loader |
+| `GooglePlayProductCatalogExporter` | CSV | Play Console → In-app products → Import |
+
+Editing the JSON directly populates the same fields the exporters read; the validation surface in the Editor window (`ExporterValidationResults`) is the user-visible signal that fields are missing.
+
+### Detection checklist
+
+When triaging an IAP issue or planning changes, check in order:
+
+1. Does `Assets/Resources/IAPProductCatalog.json` exist?
+2. Is `enableCodelessAutoInitialization` true? (`grep enableCodelessAutoInitialization Assets/Resources/IAPProductCatalog.json`)
+3. Are there `CodelessIAPButton` or legacy `IAPButton` components in scenes/prefabs?
+4. Does user code construct a `StoreController` directly (or call `UnityIAPServices.StoreController(...)`)?
+5. Does user code reference `CodelessIAPStoreListener.Instance`?
+
+Routing the result:
+
+| Catalog | autoInit | Scripted `StoreController` | Action |
+|---|---|---|---|
+| present (non-empty) | true | absent | Pure codeless — edit the catalog freely. |
+| present (non-empty) | true | present | **Race condition** — surface to the user, apply one of the three mitigations. |
+| present | false | present | Catalog is dormant unless `ProductCatalog.LoadDefaultCatalog()` is called from user code. Edits safe. |
+| present (empty) | true or false | present | Codeless auto-init short-circuits on empty catalog. Treat as scripted-only. |
+| absent | n/a | present | Standard scripted IAP. See [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md). |
+| absent | n/a | absent | No IAP — see [pre-check.md](pre-check.md) routing. |

--- a/skills/implement-in-app-purchases/references/convert-adapty.md
+++ b/skills/implement-in-app-purchases/references/convert-adapty.md
@@ -1,0 +1,270 @@
+# Adapty — Conversion Assessment and Guidance
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Overview](#overview)
+- [Step 1 — Check If Already in Observer Mode](#step-1--check-if-already-in-observer-mode)
+- [Step 2 — Feature Support Check](#step-2--feature-support-check)
+- [Step 3 — Native Google BillingClient Check](#step-3--native-google-billingclient-check)
+- [Step 4 — Route to Outcome](#step-4--route-to-outcome)
+- [Case 1 — Already in Observer Mode with Unity IAP 5](#case-1--already-in-observer-mode-with-unity-iap-5)
+- [Case 2 — Unsupported Features Detected](#case-2--unsupported-features-detected)
+- [Case 3 — No Blockers, Conversion Is Viable](#case-3--no-blockers-conversion-is-viable)
+
+Use this reference when the project has Adapty (`AdaptySDK-Unity`) installed and the user wants to **replace or remove Adapty** and switch to Unity IAP 5 (`com.unity.purchasing`). This path does not cover adding Unity IAP 5 alongside Adapty for non-IAP purposes.
+
+---
+
+## Trigger Phrases
+
+- "Replace Adapty SDK with Unity IAP"
+- "Remove Adapty and use Unity IAP"
+- "Migrate from Adapty to Unity IAP"
+- "Use Unity IAP 5 to handle store purchases and work with Adapty"
+- "Make Adapty work with Unity IAP 5"
+
+---
+
+## Overview
+
+Adapty is architecturally independent from Unity IAP — it has its own native Swift (iOS) and Kotlin (Android) SDKs that call Apple StoreKit and Google BillingClient directly. There is no simple swap. Conversion requires assessing which Adapty features the project uses and whether Unity IAP 5 can replace them.
+
+This path always produces one of three outcomes:
+
+| Case | Condition | Outcome |
+|---|---|---|
+| **1** | Already in observer mode with Unity IAP 5 | Report — no action needed |
+| **2** | Adapty-only features are in active use | Report limitations, present two choices |
+| **3** | No blockers — only basic purchase flow used | Present two conversion choices |
+
+Run Steps 1–3 in order. Collect all findings before routing.
+
+---
+
+## Step 1 — Check If Already in Observer Mode
+
+### 1a — Check Unity IAP 5 is installed
+
+Search `Packages/manifest.json` for `com.unity.purchasing` with a version matching `5\.`. Record whether it is present.
+
+### 1b — Check Adapty observer mode configuration
+
+Search `Assets/**/*.cs` for:
+
+```
+Adapty\.Activate.*observerMode|observerMode\s*=\s*true|AdaptyProfileParameters|ReportTransaction
+```
+
+Also search for `AdaptyObserverModeDelegate` or any class implementing it.
+
+If found, observer mode is active.
+
+**If both Unity IAP 5 is installed AND observer mode is active → this is Case 1. Skip Step 2 and go directly to [Case 1](#case-1--already-in-observer-mode-with-unity-iap-5).**
+
+Otherwise continue to Step 2.
+
+---
+
+## Step 2 — Feature Support Check
+
+Search `Assets/**/*.cs`, `Assets/**/*.prefab`, and `Assets/**/*.unity` for usage of Adapty features that have **no Unity IAP 5 equivalent**. Record every feature found.
+
+### 2a — Remote Paywalls / Paywall Builder
+
+```
+GetPaywall|PaywallView|AdaptyUI|AdaptyPaywall|GetPaywallForDefaultAudience|ShowPaywall|PresentCodeRedemptionSheet
+```
+
+Also check `Packages/manifest.json` or imported packages for `adapty-ui` or `AdaptyUI`.
+
+**What it means:** Adapty's Paywall Builder lets you configure paywall layouts and copy remotely without an app update. Unity IAP 5 has no remote paywall system — all products and UI must be defined in code or a local catalog. **Note: Paywall Builder is also unavailable in Adapty's own Observer Mode**, so even a partial migration loses this feature.
+
+### 2b — A/B Testing / Experiments
+
+```
+variationId|GetPaywall.*audience|LogShowPaywall|LogStartCheckout
+```
+
+**What it means:** Adapty runs A/B tests on paywall layouts and pricing server-side. Unity IAP 5 has no A/B testing capability. In Adapty Observer Mode, A/B testing also requires significant additional coding and is not automatic.
+
+### 2c — Cross-Platform Entitlement Sync
+
+```
+Adapty\.Identify|Adapty\.Profile|AdaptyProfile|accessLevels|isActive
+```
+
+Specifically look for `Adapty.Identify` being called with a customer user ID — this indicates the project relies on Adapty as the cross-platform entitlement source of truth (a user who buys on iOS retains access on Android). Unity IAP 5 has no cross-platform entitlement layer.
+
+### 2d — Webhook-Driven Backend Events
+
+Search `Assets/**/*.cs` for patterns suggesting backend subscription event handling:
+
+```
+webhook|SubscriptionCancelled|BillingIssue|AccessLevelUpdated
+```
+
+Also ask the user: *"Does your backend receive Adapty webhook events for subscription renewals, cancellations, or billing issues?"* If yes, flag this — Unity IAP 5 delivers no server-side lifecycle events.
+
+### 2e — Third-Party Analytics Integrations
+
+```
+AdaptyAttributionNetwork|UpdateAttribution|SetFallbackPaywalls|Amplitude|Mixpanel|AppsFlyer|Adjust
+```
+
+**What it means:** Adapty forwards purchase and paywall events to third-party analytics tools automatically. Unity IAP 5 has no such integration layer — you would need to instrument each event manually.
+
+---
+
+## Step 3 — Native Google BillingClient Check
+
+Search the following for custom native billing code alongside Adapty:
+
+- `Assets/**/*.cs` for: `AndroidJavaObject|AndroidJavaClass|BillingClient|BillingManager|GoogleBilling`
+- `Assets/Plugins/Android/**/*.java`, `*.kt` for: `com\.android\.billingclient`
+
+**If found:** The project has custom native Google BillingClient code in addition to Adapty. This is unusual — flag it to the user. Native BillingClient code will conflict with Unity IAP 5 at runtime and must be removed or replaced as part of the conversion. Add it to the blockers list in Case 2 if active and not just scaffolding.
+
+---
+
+## Step 4 — Route to Outcome
+
+Evaluate findings from Steps 2 and 3:
+
+```
+If native BillingClient detected (Step 3)      → Case 2 (flag as additional blocker)
+If any Step 2 feature detected                 → Case 2
+If no blockers from Steps 2 or 3              → Case 3
+```
+
+If multiple blockers are found, list all of them in the Case 2 report — do not stop at the first.
+
+---
+
+## Case 1 — Already in Observer Mode with Unity IAP 5
+
+**Condition:** Unity IAP 5 installed and Adapty already configured in observer mode.
+
+Report and stop:
+
+> "This project already has Unity IAP 5 installed and Adapty is running in observer mode. Unity IAP 5 handles purchase transactions and Adapty validates and tracks them server-side via `ReportTransaction`.
+>
+> If you want to remove Adapty entirely, re-run this skill and specify that you want to stop using Adapty. That will route to a full removal assessment."
+
+Do not make any changes.
+
+---
+
+## Case 2 — Unsupported Features Detected
+
+**Condition:** One or more Adapty-only features are in active use.
+
+Produce a blockers report listing every issue found, then present two choices:
+
+> "The following Adapty features are in use that have no Unity IAP 5 equivalent:
+>
+> [List all detected blockers, e.g.:]
+> - **Remote Paywalls / Paywall Builder** (`GetPaywall` / `AdaptyUI` detected): Unity IAP 5 has no remote paywall system. Paywall layouts and copy must be hardcoded. Note: Adapty's Paywall Builder is also unavailable in Adapty Observer Mode — switching to observer mode does not preserve this feature.
+> - **A/B Testing** (`variationId` / `logShowPaywall` detected): Unity IAP 5 has no A/B testing. In Adapty Observer Mode, A/B testing requires significant additional manual instrumentation and is not automatic.
+> - **Cross-platform entitlement sync** (`Adapty.Identify` detected): Unity IAP 5 has no cross-platform entitlement layer. A user who purchases on iOS will not retain access on Android without a custom server-side solution.
+> - **Webhook-driven backend events**: Your backend appears to receive Adapty subscription events. Unity IAP 5 delivers no server-side lifecycle events — you would need to build your own subscription tracking infrastructure.
+> - **Third-party analytics integrations**: Adapty forwards purchase events to [detected tools]. Unity IAP 5 has no integration layer — each event would need manual instrumentation.
+>
+> **Your options:**
+>
+> **(a) Stop conversion (recommended)** — Keep Adapty as the billing backend. The features in use have no Unity IAP 5 equivalent. No changes will be made.
+>
+> **(b) Convert to observer mode + Unity IAP 5 anyway** — Unity IAP 5 takes over purchase transactions. Adapty switches to observer mode for server-side validation and lifecycle tracking. You accept the following consequences:
+> - Adapty Paywall Builder stops working — you must build replacement paywall UI in Unity.
+> - [List each unsupported feature and its specific consequence.]
+> - BillingClient Gradle conflict between Unity IAP 5 and Adapty must be resolved by excluding the conflicting dependency.
+>
+> Which would you like to do?"
+
+If the user chooses **(a)**: stop, make no changes.
+
+If the user chooses **(b)**: continue with [Case 3, Path A](#path-a--convert-to-observer-mode--unity-iap-5) but preface the report with a clear warning documenting every accepted consequence.
+
+---
+
+## Case 3 — No Blockers, Conversion Is Viable
+
+**Condition:** No Adapty-only features detected — the project uses Adapty only for basic purchase flow.
+
+Present two choices:
+
+> "No blockers were found. The project uses Adapty only for basic purchase initiation and receipt handling (no remote paywalls, no cross-platform entitlements, no A/B testing). Two conversion paths are available:
+>
+> **(a) Observer mode + Unity IAP 5** — Unity IAP 5 handles purchase transactions. Adapty stays in observer mode, receiving `ReportTransaction` calls for server-side validation and subscription lifecycle tracking. Lower risk — Adapty's subscription event webhooks and analytics continue to work.
+>
+> **(b) Full removal — Unity IAP 5 only** — Adapty is removed entirely. Unity IAP 5 handles all billing. You lose Adapty's server-side receipt validation, subscription lifecycle tracking, and analytics. If the project had any Adapty paywall UI, replacement purchase UI must be built in Unity. Simpler architecture, no Adapty subscription cost.
+>
+> Which path would you like?"
+
+---
+
+### Path A — Convert to Observer Mode + Unity IAP 5
+
+1. **Install Unity IAP 5** if not already present — follow Step 1 of [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md).
+
+2. **Resolve the BillingClient Gradle conflict.** Both SDKs bundle `com.android.billingclient`. Add the following to `Assets/Plugins/Android/mainTemplate.gradle` inside the `android { }` block:
+
+   ```groovy
+   configurations.all {
+       exclude group: 'com.android.billingclient', module: 'billing'
+   }
+   ```
+
+   Then run **Assets > External Dependency Manager > Android Resolver > Delete Resolved Libraries**, followed by **Force Resolve**.
+
+3. **Enable Adapty observer mode.** In the `Adapty.Activate` call, set `observerMode: true`:
+
+   ```csharp
+   var config = new AdaptyConfig("YOUR_PUBLIC_SDK_KEY")
+   {
+       ObserverMode = true
+   };
+   Adapty.Activate(config);
+   ```
+
+4. **Implement Unity IAP 5 purchase flow.** Follow [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md) using the product catalog extracted from existing Adapty `GetPaywall` calls or hardcoded product IDs found in the codebase.
+
+5. **Call `Adapty.ReportTransaction()` after every confirmed purchase.** In the Unity IAP `OnPurchasePending` handler, after granting content and saving, report the transaction to Adapty:
+
+   ```csharp
+   Adapty.ReportTransaction(transactionId, null, (error) =>
+   {
+       if (error != null) Debug.LogWarning($"Adapty ReportTransaction failed: {error}");
+   });
+   ```
+
+   On Android, also call `Adapty.RestorePurchases` at app startup to sync any purchases Adapty may have missed.
+
+6. **Produce a verification report** covering:
+   - Files changed
+   - Gradle conflict resolution confirmed
+   - Adapty observer mode configuration location
+   - `ReportTransaction` call location in purchase flow
+   - Manual steps: verify Adapty dashboard shows purchases from the updated build in sandbox; confirm Paywall Builder is no longer used (unavailable in observer mode)
+
+---
+
+### Path B — Full Removal of Adapty
+
+1. **Extract the product catalog** from existing Adapty usage — search for hardcoded product ID strings and `GetPaywall` / `GetPaywallForDefaultAudience` calls.
+
+2. **Identify any Adapty paywall UI** — search for `AdaptyUI`, `PaywallView`, or `ShowPaywall`. These views must be replaced with custom Unity UI wired to `IAPManager.Buy(productId)`. Inform the user that building replacement shop UI is required before removal.
+
+3. **Implement Unity IAP 5** using the extracted catalog — follow [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md) in full.
+
+4. **Remove Adapty SDK references from code.** Search `Assets/**/*.cs` for `using Adapty;` and all `Adapty.*` calls. Replace purchase calls with the Unity IAP 5 equivalents from the new `IAPManager`. Remove paywall presentation calls — these must be replaced by the new shop UI.
+
+5. **Remove the Adapty package.** Delete the imported Adapty `.unitypackage` files from `Assets/` (typically under `Assets/Adapty/`). Remove any EDM4U dependency files Adapty registered.
+
+6. **Run Assets > External Dependency Manager > Android Resolver > Force Resolve** after package removal to clean up Adapty's native dependencies.
+
+7. **Produce a verification report** covering:
+   - Files changed and Adapty references removed
+   - Product catalog — confirm all product IDs are preserved in Unity IAP 5
+   - Paywall UI — confirm replacement UI is in place or listed as a pending TODO
+   - Manual steps: verify no orphaned Adapty Gradle entries remain in the Android build; confirm sandbox purchases succeed end-to-end with Unity IAP 5

--- a/skills/implement-in-app-purchases/references/convert-essentialkit.md
+++ b/skills/implement-in-app-purchases/references/convert-essentialkit.md
@@ -1,0 +1,239 @@
+# Convert Essential Kit Billing to Unity IAP 5
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Important Constraints](#important-constraints)
+- [Step 1 — Verify Essential Kit Billing Is Active](#step-1--verify-essential-kit-billing-is-active)
+- [Step 2 — Extract Product Definitions](#step-2--extract-product-definitions)
+- [Step 3 — Migration Report (produce before any edits)](#step-3--migration-report-produce-before-any-edits)
+- [Step 4 — Add Unity IAP 5](#step-4--add-unity-iap-5)
+- [Step 5 — Disable Essential Kit Billing](#step-5--disable-essential-kit-billing)
+- [Step 6 — Remove Conflicting Gradle Dependency](#step-6--remove-conflicting-gradle-dependency)
+- [Step 7 — Essential Kit → Unity IAP Concept Mapping](#step-7--essential-kit--unity-iap-concept-mapping)
+- [Step 8 — Verification Report](#step-8--verification-report)
+
+Use this reference when the project uses Essential Kit (VoxelBusters) Billing Services and needs to be converted to `com.unity.purchasing` (Unity IAP 5). Always install the latest stable version of Unity IAP.
+
+---
+
+## Trigger Phrases
+
+- "Convert Essential Kit billing function to Unity IAP"
+- "Replace VoxelBusters Essential Kit IAP with Unity IAP"
+- "Migrate from Essential Kit in-app purchases to Unity IAP"
+- "Remove Essential Kit billing and use Unity IAP"
+
+---
+
+## Important Constraints
+
+- **Do not delete any Essential Kit source files.** Disabling the Billing service toggle in settings is sufficient to prevent Essential Kit from initializing native billing at runtime. No C# source changes are needed.
+- **Leave all other Essential Kit services completely untouched.** Only the Billing service and its Gradle dependency are affected.
+- **Do not change product IDs.** The same IDs used in Essential Kit must be used in Unity IAP to preserve store history and existing purchases.
+- **Do not change backend validation endpoints** unless the receipt format change makes it unavoidable — document any required backend change.
+- **This path covers store billing (Apple App Store / Google Play) only.** Do not consider IAP D2C Capabilities / third-party payment provider migration here.
+
+---
+
+## Step 1 — Verify Essential Kit Billing Is Active
+
+### 1a — Confirm Essential Kit is installed
+
+Search `Packages/manifest.json` for `com.voxelbusters.essentialkit` and check that `Assets/Plugins/VoxelBusters/` exists.
+
+### 1b — Check Billing service is enabled
+
+Read `Resources/EssentialKitSettings.asset` (Unity YAML serialized file). Search for the Billing Services enabled flag:
+
+```
+billingServicesEnabled|isBillingServicesEnabled|BillingServices.*enabled: 1
+```
+
+Also inspect the file for any `BillingServicesSettings` section.
+
+If the Billing service flag is **not set to enabled (1)**, stop and report:
+
+> "Essential Kit Billing Services is not enabled in Project Settings (Window > Voxel Busters > Essential Kit > Open Settings → Services). There is nothing to convert."
+
+Do not proceed.
+
+### 1c — Check Unity IAP package status
+
+Search `Packages/manifest.json` for `com.unity.purchasing`. If absent or outdated, install the latest stable version via Package Manager before continuing.
+
+---
+
+## Step 2 — Extract Product Definitions
+
+Read `Resources/EssentialKitSettings.asset` and locate the products array under `BillingServicesSettings`. Each product entry contains:
+
+| Essential Kit Field | Description |
+|---|---|
+| `Id` | Internal product identifier used in code (e.g., `coins_100`) |
+| `PlatformId` | Common store product ID across platforms |
+| `PlatformIdOverrides` | Per-platform IDs — separate entries for iOS (`AppleAppStore`) and Android (`GooglePlay`) |
+| `ProductType` | `Consumable`, `NonConsumable`, or `Subscription` |
+| `Title` | Display name |
+| `Description` | User-facing description |
+
+If **no products are defined** in the settings asset, stop and report:
+
+> "No billing products found in Essential Kit Billing Settings. There is nothing to convert."
+
+Do not proceed.
+
+### Product type mapping
+
+| Essential Kit `BillingProductType` | Unity IAP `ProductType` |
+|---|---|
+| `Consumable` | `ProductType.Consumable` |
+| `NonConsumable` | `ProductType.NonConsumable` |
+| `Subscription` | `ProductType.Subscription` |
+
+### Store-specific IDs
+
+If `PlatformIdOverrides` has separate Apple and Google IDs, use `StoreSpecificIds` in the `ProductDefinition`:
+
+```csharp
+new ProductDefinition("coins_100", ProductType.Consumable,
+    new StoreSpecificIds
+    {
+        { AppleAppStore.Name, "apple_coins_100" },
+        { GooglePlay.Name, "google_coins_100" }
+    })
+```
+
+If only a single `PlatformId` is used, pass it directly as the product ID.
+
+---
+
+## Step 3 — Migration Report (produce before any edits)
+
+Generate all sections before touching any file.
+
+1. **Essential Kit billing architecture** — event-based (`OnTransactionStateChange`), auto-finish vs manual-finish mode (`AutoFinishTransactions` setting)
+2. **Files using Essential Kit Billing** — C# files referencing `BillingServices`, scene/prefab shop UI
+3. **Product catalog extracted** — all products with ID, type, and store-specific IDs
+4. **Auto Finish Transactions setting** — if disabled, the project uses server-side verification; document the receipt field mapping change (see Step 7)
+5. **Backend validation mapping** — how receipt data sent to backend changes
+6. **Restore flow mapping** — `RestorePurchases()` → `store.RestoreTransactions()` + `store.FetchPurchases()`
+7. **UI wiring** — shop buttons and callbacks that will need rewiring to Unity IAP events
+8. **Proposed Unity IAP architecture** — new files, product catalog definition
+9. **Files to create / modify**
+10. **Manual steps required** — listed in Step 8
+
+---
+
+## Step 4 — Add Unity IAP 5
+
+Use the product catalog extracted in Step 2 as input and follow **`path-add-iap-to-new-project.md`** for the full Unity IAP 5 implementation. Specifically:
+
+- Match the project's existing patterns for the IAPManager (Step 4 of that file).
+- Apply the save-before-confirm contract (Step 5 of that file).
+- Apply product type behavior rules (Step 6 of that file) — note that consumable restore rules are the same: do not restore old consumable orders.
+- Use the existing save system found in the project (Step 7 of that file).
+- Rewire existing shop UI buttons to `IAPManager.Buy(productId)` (Step 8 of that file).
+
+Do not duplicate content from `path-add-iap-to-new-project.md` — reference it.
+
+---
+
+## Step 5 — Disable Essential Kit Billing
+
+After Unity IAP is in place, disable the Essential Kit Billing service to prevent it from initializing its own native billing layer (which would conflict with Unity IAP at runtime).
+
+**Edit `Resources/EssentialKitSettings.asset`** — set the Billing Services enabled flag to `0`:
+
+```yaml
+# Before
+billingServicesEnabled: 1
+
+# After
+billingServicesEnabled: 0
+```
+
+Do not modify any other field in this file. Do not delete the file. Do not touch any other section of the settings asset.
+
+This single change prevents Essential Kit from calling `BillingClient.startConnection()` (Android) or initializing StoreKit (iOS) at startup. All Essential Kit C# billing source files remain in place and will compile normally — the service simply will not be initialized.
+
+---
+
+## Step 6 — Remove Conflicting Gradle Dependency
+
+Search `Assets/Plugins/VoxelBusters/EssentialKit/Essentials/Editor/CrossPlatformEssentialKitDependencies.xml` for `com.android.billingclient`. If the file does not exist or contains no `com.android.billingclient` entries, **skip this step entirely**.
+
+If found, Essential Kit's billing Gradle dependency conflicts with Unity IAP's own BillingClient. Remove only the billing dependency line(s):
+
+```xml
+<!-- Remove these lines -->
+<androidPackage spec="com.android.billingclient:billing:VERSION" />
+<androidPackage spec="com.android.billingclient:billing-ktx:VERSION" />
+```
+
+Leave all other `<androidPackage>` entries in the file untouched.
+
+After editing, run **Assets > External Dependency Manager > Android Resolver > Resolve** (or Force Resolve) to regenerate the Gradle dependency list.
+
+---
+
+## Step 7 — Essential Kit → Unity IAP Concept Mapping
+
+### API mapping
+
+| Essential Kit | Unity IAP 5 |
+|---|---|
+| `BillingServices.InitializeStore()` | `store.Connect()` → `store.FetchProducts(definitions)` |
+| `BillingServices.OnInitializeStoreComplete` | `store.OnStoreConnected` + `store.OnProductsFetched` |
+| `BillingServices.BuyProduct(product, options)` | `store.PurchaseProduct(product)` |
+| `BillingServices.OnTransactionStateChange` (Purchased) | `store.OnPurchasePending` |
+| `BillingServices.OnTransactionStateChange` (Failed) | `store.OnPurchaseFailed` |
+| `BillingServices.OnTransactionStateChange` (Deferred) | `store.OnPurchaseDeferred` |
+| `BillingServices.FinishTransactions(transactions)` | `store.ConfirmPurchase(pendingOrder)` |
+| `BillingServices.RestorePurchases(forceRefresh)` | `store.RestoreTransactions(callback)` (user-triggered) + `store.FetchPurchases()` (startup) |
+| `BillingServices.OnRestorePurchasesComplete` | `store.OnPurchasesFetched` + `store.RestoreTransactions` callback |
+| `BillingServices.IsProductPurchased(id)` | `store.CheckEntitlement(product)` + `store.OnCheckEntitlement` |
+| `BillingServices.CanMakePayments()` | `store.AppleStoreExtendedService?.canMakePayments` (Apple only) |
+| `BillingServices.GetProductWithId(id)` | `store.GetProductById(id)` |
+| `BillingServices.GetTransactions()` | `store.GetPurchases()` |
+| `IBillingProduct` | `Product` |
+| `IBillingTransaction` | `PendingOrder` (on `OnPurchasePending`) |
+| `product.Price.LocalizedText` | `product.metadata.localizedPriceString` |
+| `product.LocalizedTitle` | `product.metadata.localizedTitle` |
+| `product.LocalizedDescription` | `product.metadata.localizedDescription` |
+
+### Receipt / validation mapping
+
+| Essential Kit | Unity IAP 5 |
+|---|---|
+| `transaction.Receipt` (iOS JWS token) | `pendingOrder.Info.Apple?.jwsRepresentation` |
+| `transaction.RawData` JSON (`transaction` + `signature` fields, Android) | `pendingOrder.Info.Receipt` (contains the full Google receipt JSON) |
+
+If the project sends `transaction.RawData` to a backend, document the receipt format change — the backend must now parse `order.Info.Receipt` instead.
+
+### Auto Finish Transactions
+
+Essential Kit's `AutoFinishTransactions` setting maps to Unity IAP's two-step flow:
+
+| EK Setting | Unity IAP equivalent |
+|---|---|
+| `AutoFinishTransactions = true` | Call `ConfirmPurchase(pendingOrder)` immediately after granting content |
+| `AutoFinishTransactions = false` (server verification) | Hold the `PendingOrder` reference, send receipt to server, call `ConfirmPurchase` only after server confirms — never confirm before grant |
+
+---
+
+## Step 8 — Verification Report
+
+After applying changes, produce a report with these sections:
+
+1. **Files changed** — list with nature of each change
+2. **Product catalog** — all product IDs, types, and store-specific IDs
+3. **Essential Kit Billing service** — confirmed disabled in `EssentialKitSettings.asset`
+4. **Gradle dependency** — confirmed `com.android.billingclient:billing` removed from `CrossPlatformEssentialKitDependencies.xml`
+5. **Receipt / backend mapping** — any backend changes required
+6. **Manual steps still required:**
+   - Run **Assets > External Dependency Manager > Android Resolver > Force Resolve** after editing the dependencies XML
+   - Verify no duplicate `BillingClient` classes in the Android build (`./gradlew dependencies` or check Unity build log)
+   - Confirm Essential Kit Billing service is visually disabled in **Window > Voxel Busters > Essential Kit > Open Settings → Services**
+   - Verify all existing App Store Connect / Google Play Console product IDs match the Unity IAP catalog exactly
+   - Test with sandbox/license test accounts

--- a/skills/implement-in-app-purchases/references/convert-revenuecat.md
+++ b/skills/implement-in-app-purchases/references/convert-revenuecat.md
@@ -1,0 +1,277 @@
+# RevenueCat — Conversion Assessment and Guidance
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Overview](#overview)
+- [Step 1 — Check If Already in Observer Mode](#step-1--check-if-already-in-observer-mode)
+- [Step 2 — Feature Support Check](#step-2--feature-support-check)
+- [Step 3 — Platform Support Check](#step-3--platform-support-check)
+- [Step 4 — Route to Outcome](#step-4--route-to-outcome)
+- [Case 1 — Already in Observer Mode with Unity IAP 5](#case-1--already-in-observer-mode-with-unity-iap-5)
+- [Case 2 — Blocker Detected (Amazon or Unsupported Features)](#case-2--blocker-detected-amazon-or-unsupported-features)
+- [Case 3 — No Blockers, Conversion Is Viable](#case-3--no-blockers-conversion-is-viable)
+
+Use this reference when the project has RevenueCat (`com.revenuecat.purchases-unity`) installed and the user wants to **replace or remove RevenueCat** and switch to Unity IAP 5 (`com.unity.purchasing`). This path does not cover adding Unity IAP 5 alongside RevenueCat for non-IAP purposes (e.g., IAP D2C Capabilities).
+
+---
+
+## Trigger Phrases
+
+- "Replace RevenueCat with Unity IAP"
+- "Remove RevenueCat and use Unity IAP"
+- "Migrate from RevenueCat to Unity IAP"
+- "Convert RevenueCat to Unity IAP 5"
+- "Stop using RevenueCat"
+
+---
+
+## Overview
+
+RevenueCat is architecturally independent from Unity IAP — it calls Apple StoreKit and Google BillingClient directly via its own native SDKs. Because of this, there is no simple "swap" — conversion requires assessing what RevenueCat features the project uses, what platforms it targets, and how much of RevenueCat's value Unity IAP 5 can actually replace.
+
+This path always produces one of three outcomes:
+
+| Case | Condition | Outcome |
+|---|---|---|
+| **1** | Already in observer mode with Unity IAP 5 | Report — no action needed |
+| **2** | Blocker found: Amazon store targeted, or RevenueCat-only features in use | Report blockers, present two choices |
+| **3** | No blockers — no Amazon, no RevenueCat-only features | Present two conversion choices |
+
+Run Steps 1–3 in order. Collect all findings before routing.
+
+---
+
+## Step 1 — Check If Already in Observer Mode
+
+### 1a — Check Unity IAP 5 is installed
+
+Search `Packages/manifest.json` for `com.unity.purchasing` with a version matching `5\.`. Record whether it is present.
+
+### 1b — Check RevenueCat observer mode configuration
+
+Search `Assets/**/*.cs` for:
+
+```
+PurchasesAreCompletedBy\.MyApp|PurchasesAreCompletedBy\.YourApp|observerMode\s*=\s*true|SetPurchasesAreCompletedBy
+```
+
+If found, observer mode is active.
+
+**If both Unity IAP 5 is installed AND observer mode is active → this is Case 1. Skip Steps 2–3 and go directly to [Case 1](#case-1--already-in-observer-mode-with-unity-iap-5).**
+
+Otherwise continue to Step 2.
+
+---
+
+## Step 2 — Feature Support Check
+
+Search `Assets/**/*.cs`, `Assets/**/*.prefab`, and `Assets/**/*.unity` for usage of RevenueCat features that have **no Unity IAP 5 equivalent**. Record every feature found.
+
+### 2a — Remote Paywalls / Offerings
+
+```
+GetOfferings|Offerings|Offering\b|Package\b.*revenuecat|RevenueCatUI|PaywallView|PresentPaywall
+```
+
+Also check `Packages/manifest.json` for `com.revenuecat.purchases-ui-unity`.
+
+**What it means:** RevenueCat's Offerings system lets you configure products and paywall layouts remotely without an app update. Unity IAP 5 has no remote paywall or Offerings system — all products must be defined in code or a local catalog.
+
+### 2b — A/B Testing / Experiments
+
+```
+GetCurrentOffering|Experiments|currentOffering
+```
+
+**What it means:** RevenueCat Experiments allows server-side A/B testing of product prices and paywall layouts. Unity IAP 5 has no A/B testing capability.
+
+### 2c — Cross-Platform Entitlement Sync
+
+```
+LogIn|LogOut|Purchases\.SharedPurchases|appUserId|CustomerInfo
+```
+
+Specifically look for `LogIn` being called with a user ID — this indicates the project relies on RevenueCat as the cross-platform entitlement source of truth (a user who buys on iOS retains access on Android). Unity IAP 5 has no cross-platform entitlement layer — each platform's receipt is independent.
+
+### 2d — Webhook-Driven Backend Events
+
+Search `Assets/**/*.cs` for patterns suggesting server-side subscription event handling:
+
+```
+webhook|SubscriptionStatusChange|EntitlementRevoked|BillingIssue
+```
+
+Also ask the user: *"Does your backend receive RevenueCat webhook events for subscription renewals, cancellations, or billing issues?"* If yes, flag this — Unity IAP 5 delivers no server-side lifecycle events.
+
+### 2e — Offline Entitlement Caching
+
+```
+offlineCustomerInfo|OfflineEntitlements|entitlementVerification
+```
+
+**What it means:** RevenueCat's offline entitlement feature processes and caches entitlements during server outages. Unity IAP 5 has no equivalent — if the store is unreachable, entitlement state is unavailable.
+
+---
+
+## Step 3 — Platform Support Check
+
+### 3a — Native Google BillingClient detection
+
+Search the following for custom native billing code alongside RevenueCat:
+
+- `Assets/**/*.cs` for: `AndroidJavaObject|AndroidJavaClass|BillingClient|BillingManager|GoogleBilling`
+- `Assets/Plugins/Android/**/*.java`, `*.kt` for: `com\.android\.billingclient`
+
+**If found:** The project has custom native Google BillingClient code in addition to RevenueCat. This is unusual — flag it to the user. Native BillingClient code will conflict with Unity IAP 5 at runtime and must be removed or replaced as part of the conversion. Add it to the blockers list in Case 2 if native BillingClient code is active and not just scaffolding.
+
+### 3b — Amazon Appstore detection
+
+Search the following for Amazon signals:
+
+- `Packages/manifest.json` and `Packages/packages-lock.json` for: `amazon`
+- `Assets/**/*.cs` for: `useAmazon|SetUseAmazon|AmazonStore|SyncAmazonPurchase`
+- `ProjectSettings/ProjectSettings.asset` for Amazon as an enabled build target
+
+**If found:** Amazon is a hard blocker. Unity IAP 5 has removed Amazon Appstore support entirely. RevenueCat observer mode is also broken for Amazon — `syncPurchases()` does not work on Amazon builds and requires `syncAmazonPurchase()` with full purchase details.
+
+---
+
+## Step 4 — Route to Outcome
+
+Evaluate findings from Steps 2 and 3:
+
+```
+If Amazon detected (Step 3b)                    → Case 2
+If native BillingClient detected (Step 3a)      → Case 2 (flag as additional blocker)
+If any Step 2 feature detected                  → Case 2
+If no blockers from Steps 2 or 3               → Case 3
+```
+
+If multiple blockers are found, list all of them in the Case 2 report — do not stop at the first.
+
+---
+
+## Case 1 — Already in Observer Mode with Unity IAP 5
+
+**Condition:** Unity IAP 5 installed and RevenueCat already configured in observer mode.
+
+Report and stop:
+
+> "This project already has Unity IAP 5 installed and RevenueCat is running in observer mode (`PurchasesAreCompletedBy.MyApp`). The two SDKs are already co-operating — Unity IAP 5 handles purchase transactions and RevenueCat validates and tracks them server-side.
+>
+> If you want to remove RevenueCat entirely, re-run this skill and specify that you want to stop using RevenueCat. That will route to a full removal assessment."
+
+Do not make any changes.
+
+---
+
+## Case 2 — Blocker Detected (Amazon or Unsupported Features)
+
+**Condition:** Amazon store is targeted, or one or more RevenueCat-only features are in active use.
+
+Produce a blockers report listing every issue found, then present two choices:
+
+> "The following blockers were found that prevent a clean conversion to Unity IAP 5:
+>
+> [List all detected blockers, e.g.:]
+> - **Amazon Appstore**: Unity IAP 5 does not support Amazon. RevenueCat observer mode does not work on Amazon builds either — `syncPurchases()` is broken for Amazon and requires manual `syncAmazonPurchase()` calls. Dropping Amazon support is the only viable path if Unity IAP 5 is the sole billing backend.
+> - **Cross-platform entitlement sync** (`LogIn` detected): Unity IAP 5 has no cross-platform entitlement layer. A user who purchases on iOS will not retain access on Android without a custom server-side solution.
+> - **Remote Paywalls / Offerings**: Unity IAP 5 has no remote paywall system. All products and paywall layouts must be defined in code or a local catalog.
+> - **Subscription webhooks**: Your backend appears to receive RevenueCat webhook events. Unity IAP 5 delivers no server-side lifecycle events — you would need to build your own subscription tracking infrastructure.
+>
+> **Your options:**
+>
+> **(a) Stop conversion (recommended)** — Keep RevenueCat as the billing backend. The features and platforms in use have no Unity IAP 5 equivalent. No changes will be made.
+>
+> **(b) Convert to observer mode + Unity IAP 5 anyway** — Unity IAP 5 takes over purchase transactions for Google Play and Apple App Store. RevenueCat switches to observer mode and continues server-side validation and lifecycle tracking. You accept the following consequences:
+> - Amazon Appstore billing will stop working.
+> - [List each unsupported feature and its consequence.]
+> - BillingClient Gradle conflict between Unity IAP 5 and RevenueCat must be resolved by excluding the conflicting dependency.
+>
+> Which would you like to do?"
+
+If the user chooses **(a)**: stop, make no changes.
+
+If the user chooses **(b)**: continue with [Case 3, Path A](#path-a--convert-to-observer-mode--unity-iap-5) but preface the report with a clear warning documenting every accepted consequence.
+
+---
+
+## Case 3 — No Blockers, Conversion Is Viable
+
+**Condition:** No Amazon support, no RevenueCat-only features detected.
+
+Present two choices:
+
+> "No blockers were found. The project uses RevenueCat only for basic purchase flow (no remote paywalls, no cross-platform entitlements, no Amazon). Two conversion paths are available:
+>
+> **(a) Observer mode + Unity IAP 5** — Unity IAP 5 handles purchase transactions. RevenueCat stays in observer mode for server-side validation and subscription lifecycle tracking. Lower risk — RevenueCat's `CustomerInfo` and webhook delivery continue to work.
+>
+> **(b) Full removal — Unity IAP 5 only** — RevenueCat is removed entirely. Unity IAP 5 handles all billing. You lose RevenueCat's server-side receipt validation, subscription lifecycle tracking, and analytics. Simpler architecture, no RevenueCat subscription cost.
+>
+> Which path would you like?"
+
+---
+
+### Path A — Convert to Observer Mode + Unity IAP 5
+
+1. **Install Unity IAP 5** if not already present — follow Step 1 of [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md).
+
+2. **Resolve the BillingClient Gradle conflict.** Both SDKs bundle `com.android.billingclient`. Add the following to `Assets/Plugins/Android/mainTemplate.gradle` inside the `android { }` block:
+
+   ```groovy
+   configurations.all {
+       exclude group: 'com.android.billingclient', module: 'billing'
+   }
+   ```
+
+   Then run **Assets > External Dependency Manager > Android Resolver > Delete Resolved Libraries**, followed by **Force Resolve**.
+
+3. **Switch RevenueCat to observer mode.** In the `Purchases` configuration call, set:
+
+   ```csharp
+   var config = PurchasesConfiguration.Builder.Init("your_api_key")
+       .SetPurchasesAreCompletedBy(PurchasesAreCompletedBy.MyApp)
+       .Build();
+   Purchases.Configure(config);
+   ```
+
+4. **Implement Unity IAP 5 purchase flow.** Follow [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md) using the product catalog extracted from the existing RevenueCat `Purchases.GetOfferings()` or hardcoded product IDs found in the codebase.
+
+5. **Call `syncPurchases()` after every confirmed purchase.** In the Unity IAP `OnPurchasePending` handler, after granting content and saving, call:
+
+   ```csharp
+   Purchases.SharedPurchases.SyncPurchases();
+   ```
+
+   This registers the purchase token with RevenueCat's backend so it can validate the receipt and update `CustomerInfo`.
+
+6. **Produce a verification report** covering:
+   - Files changed
+   - Gradle conflict resolution confirmed
+   - RevenueCat observer mode configuration location
+   - `SyncPurchases()` call location in purchase flow
+   - Manual steps: verify RevenueCat dashboard shows purchases from the updated build in sandbox
+
+---
+
+### Path B — Full Removal of RevenueCat
+
+1. **Extract the product catalog** from existing RevenueCat usage — search for hardcoded product ID strings and `GetOfferings()` calls.
+
+2. **Implement Unity IAP 5** using the extracted catalog — follow [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md) in full.
+
+3. **Remove RevenueCat SDK references from code.** Search `Assets/**/*.cs` for `using RevenueCat;` and all `Purchases.*` calls. Replace with the Unity IAP 5 equivalents from the new `IAPManager`.
+
+4. **Remove RevenueCat packages** from `Packages/manifest.json`:
+   - `com.revenuecat.purchases-unity`
+   - `com.revenuecat.purchases-ui-unity` (if present)
+
+   Remove the OpenUPM scoped registry entry for `com.revenuecat` from `manifest.json` if no other RevenueCat packages remain.
+
+5. **Run Assets > External Dependency Manager > Android Resolver > Force Resolve** after package removal to clean up RevenueCat's native dependencies.
+
+6. **Produce a verification report** covering:
+   - Files changed and RevenueCat references removed
+   - Product catalog — confirm all product IDs are preserved in Unity IAP 5
+   - Manual steps: remove the RevenueCat project from the RevenueCat dashboard if no longer needed; verify no orphaned RevenueCat Gradle entries remain in the Android build

--- a/skills/implement-in-app-purchases/references/convert-unipay.md
+++ b/skills/implement-in-app-purchases/references/convert-unipay.md
@@ -1,0 +1,145 @@
+# UniPay IAP — Assessment and Guidance
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Overview](#overview)
+- [Step 1 — Detect UniPay Version and Unity IAP Version](#step-1--detect-unipay-version-and-unity-iap-version)
+- [Step 2 — Detect Platform Targets](#step-2--detect-platform-targets)
+- [Step 3 — Route Based on Findings](#step-3--route-based-on-findings)
+
+Use this reference when the project has UniPay (FLOBUK) installed and the user asks to migrate, convert, or upgrade IAP. This path does **not** perform a conversion — it assesses the project state and either confirms no action is needed, stops with upgrade advice, or stops due to unsupported platforms.
+
+---
+
+## Trigger Phrases
+
+- "Migrate from UniPay"
+- "Convert UniPay to Unity IAP"
+- "Remove UniPay"
+- "Upgrade UniPay"
+- "Replace UniPay with Unity IAP"
+
+---
+
+## Overview
+
+UniPay wraps `com.unity.purchasing` (Unity IAP) as its underlying billing layer for Apple App Store, Google Play, and Amazon Appstore. It also ships its own separate plugins for Steam, Meta Quest/Oculus, PayPal, and Facebook Instant Games — these platforms have **no Unity IAP equivalent** and cannot be migrated.
+
+Because UniPay already uses Unity IAP under the hood, there is no "conversion" to perform for Apple/Google/Amazon billing. The assessment stops at one of three outcomes:
+
+| Outcome | Condition |
+|---|---|
+| **Unsupported platform — stop** | Project targets Steam, Meta Quest, PayPal, or Facebook Instant Games |
+| **Upgrade required — stop** | UniPay is present with Unity IAP v4 |
+| **No action needed** | UniPay 6.2.0+ with Unity IAP v5 already installed |
+
+---
+
+## Step 1 — Detect UniPay Version and Unity IAP Version
+
+### 1a — Locate UniPay version
+
+Search for UniPay's version in this order:
+
+1. `Assets/Plugins/UniPay/package.json` — read the `"version"` field.
+2. `Assets/Plugins/SIS/package.json` — legacy path (UniPay was formerly "Simple IAP System").
+3. `Assets/Plugins/UniPay/Scripts/IAPManager.cs` or any file containing a `VersionNumber` or `version` constant string.
+4. `ProjectSettings/ProjectSettings.asset` — search for `UniPay` or `SIS` version keys.
+
+If the version cannot be determined from any of the above, report:
+
+> "UniPay is installed but its version could not be determined. Please check **Edit > Project Settings > UniPay In-App Purchasing** for the installed version and confirm whether it is 6.2.0 or later."
+
+Do not stop — proceed to Step 1b with the version marked as unknown.
+
+### 1b — Check Unity IAP version
+
+Read `Packages/manifest.json` and find the `com.unity.purchasing` entry.
+
+| Result | Note |
+|---|---|
+| Version matches `4\.` | Unity IAP v4 — see routing in Step 3 |
+| Version matches `5\.` | Unity IAP v5 — see routing in Step 3 |
+| Absent | Unexpected — UniPay requires Unity IAP; report the missing dependency and stop |
+
+---
+
+## Step 2 — Detect Platform Targets
+
+Search `ProjectSettings/ProjectSettings.asset` for the enabled build targets. Also search `Assets/**/*.cs` and `Assets/Plugins/` for integration signals:
+
+| Signal to search for | Platform implied |
+|---|---|
+| `Steamworks|SteamManager|SteamAPI|com\.rlabrecque\.steamworks` | Steam (Standalone PC/Mac) |
+| `OculusSDK|OVRManager|com\.oculus|Meta Quest|com\.unity\.xr\.oculus` | Meta Quest / Oculus |
+| `PayPal|PayPalManager|PAYPAL` in C# or prefabs | PayPal (WebGL) |
+| `FacebookSDK|FB\.Init|com\.facebook\.sdk` | Facebook Instant Games |
+
+These platforms use UniPay's own billing plugins — **Unity IAP 5 has no equivalent for any of them.** If any are detected, they must be flagged as blockers (see Step 3, Route C).
+
+---
+
+## Step 3 — Route Based on Findings
+
+Apply the first matching route below.
+
+---
+
+### Route A — Unsupported Platform Detected (stop)
+
+**Condition:** Step 2 found Steam, Meta Quest, PayPal, or Facebook Instant Games signals.
+
+Stop and report:
+
+> "This project uses UniPay's [platform] integration. Unity IAP 5 does not support [platform] — there is no migration path for this billing backend. No changes will be made.
+>
+> If you want to continue using [platform] billing, keep UniPay. If you are dropping [platform] support entirely, remove the platform-specific UniPay integration manually first, then re-run this skill."
+
+List every unsupported platform found. Do not proceed with any changes.
+
+---
+
+### Route B — Upgrade Required (Unity IAP v4 detected)
+
+**Condition:** `com.unity.purchasing` version matches `4\.`, regardless of UniPay version.
+
+Stop and report:
+
+> "This project uses Unity IAP v4 as UniPay's billing backend. UniPay 6.2.0+ requires Unity IAP v5 and Unity 6.
+>
+> **Required upgrades before any IAP work can proceed:**
+> 1. Upgrade the Unity Editor to the latest stable Unity 6 release.
+> 2. Upgrade `com.unity.purchasing` to the latest stable v5 release via **Window > Package Manager**.
+> 3. Upgrade UniPay to version 6.2.0 or later — purchase the latest version from the Unity Asset Store and follow FLOBUK's upgrade instructions.
+>
+> Once all three upgrades are complete, re-run this skill."
+
+Do not make any code or package changes. Do not proceed.
+
+---
+
+### Route C — No Action Needed (UniPay 6.2.0+ with IAP v5)
+
+**Condition:** Unity IAP v5 is installed and UniPay version is 6.2.0 or later (or version is unknown but IAP v5 is confirmed).
+
+Check the exact `com.unity.purchasing` version from `Packages/manifest.json` and include it in the report:
+
+**If `com.unity.purchasing` is v5.0–5.3:**
+
+> "This project already uses UniPay [version] with Unity IAP v5.x as its billing backend. UniPay handles the IAP layer — no migration or conversion is needed.
+>
+> Note: IAP D2C Capabilities (third-party payment providers such as Stripe or Coda) require Unity IAP v5.4+. If you plan to add D2C support in the future, you will need to upgrade `com.unity.purchasing` to v5.4+ via **Window > Package Manager**.
+>
+> If you want to add new products, modify purchase logic, or handle platform-specific billing behavior, work within UniPay's API (see FLOBUK documentation). If you want to remove UniPay entirely and use Unity IAP 5 directly, that is a manual refactor — ask specifically for that and describe which UniPay features you are replacing."
+
+**If `com.unity.purchasing` is v5.4+:**
+
+> "This project already uses UniPay [version] with Unity IAP v5.4+ as its billing backend. UniPay handles the IAP layer — no migration or conversion is needed.
+>
+> If you want to add new products, modify purchase logic, or handle platform-specific billing behavior, work within UniPay's API (see FLOBUK documentation). If you want to remove UniPay entirely and use Unity IAP 5 directly, that is a manual refactor — ask specifically for that and describe which UniPay features you are replacing."
+
+Do not make any changes. This is an informational stop.
+
+---
+

--- a/skills/implement-in-app-purchases/references/migration-v4-to-v5.md
+++ b/skills/implement-in-app-purchases/references/migration-v4-to-v5.md
@@ -1,0 +1,204 @@
+# Unity IAP v4 to v5 Migration Guide
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Overview](#overview)
+- [Migration Mapping Table](#migration-mapping-table)
+- [Key Breaking Changes](#key-breaking-changes)
+- [Migration Anti-Patterns](#migration-anti-patterns)
+- [Minimal v5 Example](#minimal-v5-example)
+
+## Trigger Phrases
+
+- "Migrate from Unity IAP v4 to v5"
+- "Upgrade Unity IAP to v5"
+- "Update IAP from v4"
+- "Migrate IStoreListener to StoreController"
+- "Replace ConfigurationBuilder with v5 IAP"
+- "Update UnityPurchasing.Initialize to v5"
+
+## Overview
+
+Unity IAP v5 replaces the listener-based pattern (`IStoreListener`) with an event-driven pattern (`StoreController` events). This is a breaking change that requires updating all IAP code.
+
+## Migration Mapping Table
+
+### Initialization
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `UnityPurchasing.Initialize(listener, builder)` | `UnityIAPServices.StoreController()` then `await store.Connect()` |
+| `ConfigurationBuilder.Instance(StandardPurchasingModule.Instance())` | Use `CatalogProvider` for store-specific IDs/payouts, or pass `List<ProductDefinition>` directly to `FetchProducts()` |
+| `builder.AddProduct("id", ProductType.Consumable)` | `new ProductDefinition("id", ProductType.Consumable)` in a list |
+| `IStoreListener.OnInitialized(controller, extensions)` | `store.OnStoreConnected` event |
+| `IStoreListener.OnInitializeFailed(error)` | `store.OnStoreDisconnected` event |
+
+### Purchase Flow
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `controller.InitiatePurchase(product)` | `store.PurchaseProduct(product)` — note: `Purchase()` no longer accepts a developer payload argument (removed in Google Billing v3) |
+| `IStoreListener.ProcessPurchase(args)` for **new** purchases | `store.OnPurchasePending` + `store.ConfirmPurchase(pendingOrder)` |
+| `IStoreListener.ProcessPurchase(args)` for **restored** purchases | `store.OnPurchasesFetched` — use existing `ProcessPurchase` logic in both `OnPurchasePending` and `OnPurchasesFetched` |
+| `IStoreListener.ProcessPurchase(args)` returning `PurchaseProcessingResult.Pending` | Just don't call `ConfirmPurchase` until ready — store the `PendingOrder` reference |
+| `IStoreListener.OnPurchaseFailed(product, reason)` | `store.OnPurchaseFailed` event with `FailedOrder` (has `FailureReason` and `Details`) |
+| `controller.ConfirmPendingPurchase(product)` | `store.ConfirmPurchase(pendingOrder)` — requires the `PendingOrder` object, not the `Product` |
+| `product.hasReceipt` | **Preferred:** call `store.CheckEntitlement(product)` and handle `store.OnCheckEntitlement` — check `entitlement.Status == EntitlementStatus.FullyEntitled`. **Alternative:** track ownership with a `bool` flag updated in `OnPurchasePending` (new) and `OnPurchasesFetched` (restored). `CheckEntitlement` is the recommended v5 pattern for non-consumables and subscriptions. |
+
+### Configuration / Products
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `ConfigurationBuilder` with `AddProduct()` | `CatalogProvider` with `AddProduct()`, or a `List<ProductDefinition>` passed to `store.FetchProducts()` |
+| `builder.AddProduct("id", type, new IDs { { "store_id", store } })` | `catalogProvider.AddProduct("id", type, new StoreSpecificIds { { "store_id", store } })` — or `new ProductDefinition("id", "store_id", type)` for a single store ID |
+| `controller.products.WithID("id")` | `store.GetProductById("id")` |
+| `controller.products.all` | `store.GetProducts()` |
+
+### Restore Transactions
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `extensions.GetExtension<IAppleExtensions>().RestoreTransactions(callback)` | `store.RestoreTransactions(callback)` |
+| Manual restore call required | Confirmed purchases are **automatically restored** when you call `store.FetchPurchases()` or `store.CheckEntitlement()` — `RestoreTransactions` is only needed for explicit user-triggered restore buttons (required on iOS) |
+
+### Receipt Validation
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `CrossPlatformValidator` with Apple + Google | `CrossPlatformValidator` still works, but under StoreKit 2 Apple validation returns an empty array (no-op). **Recommended:** Use the Google-only constructor: `CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier)`. The legacy 4-arg constructor still works. Single-bundle-ID constructors are `[Obsolete]` |
+| `AppleTangle.Data()` for Apple validation | Under StoreKit 2, local Apple receipt validation is a no-op. Use `order.Info.Apple?.jwsRepresentation` for server-side Apple validation instead |
+| Manual receipt parsing | Use `order.Info.Apple?.jwsRepresentation` for server-side validation |
+| `product.receipt` | `order.Info.Receipt` — receipt is now accessed from the `Order`/`PendingOrder`, not the `Product` |
+
+### Platform Extensions
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `extensions.GetExtension<IAppleExtensions>()` | `store.AppleStoreExtendedService` / `store.AppleStoreExtendedPurchaseService` |
+| `extensions.GetExtension<IGooglePlayStoreExtensions>()` | `store.GooglePlayStoreExtendedService` / `store.GooglePlayStoreExtendedPurchaseService` |
+| `builder.Configure<IAppleConfiguration>().SetApplePromotionalPurchaseInterceptorCallback(cb)` | `store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += cb` (event on `IAppleStoreExtendedPurchaseService`, null-check required; callback signature: `Action<Product>`) |
+| `appleExtensions.ContinuePromotionalPurchases()` | `store.AppleStoreExtendedPurchaseService?.ContinuePromotionalPurchases()` |
+| `appleExtensions.RegisterPurchaseDeferredListener(cb)` | `store.OnPurchaseDeferred += cb` (event on `StoreController`) |
+| `appleExtensions.simulateAskToBuy` | `store.AppleStoreExtendedPurchaseService?.simulateAskToBuy` (null-check required) |
+| `appleExtensions.PresentCodeRedemptionSheet()` | `store.AppleStoreExtendedPurchaseService?.PresentCodeRedemptionSheet()` |
+| `appleExtensions.RestoreTransactions(cb)` | `store.RestoreTransactions(cb)` |
+| `appleExtensions.SetApplicationUsername(hashedString)` | `store.AppleStoreExtendedService?.SetAppAccountToken(Guid)` — must be called **after** `Connect()`; accepts a `Guid` (not a hash) identifying the user account in your system |
+| `builder.Configure<IAppleConfiguration>().SetEntitlementsRevokedListener(cb)` | `store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += cb` (event on `IAppleStoreExtendedPurchaseService`, null-check required; callback signature: `Action<string>` — receives a single product ID, NOT `List<Product>`) |
+| `appleExtensions.GetTransactionReceiptForProduct(product)` | `order.Info.Receipt` inside `OnPurchasePending` — per-transaction receipt is now on the order |
+| `builder.Configure<IAppleConfiguration>().canMakePayments` | `store.AppleStoreExtendedService?.canMakePayments` — must be checked **after** `Connect()`, not before initialization |
+| `appleExtensions.GetIntroductoryPriceDictionary()` | `store.AppleStoreExtendedProductService?.GetIntroductoryPriceDictionary()` — returns `Dictionary<string, string>` mapping product store-specific IDs to JSON with intro offer details. **NOT removed**, just moved to the product extension service. `AppleProductMetadata` does NOT expose `introductoryPrice`, `introductoryPriceLocale`, `introductoryNumberOfPeriods`, or `subscriptionPeriod` — those fields do not exist on that class. For introductory price data, use `SubscriptionInfo` methods (`GetIntroductoryPrice()`, `GetIntroductoryPricePeriod()`, `GetIntroductoryPricePeriodCycles()`). |
+| `appleExtensions.GetProductDetails()` | `store.AppleStoreExtendedProductService?.GetProductDetails()` — returns `Dictionary<string, string>`. **NOT removed**, just moved to the product extension service. Basic metadata (title, description, price) is on `product.metadata` directly. |
+| `appleExtensions.SetStorePromotionOrder(products)` | `store.AppleStoreExtendedProductService?.SetStorePromotionOrder(products)` — moved to `IAppleStoreExtendedProductService` (null-check required) |
+| `appleExtensions.SetStorePromotionVisibility(product, visibility)` | `store.AppleStoreExtendedProductService?.SetStorePromotionVisibility(product, visibility)` — moved to `IAppleStoreExtendedProductService` (null-check required) |
+| `appleExtensions.FetchStorePromotionOrder(success, failure)` | `store.AppleStoreExtendedProductService?.FetchStorePromotionOrder(successCb, errorCb)` — moved to `IAppleStoreExtendedProductService` (null-check required; callback signatures: `Action<List<Product>>`, `Action<string>`) |
+| `appleExtensions.FetchStorePromotionVisibility(product, success, failure)` | `store.AppleStoreExtendedProductService?.FetchStorePromotionVisibility(product, successCb, errorCb)` — moved to `IAppleStoreExtendedProductService` (null-check required; callback signatures: `Action<string, AppleStorePromotionVisibility>`, `Action<string>`) |
+| `googlePlayConfig.SetDeferredPurchaseListener(cb)` | `store.OnPurchaseDeferred += cb` (event on `StoreController`) |
+| `googlePlayConfig.SetDeferredProrationUpgradeDowngradeSubscriptionListener(cb)` | `store.GooglePlayStoreExtendedPurchaseService.OnDeferredPaymentUntilRenewalDate += cb` (event on `IGooglePlayStoreExtendedPurchaseService`, null-check required; callback signature: `Action<DeferredPaymentUntilRenewalDateOrder>` — NOT `Action<Product>`. Access the product via `deferredOrder.SubscriptionOrdered`) |
+| `googlePlayExtensions.UpgradeDowngradeSubscription(currentId, newId, mode)` | `store.GooglePlayStoreExtendedPurchaseService?.UpgradeDowngradeSubscription(currentOrder, newProduct, desiredReplacementMode)` — takes `Order` and `Product` objects instead of string IDs; third parameter is `GooglePlayReplacementMode` (not the deprecated `GooglePlayProrationMode`); call after `Connect()` |
+| `googlePlayExtensions.IsPurchasedProductDeferred(product)` | `store.GooglePlayStoreExtendedPurchaseService?.IsOrderDeferred(order)` — renamed and takes `Order` instead of `Product`; marked `[Obsolete]`. Prefer tracking deferred state via `store.OnPurchaseDeferred` / `store.OnPurchasePending` events instead |
+| `googlePlayExtensions.RestoreTransactions(cb)` | `store.RestoreTransactions(cb)` — moved to `StoreController` directly |
+| `googlePlayConfig.SetObfuscatedAccountId(id)` | `store.GooglePlayStoreExtendedService?.SetObfuscatedAccountId(id)` — moved from config-time to **post-`Connect()`** |
+| `googlePlayConfig.SetObfuscatedProfileId(id)` | `store.GooglePlayStoreExtendedService?.SetObfuscatedProfileId(id)` — moved from config-time to **post-`Connect()`** |
+
+### Subscription Info
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `new SubscriptionManager(product, introJson).getSubscriptionInfo()` | `order.Info.PurchasedProductInfo.FirstOrDefault(p => p.productId == productId)?.subscriptionInfo` — accessed via `IPurchasedProductInfo` on the order's info, NOT on `CartItem`. `CartItem` only has `Product` and `Quantity`. |
+| `subscriptionInfo.isSubscribed() == Result.True` | `purchasedProductInfo?.subscriptionInfo?.IsSubscribed() == Result.True` — method is now PascalCase but still returns `Result` enum (True/False/Unsupported), NOT `bool`. Use `== Result.True` for null-safe comparison (returns `false` if the chain is null). Do NOT use `?? false` — `Result?` and `bool` are incompatible types. |
+| `product.receipt == null` to check ownership | **Preferred:** use `store.CheckEntitlement(product)` + `store.OnCheckEntitlement` — the recommended v5 ownership check. **Alternative:** track ownership with a `bool` flag updated in `OnPurchasePending` (new purchase) and `OnPurchasesFetched` (restored purchases). |
+| `product.metadata.GetAppleProductMetadata()?.isFamilyShareable` | Still valid — `GetAppleProductMetadata()` extension method on `ProductMetadata` is unchanged |
+
+### Codeless IAP
+
+| v4 (Legacy) | v5 (Current) |
+|---|---|
+| `CodelessIAPStoreListener.Instance` | Codeless still works but uses v5 under the hood |
+| `CodelessIAPStoreListener.initializationComplete` | `CodelessIAPStoreListener.IsInitialized()` |
+
+## Key Breaking Changes
+
+1. **`IStoreListener` is deprecated**: Replace the interface implementation with event subscriptions on `StoreController`. The interface still compiles but is `[Obsolete]`.
+2. **Two-step purchase flow is mandatory**: v5 always uses pending → confirm. There is no equivalent of returning `PurchaseProcessingResult.Complete` from `ProcessPurchase`.
+3. **`ConfigurationBuilder` is deprecated**: Use `CatalogProvider` for store-specific IDs and payouts, or pass `List<ProductDefinition>` directly to `FetchProducts()`. The class still compiles but is `[Obsolete]`.
+4. **Apple local receipt validation is a no-op under StoreKit 2**: `CrossPlatformValidator` itself is not deprecated, but Apple validation silently returns an empty array under StoreKit 2. **Recommended:** use the Google-only constructor `CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier)`. Single-bundle-ID constructors are `[Obsolete]`. For server-side Apple validation, use `order.Info.Apple?.jwsRepresentation`.
+5. **Extensions are direct properties**: No more `GetExtension<T>()` pattern. Access via `store.AppleStoreExtendedService`, `store.AppleStoreExtendedPurchaseService`, `store.GooglePlayStoreExtendedService`, `store.GooglePlayStoreExtendedPurchaseService` (null-check required — only non-null on the matching platform).
+6. **`product.receipt` and `product.hasReceipt` are gone**: Use `order.Info.Receipt` from `PendingOrder` for the transaction receipt. For ownership checking, use `store.CheckEntitlement(product)` + `OnCheckEntitlement` (recommended) or track ownership with `bool` flags updated in `OnPurchasePending` and `OnPurchasesFetched`.
+7. **`Purchase()` no longer has a payload**: Developer payload support was removed in Google Billing v3.
+8. **`ProcessPurchase` logic belongs in two places**: Put it in both `OnPurchasePending` (new purchases) and `OnPurchasesFetched` (restored/existing purchases).
+9. **Restore is implicit**: Calling `FetchPurchases()` automatically re-delivers any unconfirmed purchases via `OnPurchasePending`. Explicit `RestoreTransactions()` is still required for the iOS "Restore Purchases" button.
+10. **`SubscriptionManager` is replaced**: No more `new SubscriptionManager(product, introJson).getSubscriptionInfo()`. In v5, subscription info is accessed via `order.Info.PurchasedProductInfo.FirstOrDefault(p => p.productId == id)?.subscriptionInfo` — it's on `IPurchasedProductInfo`, NOT on `CartItem`. `CartItem` only has `Product` and `Quantity`. Method names are now PascalCase: `IsSubscribed()` not `isSubscribed()`.
+11. **Platform-specific config must happen post-`Connect()`**: `SetAppAccountToken`, `SetObfuscatedAccountId/ProfileId`, `canMakePayments` — all moved from pre-init `ConfigurationBuilder` to the corresponding extended service, only available after `await store.Connect()`.
+12. **Apple promotional APIs moved to `IAppleStoreExtendedProductService`**: `SetStorePromotionOrder`, `SetStorePromotionVisibility`, `FetchStorePromotionOrder`, `FetchStorePromotionVisibility` are now on `store.AppleStoreExtendedProductService` (null-check required — only non-null on Apple platforms). No more `GetExtension<IAppleExtensions>()` pattern.
+13. **`OnPurchaseConfirmed` receives `Order` base type**: You MUST pattern-match `ConfirmedOrder` (success) vs `FailedOrder` (confirmation failed). Do not assume confirmation always succeeds.
+14. **Platform-specific events are on extended services, NOT `StoreController`**: `OnPromotionalPurchaseIntercepted` and `OnEntitlementRevoked` are on `AppleStoreExtendedPurchaseService`. `OnDeferredPaymentUntilRenewalDate` is on `GooglePlayStoreExtendedPurchaseService`. Only `OnPurchaseDeferred` (Ask-to-Buy) is directly on `StoreController`. Always null-check the extended service before subscribing to events (use `if (store.AppleStoreExtendedPurchaseService != null)` pattern — `?.` does not work with `+=`).
+
+## Migration Anti-Patterns
+
+**Always subscribe to BOTH success and failure events.** Not subscribing to failure events (e.g., `OnProductsFetchFailed`, `OnPurchasesFetchFailed`, `OnStoreDisconnected`) generates runtime warnings and leaves failures unhandled.
+
+**Always subscribe to `OnPurchaseDeferred`.** This event fires for Ask-to-Buy (iOS parental approval) and Google Play deferred purchases. Not subscribing means deferred purchases are silently ignored.
+
+**Use `CheckEntitlement` for ownership checks, not manual bool flags.** When migrating `product.hasReceipt` or `product.receipt == null` ownership checks, the recommended v5 pattern is `store.CheckEntitlement(product)` + `store.OnCheckEntitlement`. This works cross-platform and handles edge cases (refunds, subscription expiration) automatically.
+
+**`StoreConnectionFailureDescription` has `.message`, NOT `.reason`.** When migrating `OnInitializeFailed(error, message)` to `store.OnStoreDisconnected`, the failure description property is `failureDescription.message` (lowercase), not `reason`.
+
+**`ProductFetchFailed` has `.FailureReason`, NOT `.Message`.** When handling `store.OnProductsFetchFailed`, access the reason via `failure.FailureReason`.
+
+**Subscribe to events BEFORE calling `Connect()`.** Pending purchases from a previous session may fire immediately on reconnect. If your `OnPurchasePending` handler is not yet registered, those purchases will be missed.
+
+**`OnPurchaseConfirmed` can receive `FailedOrder`.** The `OnPurchaseConfirmed` event fires with `Order` (base type). Always pattern-match: `ConfirmedOrder` means success, `FailedOrder` means confirmation failed. Do not assume confirmation always succeeds.
+
+**Use `Awake()` for initialization, not `Start()`.** The official v5 samples use `Awake()` for `StoreController` setup and event subscription. This ensures IAP is initialized before other `Start()` methods that may depend on it.
+
+## Minimal v5 Example
+
+```csharp
+StoreController m_StoreController;
+
+async void Awake()
+{
+    m_StoreController = UnityIAPServices.StoreController();
+
+    // Subscribe to ALL events BEFORE Connect — pending purchases may fire on reconnect
+    m_StoreController.OnPurchasePending += (order) =>
+    {
+        var product = order.CartOrdered.Items().FirstOrDefault()?.Product;
+        GrantContent(product);
+        m_StoreController.ConfirmPurchase(order);
+    };
+    m_StoreController.OnPurchaseConfirmed += (order) =>
+    {
+        switch (order)
+        {
+            case ConfirmedOrder: Debug.Log("Purchase confirmed"); break;
+            case FailedOrder failed: Debug.LogError($"Confirmation failed: {failed.FailureReason}"); break;
+        }
+    };
+    m_StoreController.OnPurchaseFailed += (failed) => Debug.LogError($"{failed.FailureReason} - {failed.Details}");
+    m_StoreController.OnPurchaseDeferred += (deferred) => Debug.Log("Purchase deferred (e.g., Ask-to-Buy)");
+
+    m_StoreController.OnStoreConnected += OnStoreConnected;
+    m_StoreController.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+    await m_StoreController.Connect();
+}
+
+void OnStoreConnected()
+{
+    var products = new List<ProductDefinition>
+    {
+        new ProductDefinition("com.mygame.coins100", ProductType.Consumable)
+    };
+
+    m_StoreController.OnProductsFetched += (fetched) => Debug.Log("Products ready");
+    m_StoreController.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+    m_StoreController.FetchProducts(products);
+
+    // Restore any pending/unfinished purchases from the platform store
+    m_StoreController.OnPurchasesFetched += (orders) => Debug.Log($"Restored {orders.PendingOrders.Count} pending purchases");
+    m_StoreController.OnPurchasesFetchFailed += (failure) => Debug.LogError($"Purchase fetch failed: {failure.Message}");
+    m_StoreController.FetchPurchases();
+}
+```

--- a/skills/implement-in-app-purchases/references/path-add-iap-to-new-project.md
+++ b/skills/implement-in-app-purchases/references/path-add-iap-to-new-project.md
@@ -1,0 +1,198 @@
+# Add Unity IAP 5 to a Project With No IAP
+
+## Table of Contents
+
+- [Step 1 — Package Installation](#step-1--package-installation)
+- [Step 2 — Project Scan](#step-2--project-scan)
+- [Step 3 — Product Discovery](#step-3--product-discovery)
+- [Step 4 — IAPManager Architecture](#step-4--iapmanager-architecture)
+- [Step 5 — Purchase Handling Contract](#step-5--purchase-handling-contract)
+- [Step 6 — Product Type Behavior Rules](#step-6--product-type-behavior-rules)
+- [Step 7 — Cloud Save Integration](#step-7--cloud-save-integration)
+- [Step 8 — UI Integration](#step-8--ui-integration)
+- [Step 9 — Verification Report](#step-9--verification-report)
+
+Use this reference when the project has no existing in-app purchase implementation and needs Unity IAP 5 added from scratch.
+
+## Step 1 — Package Installation
+
+Check `Packages/manifest.json` for `com.unity.purchasing`:
+
+- **If absent:** Install via **Window > Package Manager > Unity Registry > In App Purchasing**. Do not edit `manifest.json` directly unless the user explicitly allows it. Confirm installation before proceeding.
+- **If present but below v5.0:** Instruct the user to upgrade via Package Manager to the latest stable v5 release. Do not proceed until the upgrade is confirmed.
+- **If v5.0+ is already present:** Note the exact version and proceed.
+
+Always use the latest stable v5 release unless the user specifies a version. Never downgrade an existing package.
+
+## Step 2 — Project Scan
+
+### 2a — Code scan
+
+Search `Assets/**/*.cs` for any existing IAP signals:
+
+```
+ProductType|ProductDefinition|StoreController|IAPButton|CodelessIAP
+ProcessPurchase|PendingOrder|DeferredOrder|ConfirmPurchase|FetchPurchases
+IStoreListener|UnityPurchasing\.Initialize|ConfigurationBuilder
+```
+
+### 2b — Inventory and economy scan
+
+Search `Assets/**/*.cs` for terms that indicate what needs to be credited after purchase:
+
+```
+\bcoins\b|\bgems\b|\blives\b|\binventory\b|\bcurrency\b
+PlayerData|SaveAsync|CloudSave|SaveDataAsync|SaveGame
+Economy
+```
+
+### 2c — Shop UI scan
+
+Search `Assets/**/*.unity`, `*.prefab`, `*.asset` for shop-related GameObjects and scripts:
+```
+Shop|Store|Purchase|Buy|IAP|Product|Monetiz
+```
+
+Collect: scene names, prefab paths, button component names, and any serialized product ID strings.
+
+## Step 3 — Product Discovery
+
+### If product definitions are already found (from Step 2a/2b/2c)
+
+Use them. Confirm types with the user if ambiguous.
+
+### If no product definitions exist
+
+**Stop and ask:**
+
+> "Please provide the first IAP product ID and type — for example `com.mygame.coins100` as Consumable — and tell me which inventory field, currency, or item should be credited after purchase."
+
+- If the user provides only a product ID with no type, **default to Consumable** but state the assumption explicitly before proceeding.
+- Collect all products before writing any code. For each product record: `productId`, `ProductType`, reward target (field name / method name / amount).
+
+## Step 4 — IAPManager Architecture
+
+### Match the project's existing patterns
+
+Before generating code:
+- Check whether the project uses MonoBehaviour singletons, ScriptableObject services, or dependency injection.
+- Check the namespace convention used in `Assets/Scripts/`.
+- Prefer the pattern already in use rather than introducing a new one.
+
+### IAPManager responsibilities
+
+Create a single `IAPManager` (MonoBehaviour singleton or service, matching project pattern) that:
+
+- Holds the `StoreController` instance.
+- Exposes `Buy(string productId)`.
+- Exposes `RestorePurchases()` — **only** if the product list contains `NonConsumable` or `Subscription` types.
+- Fires UI-friendly events or callbacks for: `OnInitialized`, `OnProductsLoaded`, `OnPurchaseSuccess`, `OnPurchaseFailed`, `OnPurchaseDeferred`.
+- Initializes once in `Awake()` — see the **Initialization Flow** section in SKILL.md for the exact event subscription and `Connect()` ordering rules.
+- Registers all products from a single authoritative product list (not scattered across UI handlers).
+
+### Product catalog
+
+Define products in one place — a `ScriptableObject`, a plain `List<ProductDefinition>`, or a constants class — not inside button click handlers. Wire button click handlers to `IAPManager.Buy(productId)` using the catalog, not hardcoded strings.
+
+## Step 5 — Purchase Handling Contract
+
+For API mechanics (two-step flow, event names, `ConfirmPurchase` signature) see the **Two-Step Purchase Flow** and **Required Event Subscriptions** sections in SKILL.md. This section covers only the grant-and-save contract that is specific to this path.
+
+### PendingOrder — the save-before-confirm rule
+
+```
+OnPurchasePending fires
+  → grant reward to inventory / currency / entitlement
+  → save player data (see Cloud Save Integration below)
+  → ONLY IF save succeeds: call ConfirmPurchase(pendingOrder)
+  → IF save fails: do NOT confirm — store will re-deliver on next launch
+```
+
+Never call `ConfirmPurchase` before the save completes. An unconfirmed purchase is safe — it re-delivers. A confirmed purchase that was never saved is a lost reward.
+
+### Duplicate grant prevention
+
+`OnPurchasePending` may fire more than once for the same purchase (app restart before confirmation). Track processed order IDs (e.g., in Cloud Save or a local ledger) and skip grant if the order ID was already processed.
+
+### DeferredOrder
+
+Do not grant anything. Fire `OnPurchaseDeferred` event to update UI ("Purchase pending approval"). Wait for `OnPurchasePending` when the purchase is approved.
+
+### FailedOrder
+
+Do not grant anything. Fire `OnPurchaseFailed` with the reason. See **Failure Description Property Names** in SKILL.md for the correct property names per type.
+
+## Step 6 — Product Type Behavior Rules
+
+### Consumable
+
+- Credit inventory or currency after purchase.
+- Persist the credited state in save data before confirming.
+- **Do not restore** old consumable orders — confirmed consumables are not returned by `FetchPurchases` and must not be re-granted.
+- Track consumable grants yourself (order ID ledger in Cloud Save or local save).
+
+### NonConsumable
+
+- Unlock a durable entitlement (feature flag, item ownership).
+- Include `RestorePurchases()` — required on iOS, good practice on Android.
+- Re-apply the entitlement on app startup: call `store.FetchPurchases()` and re-check ownership in `OnPurchasesFetched`, or use `store.CheckEntitlement(product)`. See **Entitlement Checking** and **Fetch Existing Purchases** in SKILL.md.
+
+### Subscription
+
+- Restore or check subscription state on app startup, not only at purchase time. Subscriptions can expire or be cancelled externally.
+- Use `store.CheckEntitlement(product)` or inspect `OnPurchasesFetched` results to update active/expired/unknown state.
+- See **Subscription Info** in SKILL.md for the correct access path (`order.Info.PurchasedProductInfo`, `IsSubscribed() == Result.True`).
+
+## Step 7 — Cloud Save Integration
+
+### Detect the existing save system first
+
+Search for any of these patterns before writing save code:
+
+```
+\.SaveAsync\(\)|CloudSaveService\.Instance
+SaveGame\(|SaveDataAsync\(|PlayerPrefs\.SetInt|JsonUtility\.ToJson|JsonConvert\.Serialize
+```
+
+### Rules
+
+- **Use the existing save abstraction** — do not create a new save system.
+- Prefer methods already in use: `CloudSaveService.Instance.Data.Player.SaveAsync()`, `SaveGame()`, `SaveDataAsync()`, or equivalent.
+- If no save system exists, use `PlayerPrefs` as a minimal fallback and document it as a TODO for the developer to upgrade.
+- Save **must complete before `ConfirmPurchase`** is called (see Step 5).
+
+## Step 8 — UI Integration
+
+### Wiring
+
+- Wire existing shop buttons to `IAPManager.Buy(productId)` — do not embed product IDs in button click handlers directly.
+- Subscribe to `IAPManager` events in the shop UI script to drive state changes.
+
+### States to handle in UI
+
+| State | Trigger | UI action |
+|---|---|---|
+| Initializing | Before `OnInitialized` | Disable buy buttons or show spinner |
+| Products loaded | `OnProductsLoaded` | Display localized price from `product.metadata.localizedPriceString` |
+| Product unavailable | Product missing from `OnProductsFetched` result | Hide or grey out the button |
+| Purchase pending | `PurchaseProduct()` called | Disable button, show loading state |
+| Purchase deferred | `OnPurchaseDeferred` | Show "pending approval" message |
+| Purchase success | `OnPurchaseSuccess` | Show confirmation, update inventory display |
+| Purchase failed | `OnPurchaseFailed` | Show error message, re-enable button |
+
+### Restore button
+
+Add a "Restore Purchases" button **only** if the product list contains `NonConsumable` or `Subscription` products. Required on iOS. Wire to `IAPManager.RestorePurchases()`.
+
+## Step 9 — Verification Report
+
+After applying changes, produce a report with these sections:
+
+1. **Files changed** — list with nature of each change
+2. **Product IDs and types** — final catalog
+3. **Reward mapping** — product ID → field/method credited
+4. **Save behavior** — which save method is called, when
+5. **Restore behavior** — which products are restorable, how
+6. **Pending / deferred handling** — confirmation of save-before-confirm and deferred UI
+7. **Duplicate grant prevention** — how order IDs are tracked
+8. **Manual steps still required** — Unity Editor steps (Receipt Validation Obfuscator if using local Google Play validation), App Store Connect / Play Console product setup, sandbox testing accounts

--- a/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
+++ b/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
@@ -1,0 +1,356 @@
+# Convert Native Google Billing to Unity IAP 5
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Important Constraints](#important-constraints)
+- [Step 1 — Pre-Conversion Scan](#step-1--pre-conversion-scan)
+- [Step 2 — Product Classification](#step-2--product-classification)
+- [Step 3 — Migration Report (produce before any edits)](#step-3--migration-report-produce-before-any-edits)
+- [Step 4 — Blocker Detection](#step-4--blocker-detection)
+- [Step 5 — Target Architecture](#step-5--target-architecture)
+- [Step 6 — Migration Phases](#step-6--migration-phases)
+- [Step 7 — Behavior Change Rules](#step-7--behavior-change-rules)
+- [Step 8 — Native → Unity IAP Concept Mapping](#step-8--native--unity-iap-concept-mapping)
+- [Step 9 — Rollback Plan](#step-9--rollback-plan)
+- [Step 10 — Test Checklist](#step-10--test-checklist)
+- [Step 11 — Questions to Ask (only when required)](#step-11--questions-to-ask-only-when-required)
+
+Use this reference when the project uses C# → Java/Kotlin AndroidJavaObject calls to Google Play BillingClient and needs to be migrated to `com.unity.purchasing`. Always install the latest stable version.
+
+## Trigger Phrases
+
+- "Convert native Google Billing to the latest Unity IAP"
+- "Migrate BillingClient integration to Unity IAP"
+- "Replace AndroidJavaObject Google billing bridge with Unity IAP"
+- "Upgrade custom Google Play Billing to the latest stable version of com.unity.purchasing"
+- "Remove native BillingClient and use Unity IAP"
+
+## Important Constraints
+
+- **Do not delete existing native billing files unless explicitly requested.** Always preserve with `#if !USE_UNITY_IAP_V5` guards.
+- **Create the new Unity IAP adapter first**, then mark the old native adapter as deprecated.
+- **Preserve public game-facing APIs** via a compatibility facade so gameplay code does not need large rewrites.
+- **Do not change product IDs.**
+- **Do not change backend validation endpoints** unless the receipt format change makes it unavoidable — document any backend change required.
+- **Do not grant purchases on the client** if the existing project uses server-side validation.
+- **Do not assume all products are consumables.** Detect and classify each product.
+- **Do not assume subscriptions are simple.** Detect base plans, offer tokens, pricing phases, and `SubscriptionOfferDetails`. If found, surface as a migration blocker and let the user choose a path (see Subscription Blocker Options below).
+- **If the project contains RevenueCat, Adapty, or Essential Kit**, stop and notify the user — this skill does not support converting those packages.
+- **If Google-specific features are not cleanly expressible in Unity IAP**, report them as migration blockers rather than silently removing them.
+
+## Step 1 — Pre-Conversion Scan
+
+Scan before making any changes. Do not edit files until the migration report is accepted.
+
+### 1a — Unity C# Bridge Patterns
+
+Search `Assets/**/*.cs`:
+
+```
+AndroidJavaObject|AndroidJavaClass|UnityPlayer\.currentActivity
+UnitySendMessage
+GoogleBilling|BillingManager|BillingClient|BillingBridge|AndroidBillingBridge|PlayBilling
+purchaseToken|originalJson|signature|productId|orderId
+\backnowledge\b|\bconsume\b
+restore.?purchases|query.?products|query.?purchases
+subscription.?status|receipt.?valid|entitlement.?grant
+```
+
+### 1b — Android Java/Kotlin Patterns
+
+Search `Assets/Plugins/Android/**/*.java`, `*.kt`:
+
+```
+com\.android\.billingclient\.api\.BillingClient
+PurchasesUpdatedListener|BillingClientStateListener
+ProductDetails|ProductDetails\.SubscriptionOfferDetails
+QueryProductDetailsParams|BillingFlowParams
+AcknowledgePurchaseParams|ConsumeParams|QueryPurchasesParams
+launchBillingFlow|acknowledgePurchase|consumeAsync
+queryProductDetailsAsync|queryPurchasesAsync|enablePendingPurchases
+offerToken|basePlanId|offerId|pricingPhases
+```
+
+### 1c — Gradle / Manifest Patterns
+
+Search `mainTemplate.gradle`, `launcherTemplate.gradle`, `baseProjectTemplate.gradle`, `AndroidManifest.xml`:
+
+```
+com\.android\.billingclient:billing
+com\.android\.billingclient:billing-ktx
+```
+
+Also list all `.jar`/`.aar` files under `Assets/Plugins/Android/` — these may contain pre-compiled billing code.
+
+### 1d — Scene / Prefab / Asset Scan
+
+Search `.unity`, `.prefab`, `.asset` files for references to billing-related MonoBehaviour names found in 1a.
+
+## Step 2 — Product Classification
+
+Classify every detected product into one of: **Consumable**, **NonConsumable**, **Subscription**, **Unknown**.
+
+Infer from (in priority order):
+1. `BillingClient.ProductType.INAPP` (consumable or non-consumable) / `BillingClient.ProductType.SUBS`
+2. `consumeAsync` calls → Consumable; `acknowledgePurchase` without consume → NonConsumable
+3. Product ID naming conventions (e.g., `coins`, `gems`, `pack` → Consumable; `remove_ads`, `unlock` → NonConsumable; `monthly`, `annual`, `sub` → Subscription)
+4. Entitlement / backend grant code
+5. Comments or config files
+
+If type cannot be confidently inferred, mark as **Unknown** and add to the blocker question list.
+
+## Step 3 — Migration Report (produce before any edits)
+
+Generate all 18 sections. Do not skip any.
+
+1. **Current native billing architecture** — describe the bridge pattern (C# wrapper → JNI → BillingClient)
+2. **Files using native Google Billing** — full list with role of each file
+3. **Product catalog discovered** — all product IDs found
+4. **Product type mapping** — inferred type + confidence + source of inference for each product
+5. **Purchase flow mapping** — native → Unity IAP step-by-step
+6. **Restore purchase flow mapping** — `queryPurchasesAsync` → `FetchPurchases` + `RestoreTransactions`
+7. **Backend validation mapping** — what data the old flow sent (`purchaseToken`, `originalJson`, `signature`, `packageName`) vs what Unity IAP provides (`order.Info.Receipt`, `order.Info.Apple?.jwsRepresentation`)
+8. **Consumable consume behavior mapping** — native `consumeAsync` → Unity IAP `ConfirmPurchase` (only after grant)
+9. **Non-consumable acknowledgement behavior mapping** — native `acknowledgePurchase` → Unity IAP `ConfirmPurchase` (only after grant)
+10. **Subscription behavior mapping** — detected subscription products, restore path, renewal handling
+11. **Google-specific features detected** — list each (see Blocker Detection below)
+12. **Unity IAP 5.2 migration blockers** — features that cannot be cleanly mapped
+13. **Proposed new Unity IAP architecture** — new files and their roles
+14. **Code files to create** — with paths
+15. **Code files to modify** — with nature of each change
+16. **Manual Play Console checks** — product IDs, base plan compatibility, billing permissions
+17. **Test plan** — from the checklist in this document
+18. **Rollback plan** — from the rollback plan section in this document
+
+## Step 4 — Blocker Detection
+
+Report these as migration blockers if detected. Do not silently remove them.
+
+| Feature | Detection Signal | Blocker Level |
+|---|---|---|
+| Multiple subscription base plans | `basePlanId` usage, multiple `SubscriptionOfferDetails` per product | **Hard** — ask user to choose option A/B/C (see below) |
+| Explicit offer token selection | `offerToken` set on `BillingFlowParams` | **Hard** |
+| Introductory offer selection by `offerId` | `offerId` in offer params | **Hard** |
+| Offer tags | `offerTags` access on `SubscriptionOfferDetails` | **Soft** — document loss |
+| Pricing phase inspection | `pricingPhases` / `PricingPhase` fields read | **Soft** — document loss |
+| Multi-quantity purchases | `quantity` > 1 in `BillingFlowParams` | **Hard** |
+| Alternative billing / external offers | `setExternalOfferToken` or alternative billing config | **Hard** |
+| Personalized price disclosure | `setIsPersonalizedPrice(true)` | **Hard** |
+| Obfuscated account / profile IDs | `setObfuscatedAccountId`, `setObfuscatedProfileId` | **Soft** — Unity IAP exposes `SetObfuscatedAccountId/ProfileId` post-`Connect()` on `GooglePlayStoreExtendedService` |
+| Custom `BillingFlowParams` fields | Any `BillingFlowParams.Builder` method not listed above | **Soft** — document loss |
+| Direct `ProductDetails` metadata | Reading `ProductDetails` fields not available on `Product.metadata` | **Soft** — document loss |
+
+### Subscription Blocker Options (present to user when hard subscription blockers found)
+
+**A mixed Unity IAP + native BillingClient architecture is not recommended and must not be offered as an option.** Both systems compete for the same `PurchasesUpdatedListener` slot on the device — only one receives purchase callbacks, the other silently drops purchases. This risks lost purchases, double grants, and unacknowledged tokens. If the user asks about a mixed approach, explain this risk and redirect to Option A or B.
+
+**Option A — Simplify Play Console setup for Unity IAP compatibility**
+Remove extra base plans/offers in Play Console so one product has one base plan. Unity IAP then handles all products including subscriptions. This is the recommended path — single system, no coexistence risk.
+
+**Option B — Stay on native Google Billing for all products**
+Do not migrate at this time. Keep the native BillingClient implementation as-is until the Play Console subscription configuration can be simplified or Unity IAP exposes the required subscription features. Stop the conversion and document the blocker and this decision in `IapMigrationNotes.md`.
+
+## Step 5 — Target Architecture
+
+Create under `Assets/Scripts/IAP/`:
+
+| File | Purpose |
+|---|---|
+| `IStorePurchaseService.cs` | Game-facing interface (stable public API) |
+| `UnityIapStorePurchaseService.cs` | Unity IAP 5.x implementation |
+| `ProductCatalogDefinition.cs` | ScriptableObject or plain class holding all `ProductDefinitionEntry` |
+| `ProductDefinitionEntry.cs` | Per-product data: ID, type, store-specific IDs |
+| `PurchaseEntitlementMapper.cs` | Maps Unity IAP order data → game grant calls |
+| `PurchaseValidationRequest.cs` | DTO sent to backend |
+| `PurchaseValidationResult.cs` | DTO received from backend |
+| `PurchaseRestoreResult.cs` | Result of restore operation |
+| `LegacyGoogleBillingAdapterDeprecated.cs` | Compatibility facade (only if game code calls old billing API) |
+| `IapMigrationNotes.md` | Human-readable notes on what changed, blockers found, manual steps |
+
+### Game-Facing Interface (preserve or adapt from existing API surface)
+
+```csharp
+public interface IStorePurchaseService
+{
+    Task InitializeAsync();
+    Task FetchProductsAsync();
+    IReadOnlyList<StoreProductInfo> GetProducts();
+    Task PurchaseAsync(string productId);
+    Task RestorePurchasesAsync();
+    bool IsInitialized { get; }
+}
+```
+
+## Step 6 — Migration Phases
+
+### Phase 1 — Package Check
+
+- Verify `com.unity.purchasing` exists in `Packages/manifest.json`.
+- If `com.unity.purchasing` is absent or outdated, install the latest stable version via Package Manager.
+- If missing or outdated, provide Package Manager instructions. Do not auto-edit `manifest.json` unless the user explicitly allows it.
+
+### Phase 2 — Product Catalog Extraction
+
+- Extract all product IDs and inferred types from the scan.
+- Generate `ProductCatalogDefinition.cs` / `ProductDefinitionEntry.cs`.
+- Each entry: `productId`, `ProductType`, optional `storeSpecificIds`, `notes`.
+
+### Phase 3 — New Unity IAP Service
+
+Create `UnityIapStorePurchaseService`:
+
+1. **Initialization** — `UnityIAPServices.StoreController()`, subscribe all events **before** `Connect()`.
+2. **Product fetching** — build `List<ProductDefinition>` from catalog, call `store.FetchProducts()`, handle `OnProductsFetched` / `OnProductsFetchFailed`.
+3. **Purchase initiation** — `store.PurchaseProduct(product)`.
+4. **Purchase callback** — `OnPurchasePending`: validate receipt → grant entitlement → `ConfirmPurchase(pendingOrder)`. **Never confirm before grant.**
+5. **Deferred purchases** — `OnPurchaseDeferred`: show pending UI, do not grant.
+6. **Failed purchases** — `OnPurchaseFailed`: map `FailureReason` to user-facing error.
+7. **Restore / fetch** — `store.FetchPurchases()` (re-delivers unconfirmed via `OnPurchasePending`) + `store.RestoreTransactions(callback)` for explicit iOS restore button.
+8. **Validation handoff** — send `order.Info.Receipt` (and `order.Info.Apple?.jwsRepresentation` on Apple) to backend in place of legacy `purchaseToken` + `originalJson` + `signature`. Document any backend change required.
+
+### Phase 4 — Compatibility Facade
+
+If game code calls the old billing API directly (e.g., `GoogleBillingManager.Purchase(id)`):
+
+- Create `LegacyGoogleBillingAdapterDeprecated.cs` that implements the same method signatures.
+- Delegate all calls to `UnityIapStorePurchaseService`.
+- Mark all methods `[Obsolete("Use IStorePurchaseService — remove after migration validation")]`.
+
+### Phase 5 — Remove Native Dependency from Active Path
+
+- Stop calling `AndroidJavaObject` bridge for migrated products.
+- Wrap native calls in `#if !USE_UNITY_IAP_V5` — do not delete them.
+- Leave Gradle billing dependencies unless user explicitly requests removal.
+
+### Phase 6 — Test Scaffolding
+
+- Add debug logs at each IAP event.
+- Add editor stubs for sandbox testing.
+- Add the QA checklist from the test plan below to `IapMigrationNotes.md`.
+
+## Step 7 — Behavior Change Rules
+
+### Acknowledgement and Consumption
+
+Native billing requires explicit `acknowledgePurchase` or `consumeAsync`. Unity IAP abstracts both through `ConfirmPurchase(pendingOrder)`. Map:
+
+| Native | Unity IAP |
+|---|---|
+| `consumeAsync` (consumable) | `ConfirmPurchase(pendingOrder)` after grant |
+| `acknowledgePurchase` (non-consumable / subscription) | `ConfirmPurchase(pendingOrder)` after grant |
+
+**Never call `ConfirmPurchase` before the entitlement is safely granted.**
+
+### Backend Validation
+
+| Native field sent | Unity IAP equivalent |
+|---|---|
+| `purchaseToken` | `order.Info.Receipt` (contains the Google receipt JSON) |
+| `originalJson` | Embedded in `order.Info.Receipt` |
+| `signature` | Embedded in `order.Info.Receipt` |
+| `packageName` | `Application.identifier` |
+| `productId` | `pendingOrder.CartOrdered.Items().First().Product.definition.id` |
+
+If the backend parses `purchaseToken` or `originalJson` fields directly, document the receipt format change as a required backend update.
+
+### Obfuscated IDs
+
+If native code sets `setObfuscatedAccountId` / `setObfuscatedProfileId` in `BillingFlowParams`, set the equivalent **after** `await store.Connect()`:
+
+```csharp
+store.GooglePlayStoreExtendedService?.SetObfuscatedAccountId("hashed_id");
+store.GooglePlayStoreExtendedService?.SetObfuscatedProfileId("hashed_profile_id");
+```
+
+Retrieve per-order:
+
+```csharp
+string accountId = store.GooglePlayStoreExtendedPurchaseService?.GetObfuscatedAccountId(order);
+```
+
+### Pending Purchases
+
+If native code handles `BillingClient.enablePendingPurchases()` or checks purchase state for `PENDING`:
+
+- Unity IAP surfaces deferred purchases via `store.OnPurchaseDeferred`.
+- On `OnPurchaseDeferred`: show "pending approval" UI. Do not grant.
+- When approved, the store re-delivers via `store.OnPurchasePending`.
+
+### Subscription Upgrade / Downgrade
+
+If native code calls `launchBillingFlow` with a `subscriptionUpdateParams` (prorating an existing subscription):
+
+```csharp
+store.GooglePlayStoreExtendedPurchaseService?.UpgradeDowngradeSubscription(
+    currentOrder,       // Order object of the current subscription
+    newProduct,         // Product to upgrade/downgrade to
+    GooglePlayReplacementMode.ChargeFullPrice  // choose appropriate mode
+);
+```
+
+See [platform-notes.md](platform-notes.md) for all `GooglePlayReplacementMode` values.
+
+## Step 8 — Native → Unity IAP Concept Mapping
+
+| Native Google Billing | Unity IAP 5.x |
+|---|---|
+| `ProductDetails` | `Product` (via `store.GetProductById`) |
+| `Purchase` | `PendingOrder` (on `OnPurchasePending`) |
+| `purchaseToken` | `order.Info.Receipt` (contains the token) |
+| `originalJson` | embedded in `order.Info.Receipt` |
+| `signature` | embedded in `order.Info.Receipt` |
+| `acknowledgePurchase` | `store.ConfirmPurchase(pendingOrder)` |
+| `consumeAsync` | `store.ConfirmPurchase(pendingOrder)` |
+| `queryPurchasesAsync` | `store.FetchPurchases()` → `OnPurchasesFetched` |
+| `BillingResult` / `BillingResponseCode` | `FailedOrder.FailureReason` / `StoreConnectionFailureDescription` |
+| `ProductType.INAPP` | `ProductType.Consumable` or `ProductType.NonConsumable` (distinguish by consume behavior) |
+| `ProductType.SUBS` | `ProductType.Subscription` |
+| `offerToken` / `basePlanId` / `pricingPhases` | **Not directly exposed** — report as blocker |
+
+## Step 9 — Rollback Plan
+
+- Wrap all new IAP code in `#if USE_UNITY_IAP_V5`.
+- Wrap all replaced native bridge calls in `#if !USE_UNITY_IAP_V5`.
+- To revert: remove `USE_UNITY_IAP_V5` from **Edit > Project Settings > Player > Scripting Define Symbols**. The native billing path is restored without any code changes.
+- Never activate both purchase systems for the same product simultaneously.
+- Document the rollback steps in `IapMigrationNotes.md`.
+
+## Step 10 — Test Checklist
+
+Include this in `IapMigrationNotes.md` after migration:
+
+- [ ] Fresh install — products load and display prices
+- [ ] Upgrade from old app version to migrated version — no duplicate entitlements
+- [ ] Consumable purchase — content granted
+- [ ] Repeat consumable purchase — repeatable, no block
+- [ ] Non-consumable purchase — content granted once
+- [ ] Non-consumable restore — content restored on reinstall
+- [ ] Subscription purchase — subscription active
+- [ ] Subscription restore — status refreshed on launch
+- [ ] Pending purchase (if applicable) — deferred UI shown, no premature grant
+- [ ] Interrupted purchase flow — re-delivered on next launch via `OnPurchasePending`
+- [ ] Backend validation success — entitlement granted
+- [ ] Backend validation failure — entitlement NOT granted, purchase not confirmed
+- [ ] Network failure during validation — purchase left pending, re-delivered on next launch
+- [ ] App killed during purchase — pending order re-delivered on next launch
+- [ ] App resumed after Google purchase UI — `OnPurchasePending` fires correctly
+- [ ] Sandbox tester account — no real charges
+- [ ] Internal testing track build
+- [ ] Play Console product ID match — all IDs match exactly
+- [ ] Play Console base plan compatibility — no advanced offer config that Unity IAP cannot reach
+- [ ] No duplicate entitlement grant
+- [ ] No unacknowledged purchases remaining
+- [ ] No double consumption of consumables
+
+## Step 11 — Questions to Ask (only when required)
+
+Ask only when the information cannot be inferred:
+
+1. Which product IDs are consumable, non-consumable, or subscription?
+2. Does the backend currently validate Google purchase tokens directly (raw `purchaseToken` field)?
+3. Are any subscriptions using multiple base plans or offer tokens?
+4. Should the skill preserve the old public C# billing API as a compatibility facade?
+5. Should native billing files be kept, disabled, or removed?
+
+If enough information can be inferred, proceed with a best-effort plan and mark uncertain items as **TODO**.

--- a/skills/implement-in-app-purchases/references/path-convert-native-storekit.md
+++ b/skills/implement-in-app-purchases/references/path-convert-native-storekit.md
@@ -1,0 +1,446 @@
+# Convert Native iOS StoreKit to Unity IAP 5
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Important Constraints](#important-constraints)
+- [Step 1 — Pre-Conversion Scan](#step-1--pre-conversion-scan)
+- [Step 2 — StoreKit Version Detection](#step-2--storekit-version-detection)
+- [Step 3 — Product Classification](#step-3--product-classification)
+- [Step 4 — Migration Report (produce before any edits)](#step-4--migration-report-produce-before-any-edits)
+- [Step 5 — Blocker Detection](#step-5--blocker-detection)
+- [Step 6 — Target Architecture](#step-6--target-architecture)
+- [Step 7 — Migration Phases](#step-7--migration-phases)
+- [Step 8 — Behavior Change Rules](#step-8--behavior-change-rules)
+- [Step 9 — Native → Unity IAP Concept Mapping](#step-9--native--unity-iap-concept-mapping)
+- [Step 10 — Rollback Plan](#step-10--rollback-plan)
+- [Step 11 — Test Checklist](#step-11--test-checklist)
+- [Step 12 — Questions to Ask (only when required)](#step-12--questions-to-ask-only-when-required)
+
+Use this reference when the project uses a custom native iOS StoreKit plugin (Objective-C or Swift, bridged into Unity via `[DllImport("__Internal")]` and `UnitySendMessage`) and needs to be migrated to `com.unity.purchasing`. Always install the latest stable version.
+
+## Trigger Phrases
+
+- "Convert native StoreKit to Unity IAP"
+- "Migrate SKPaymentQueue integration to Unity IAP"
+- "Replace custom iOS billing plugin with Unity IAP"
+- "Remove native StoreKit and use Unity IAP"
+- "Migrate DllImport StoreKit bridge to Unity IAP"
+- "Replace SKProduct / SKPayment with Unity IAP"
+
+## Important Constraints
+
+- **Do not delete existing native iOS plugin files unless explicitly requested.** Always preserve with `#if !USE_UNITY_IAP_V5` guards on the C# side. ObjC/Swift files cannot use C# defines — guard their call sites in C# instead.
+- **Create the new Unity IAP adapter first**, then mark the old native adapter as deprecated.
+- **Preserve public game-facing APIs** via a compatibility facade so gameplay code does not need large rewrites.
+- **Do not change product IDs.**
+- **Do not change backend validation endpoints** unless the receipt format change makes it unavoidable — document any backend change required. The receipt format change from SK1 bundle to per-transaction JWS is a breaking backend change; flag it prominently.
+- **Do not grant purchases on the client** if the existing project uses server-side validation.
+- **Do not assume all products are consumables.** Detect and classify each product.
+- **Do not assume subscriptions are simple.** Detect promotional offers, offer codes, and introductory price usage. If found, surface as migration blockers and let the user choose a path.
+- **If the project contains RevenueCat, Adapty, or Essential Kit**, stop and notify the user — this skill does not support converting those packages.
+- **If StoreKit-specific features are not cleanly expressible in Unity IAP**, report them as migration blockers rather than silently removing them.
+- **A mixed Unity IAP + native StoreKit architecture is not recommended.** Both systems register as `SKPaymentQueue` observers — only one reliably receives transaction callbacks. Do not offer a mixed approach; if the user asks, explain the risk and redirect to Option A or B (see Subscription Blocker Options).
+
+---
+
+## Step 1 — Pre-Conversion Scan
+
+Scan before making any changes. Do not edit files until the migration report is accepted.
+
+### 1a — Native iOS Plugin Files
+
+Search `Assets/Plugins/iOS/` for:
+- `*.m`, `*.mm` files — Objective-C plugins
+- `*.h` files — headers with StoreKit imports or `extern "C"` bridge declarations
+- `*.swift` files — Swift plugins (rare but increasingly common)
+
+List all files found. For each, note whether it imports `StoreKit` or `StoreKit2`.
+
+### 1b — C# Bridge Patterns
+
+Search `Assets/**/*.cs` for:
+
+```
+DllImport.*__Internal
+UnitySendMessage
+SKProduct|SKPayment|SKPaymentTransaction|SKPaymentQueue|SKReceiptRefresh
+StoreKit|AppStore|AppleIAP|iOSBilling|iOSIAP|iOSPurchase
+Application\.platform.*IPhonePlayer|RuntimePlatform\.IPhonePlayer
+```
+
+Also search for callback method names referenced in `UnitySendMessage` calls in the native files — these will be C# methods receiving callbacks.
+
+### 1c — StoreKit 1 Patterns (in .m / .mm / .h files)
+
+```
+SKProductsRequest|SKProductsRequestDelegate
+SKPaymentQueue|SKPaymentTransactionObserver
+SKPaymentTransaction|SKPayment|SKMutablePayment
+SKProduct|SKProductSubscriptionPeriod|SKProductDiscount
+paymentQueue:updatedTransactions:|finishTransaction:
+SKReceiptRefreshRequest
+SKPaymentDiscount|paymentDiscount
+SKStorefront|paymentQueueDidChangeStorefront
+canMakePayments
+```
+
+### 1d — StoreKit 2 Patterns (in .swift files)
+
+```
+import StoreKit
+Product\.products\(for:\)|product\.purchase\(\)
+Transaction\.currentEntitlements|Transaction\.updates|Transaction\.finish
+verificationResult|JWSTransaction
+winBackOffer|eligibleWinBackOffers
+```
+
+### 1e — Scene / Prefab / Asset Scan
+
+Search `.unity`, `.prefab`, `.asset` files for references to billing-related MonoBehaviour names found in 1b. List all scene references so they can be rewired after migration.
+
+---
+
+## Step 2 — StoreKit Version Detection
+
+Classify the native plugin as **StoreKit 1**, **StoreKit 2**, or **Mixed** based on Step 1 findings.
+
+| Generation | Signals | Notes |
+|---|---|---|
+| **StoreKit 1** | `SKPaymentQueue`, `SKPaymentTransaction`, `SKProductsRequest` | Most Unity projects pre-2023 |
+| **StoreKit 2** | `Product.products(for:)`, `Transaction.currentEntitlements`, `Transaction.updates` | Swift 5.5+, iOS 15+ |
+| **Mixed** | Both sets of signals present | Treat as StoreKit 1 for blocker purposes; flag SK2 usage for review |
+
+Document the detected generation in the migration report. StoreKit 2 has additional blockers (see Step 5).
+
+---
+
+## Step 3 — Product Classification
+
+Classify every detected product into one of: **Consumable**, **NonConsumable**, **Subscription**, **Unknown**.
+
+Infer from (in priority order):
+
+1. `SKProduct.subscriptionPeriod` non-nil → **Subscription**
+2. `finishTransaction:` called after grant without a "restore" path → **Consumable**
+3. `restoreCompletedTransactions` handling or checking `originalTransaction` → **NonConsumable** or **Subscription**
+4. Product ID naming conventions (`coins`, `gems`, `pack` → Consumable; `remove_ads`, `unlock`, `premium` → NonConsumable; `monthly`, `annual`, `sub` → Subscription)
+5. Entitlement / backend grant code patterns
+6. Comments or config files
+
+If type cannot be confidently inferred, mark as **Unknown** and add to the blocker question list.
+
+---
+
+## Step 4 — Migration Report (produce before any edits)
+
+Generate all sections before touching any file. Do not skip any.
+
+1. **Current native billing architecture** — describe the bridge pattern (C# `[DllImport("__Internal")]` → ObjC/Swift plugin → StoreKit)
+2. **StoreKit generation** — SK1, SK2, or Mixed
+3. **Files using native StoreKit** — full list with role of each file (plugin, bridge, callback receiver, UI)
+4. **Product catalog discovered** — all product IDs found
+5. **Product type mapping** — inferred type + confidence + source of inference for each product
+6. **Purchase flow mapping** — native → Unity IAP step-by-step
+7. **Restore purchase flow mapping** — `restoreCompletedTransactions` / `Transaction.currentEntitlements` → `store.FetchPurchases()` + `store.RestoreTransactions(callback)`
+8. **Backend validation mapping** — what data the old flow sent vs what Unity IAP provides (see Behavior Change Rules — receipt format is a breaking change)
+9. **Transaction finish behavior mapping** — `finishTransaction:` → `store.ConfirmPurchase(pendingOrder)` (only after grant)
+10. **Subscription behavior mapping** — detected subscription products, restore path, renewal handling, introductory price usage
+11. **StoreKit-specific features detected** — list each (see Blocker Detection)
+12. **Migration blockers** — features that cannot be cleanly mapped
+13. **Proposed new Unity IAP architecture** — new files and their roles
+14. **Code files to create** — with paths
+15. **Code files to modify** — with nature of each change
+16. **Manual App Store Connect checks** — product ID match, subscription group configuration
+17. **Test plan** — from the checklist in this document
+18. **Rollback plan** — from the rollback plan section in this document
+
+---
+
+## Step 5 — Blocker Detection
+
+Report these as migration blockers if detected. Do not silently remove them.
+
+| Feature | Detection Signal | Blocker Level |
+|---|---|---|
+| Promotional offer signing (SK1 `SKPaymentDiscount`) | `SKPaymentDiscount`, `paymentDiscount`, `offerIdentifier`, `keyIdentifier`, `nonce`, `signature` | **Hard** — requires server-side signed offers; Unity IAP has no equivalent |
+| SK2 promotional offer signing | `promotionalOffer`, `PromotionalOffer`, `eligiblePromotionOfferSignature` | **Hard** — not exposed in Unity IAP |
+| Win-back offers (SK2) | `winBackOffer`, `eligibleWinBackOffers` | **Hard** — not supported in Unity IAP 5.4 |
+| `SKReceiptRefreshRequest` (manual receipt refresh) | `SKReceiptRefreshRequest` | **Soft** — `store.FetchPurchases()` covers the re-delivery use case; document loss of explicit refresh |
+| `SKStorefront` / storefront change observer | `SKStorefront`, `paymentQueueDidChangeStorefront` | **Soft** — not exposed in Unity IAP; document loss |
+| Multi-quantity purchases | `quantity > 1` in `SKMutablePayment` | **Hard** — Unity IAP does not support quantity > 1 per transaction |
+| Custom `SKPaymentQueue` observers remaining alongside Unity IAP | Other `addTransactionObserver` calls not being removed | **Hard** — both observers compete; only one reliably receives callbacks |
+| `SKOverlay` / `SKStoreProductViewController` | `SKOverlay`, `SKStoreProductViewController` | **Soft** — not IAP-related; these are store UI overlays. Document as out of scope for this migration |
+| Direct App Store receipt bundle validation (`appStoreReceiptURL`) | `appStoreReceiptURL`, `receiptData`, `/verifyReceipt` in backend URLs | **Hard blocker for backend** — Unity IAP uses per-transaction JWS, not the receipt bundle. Backend must migrate from `/verifyReceipt` to JWS validation |
+
+### Subscription Blocker Options (present to user when hard subscription blockers found)
+
+**Option A — Remove the blocking feature and simplify App Store Connect setup for Unity IAP compatibility**
+Remove promotional offer signing or simplify subscription configuration so Unity IAP can handle all products without native StoreKit. Recommended — single system, no coexistence risk.
+
+**Option B — Stay on native StoreKit for all products**
+Do not migrate at this time. Keep the native StoreKit plugin as-is until the App Store Connect configuration can be simplified or Unity IAP exposes the required features. Stop the conversion and document the blocker and this decision in `IapMigrationNotes.md`.
+
+---
+
+## Step 6 — Target Architecture
+
+Create under `Assets/Scripts/IAP/`:
+
+| File | Purpose |
+|---|---|
+| `IStorePurchaseService.cs` | Game-facing interface (stable public API) |
+| `UnityIapStorePurchaseService.cs` | Unity IAP 5.x implementation |
+| `ProductCatalogDefinition.cs` | ScriptableObject or plain class holding all `ProductDefinitionEntry` |
+| `ProductDefinitionEntry.cs` | Per-product data: ID, type, store-specific IDs |
+| `PurchaseEntitlementMapper.cs` | Maps Unity IAP order data → game grant calls |
+| `PurchaseValidationRequest.cs` | DTO sent to backend |
+| `PurchaseValidationResult.cs` | DTO received from backend |
+| `PurchaseRestoreResult.cs` | Result of restore operation |
+| `LegacyStoreKitAdapterDeprecated.cs` | Compatibility facade (only if game code calls old StoreKit bridge API directly) |
+| `IapMigrationNotes.md` | Human-readable notes on what changed, blockers found, manual steps |
+
+### Game-Facing Interface (preserve or adapt from existing API surface)
+
+```csharp
+public interface IStorePurchaseService
+{
+    Task InitializeAsync();
+    Task FetchProductsAsync();
+    IReadOnlyList<StoreProductInfo> GetProducts();
+    Task PurchaseAsync(string productId);
+    Task RestorePurchasesAsync();
+    bool IsInitialized { get; }
+}
+```
+
+---
+
+## Step 7 — Migration Phases
+
+### Phase 1 — Package Check
+
+- Verify `com.unity.purchasing` exists in `Packages/manifest.json`.
+- If absent or outdated, install the latest stable version via **Window > Package Manager > Unity Registry > In App Purchasing**. Do not auto-edit `manifest.json` unless the user explicitly allows it.
+- Confirm installation before proceeding.
+
+### Phase 2 — Product Catalog Extraction
+
+- Extract all product IDs and inferred types from the scan.
+- Generate `ProductCatalogDefinition.cs` / `ProductDefinitionEntry.cs`.
+- Each entry: `productId`, `ProductType`, optional `storeSpecificIds`, `notes`.
+
+### Phase 3 — New Unity IAP Service
+
+Create `UnityIapStorePurchaseService`:
+
+1. **Initialization** — `UnityIAPServices.StoreController()`, subscribe all events **before** `Connect()`.
+2. **Product fetching** — build `List<ProductDefinition>` from catalog, call `store.FetchProducts()`, handle `OnProductsFetched` / `OnProductsFetchFailed`.
+3. **Purchase initiation** — `store.PurchaseProduct(product)`.
+4. **Purchase callback** — `OnPurchasePending`: validate receipt → grant entitlement → `ConfirmPurchase(pendingOrder)`. **Never confirm before grant.**
+5. **Deferred purchases (Ask-to-Buy)** — `OnPurchaseDeferred`: show pending UI, do not grant. When approved, `OnPurchasePending` fires.
+6. **Promotional purchase interception** — if the existing plugin intercepts App Store promotional purchases, wire up:
+   ```csharp
+   if (store.AppleStoreExtendedPurchaseService != null)
+       store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += OnPromotionalPurchase;
+   ```
+   Call `store.AppleStoreExtendedPurchaseService?.ContinuePromotionalPurchases()` when ready to proceed.
+7. **Failed purchases** — `OnPurchaseFailed`: map `FailureReason` to user-facing error.
+8. **Restore** — `store.FetchPurchases()` re-delivers unconfirmed purchases via `OnPurchasePending`. Add `store.RestoreTransactions(callback)` for the explicit "Restore Purchases" button (required on iOS).
+9. **Validation handoff** — send `order.Info.Apple?.jwsRepresentation` to backend in place of the SK1 receipt bundle. Document the backend endpoint change required (see Behavior Change Rules).
+
+### Phase 4 — Compatibility Facade
+
+If game code calls the old native bridge directly (e.g., `NativeStoreKit.Purchase(id)`):
+
+- Create `LegacyStoreKitAdapterDeprecated.cs` that implements the same method signatures.
+- Delegate all calls to `UnityIapStorePurchaseService`.
+- Mark all methods `[Obsolete("Use IStorePurchaseService — remove after migration validation")]`.
+
+### Phase 5 — Remove Native Plugin from Active Path
+
+- Stop calling `[DllImport("__Internal")]` bridge methods for migrated products.
+- Wrap all native bridge calls in C# with `#if !USE_UNITY_IAP_V5` — do not delete them.
+- Do not delete ObjC/Swift plugin files — leave them in `Assets/Plugins/iOS/`. The `#if` guards on the C# call sites are sufficient to prevent the old bridge from being invoked.
+- If the existing plugin registers its own `SKPaymentQueue` observer (common), add a note in `IapMigrationNotes.md` that the plugin's observer registration must be removed or disabled before shipping — both observers competing for the same queue is a hard conflict.
+
+### Phase 6 — Test Scaffolding
+
+- Add debug logs at each IAP event.
+- Add editor stubs for sandbox testing.
+- Add the QA checklist from the test plan below to `IapMigrationNotes.md`.
+
+---
+
+## Step 8 — Behavior Change Rules
+
+### Receipt Format (backend-breaking change)
+
+The receipt format is fundamentally different between native StoreKit and Unity IAP. Flag this as a **required backend change** if server-side validation is in use.
+
+| Native approach | Unity IAP equivalent |
+|---|---|
+| SK1: `[NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]]` base64-encoded, validated against Apple's `/verifyReceipt` endpoint | `order.Info.Apple?.jwsRepresentation` — a per-transaction JWS string, validated against Apple's App Store Server API |
+| SK2: Per-transaction JWS string from `verificationResult` | Same — `order.Info.Apple?.jwsRepresentation` |
+
+Unity IAP uses StoreKit 2 under the hood (on iOS 15+). The resulting receipt is a JWS per transaction, not the SK1 app receipt bundle. If the backend currently calls `/verifyReceipt` with a base64 receipt, it must migrate to Apple's App Store Server API (`GET /inApps/v1/transactions/{transactionId}`) or use the JWS directly.
+
+### Transaction Finishing (Acknowledgement / Consumption)
+
+| Native StoreKit | Unity IAP |
+|---|---|
+| `SKPaymentQueue.default().finishTransaction(transaction)` — called after grant for all types | `store.ConfirmPurchase(pendingOrder)` — called after grant for all types |
+
+**Never call `ConfirmPurchase` before the entitlement is safely granted and saved.**
+
+### Restore Transactions
+
+| Native StoreKit | Unity IAP |
+|---|---|
+| `SKPaymentQueue.default().restoreCompletedTransactions()` | `store.RestoreTransactions(callback)` — for the explicit "Restore Purchases" button |
+| Checking for existing transactions at startup | `store.FetchPurchases()` — re-delivers any unconfirmed purchases via `OnPurchasePending` |
+
+`store.FetchPurchases()` should be called at startup. `RestoreTransactions` is only needed for the user-triggered restore button (required on iOS for Apple App Store compliance).
+
+### App Account Token (replacing `applicationUsername`)
+
+If the native plugin set `SKMutablePayment.applicationUsername` to associate purchases with a backend user:
+
+```csharp
+// Set after Connect() — accepts a Guid, not a string hash
+store.AppleStoreExtendedService?.SetAppAccountToken(Guid.Parse(userAccountGuid));
+```
+
+Must be called **after** `await store.Connect()`. The token is attached to the transaction and surfaced in the JWS payload.
+
+### Ask-to-Buy (Deferred Purchases)
+
+| Native StoreKit | Unity IAP |
+|---|---|
+| `SKPaymentTransactionStatePurchasing` + parent approval pending → `paymentQueue:removedTransactions:` | `store.OnPurchaseDeferred` — show pending UI, do not grant |
+| Purchase approved → `paymentQueue:updatedTransactions:` with `SKPaymentTransactionStatePurchased` | `store.OnPurchasePending` — grant content, then confirm |
+
+If the existing plugin simulates Ask-to-Buy via `store.AppleStoreExtendedPurchaseService?.simulateAskToBuy`, that property is still available in Unity IAP 5.
+
+### Code Redemption Sheet
+
+If the native plugin calls `SKPaymentQueue.default().presentCodeRedemptionSheet()`:
+
+```csharp
+store.AppleStoreExtendedPurchaseService?.PresentCodeRedemptionSheet();
+```
+
+Available after `Connect()`. Null-check required — only non-null on iOS.
+
+### Promotional Purchases
+
+If the native plugin intercepts App Store promotional purchases (products promoted on the App Store product page):
+
+```csharp
+// Subscribe after Connect() — if() required (?.+= does not work with events)
+if (store.AppleStoreExtendedPurchaseService != null)
+    store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += OnPromotionalPurchase;
+
+void OnPromotionalPurchase(Product product)
+{
+    // Show confirmation UI, then:
+    store.AppleStoreExtendedPurchaseService?.ContinuePromotionalPurchases();
+}
+```
+
+---
+
+## Step 9 — Native → Unity IAP Concept Mapping
+
+### StoreKit 1
+
+| Native StoreKit 1 | Unity IAP 5.x |
+|---|---|
+| `SKProduct` | `Product` (via `store.GetProductById`) |
+| `SKPaymentTransaction` | `PendingOrder` (on `OnPurchasePending`) |
+| `SKPaymentTransaction.transactionIdentifier` | `pendingOrder.Info.Apple?.transactionId` |
+| `SKPaymentTransaction.payment.productIdentifier` | `pendingOrder.CartOrdered.Items().First().Product.definition.id` |
+| App receipt (`appStoreReceiptURL` base64) | `order.Info.Apple?.jwsRepresentation` (per-transaction JWS — see receipt format note) |
+| `SKPaymentQueue.default().finishTransaction:` | `store.ConfirmPurchase(pendingOrder)` |
+| `SKPaymentQueue.default().restoreCompletedTransactions()` | `store.RestoreTransactions(callback)` |
+| `SKPaymentTransactionStatePurchased` | `store.OnPurchasePending` |
+| `SKPaymentTransactionStateFailed` | `store.OnPurchaseFailed` |
+| `SKPaymentTransactionStateDeferred` | `store.OnPurchaseDeferred` |
+| `SKPaymentTransactionStateRestored` | `store.OnPurchasesFetched` (via `FetchPurchases`) or `store.OnPurchasePending` (via `RestoreTransactions`) |
+| `SKProductsRequest` + `productsRequest:didReceiveResponse:` | `store.FetchProducts(definitions)` → `store.OnProductsFetched` |
+| `SKPaymentQueue.canMakePayments()` | `store.AppleStoreExtendedService?.canMakePayments` (after `Connect()`) |
+| `SKMutablePayment.applicationUsername` | `store.AppleStoreExtendedService?.SetAppAccountToken(Guid)` (after `Connect()`) |
+| `SKPaymentDiscount` (promotional offer) | **Not supported** — report as hard blocker |
+| `SKReceiptRefreshRequest` | No direct equivalent — `store.FetchPurchases()` covers re-delivery |
+| `SKStorefront` | Not exposed in Unity IAP |
+| `product.subscriptionPeriod` | `store.AppleStoreExtendedProductService?.GetProductDetails()` (returns raw JSON) |
+| `product.introductoryPrice` | `store.AppleStoreExtendedProductService?.GetIntroductoryPriceDictionary()` |
+
+### StoreKit 2
+
+| Native StoreKit 2 | Unity IAP 5.x |
+|---|---|
+| `Product.products(for:)` | `store.FetchProducts(definitions)` → `store.OnProductsFetched` |
+| `product.purchase()` | `store.PurchaseProduct(product)` |
+| `Transaction.currentEntitlements` (async stream) | `store.FetchPurchases()` → `store.OnPurchasesFetched` |
+| `Transaction.updates` (async stream) | `store.OnPurchasePending` (event-driven) |
+| `transaction.finish()` | `store.ConfirmPurchase(pendingOrder)` |
+| JWS transaction string from `verificationResult` | `order.Info.Apple?.jwsRepresentation` |
+| `Transaction.currentEntitlements` for entitlement check | `store.CheckEntitlement(product)` → `store.OnCheckEntitlement` |
+| `winBackOffer` / `eligibleWinBackOffers` | **Not supported** — report as hard blocker |
+
+---
+
+## Step 10 — Rollback Plan
+
+- Wrap all new Unity IAP C# code in `#if USE_UNITY_IAP_V5`.
+- Wrap all replaced native bridge calls (`[DllImport("__Internal")]` invocations) in `#if !USE_UNITY_IAP_V5`.
+- ObjC/Swift plugin files cannot use C# defines — leave them in place untouched. The `#if` guards on the C# call sites prevent the bridge from being invoked.
+- To revert: remove `USE_UNITY_IAP_V5` from **Edit > Project Settings > Player > Scripting Define Symbols**. The native StoreKit bridge is restored without any code changes.
+- Never activate both purchase systems simultaneously — both register as `SKPaymentQueue` observers and will compete.
+- Document the rollback steps in `IapMigrationNotes.md`.
+
+---
+
+## Step 11 — Test Checklist
+
+Include this in `IapMigrationNotes.md` after migration:
+
+- [ ] Fresh install — products load and display prices
+- [ ] Upgrade from old app version to migrated version — no duplicate entitlements
+- [ ] Consumable purchase — content granted
+- [ ] Repeat consumable purchase — repeatable, no block
+- [ ] Non-consumable purchase — content granted once
+- [ ] Non-consumable restore via "Restore Purchases" button — content restored on reinstall
+- [ ] Subscription purchase — subscription active
+- [ ] Subscription restore — status refreshed on launch
+- [ ] Ask-to-Buy (deferred) — pending UI shown, no premature grant; purchase completes when parent approves
+- [ ] Promotional purchase intercept (if applicable) — `OnPromotionalPurchaseIntercepted` fires, `ContinuePromotionalPurchases()` proceeds correctly
+- [ ] Code redemption sheet (if applicable) — `PresentCodeRedemptionSheet()` opens
+- [ ] Interrupted purchase flow — re-delivered on next launch via `OnPurchasePending`
+- [ ] App killed during purchase — pending order re-delivered on next launch
+- [ ] Backend validation success — entitlement granted (JWS payload accepted by backend)
+- [ ] Backend validation failure — entitlement NOT granted, purchase not confirmed
+- [ ] Network failure during validation — purchase left pending, re-delivered on next launch
+- [ ] Sandbox tester account — no real charges, sandbox transactions process correctly
+- [ ] TestFlight build — products load and sandbox purchases succeed
+- [ ] App Store Connect product ID match — all IDs match exactly
+- [ ] App Store Connect subscription group — base plan configuration compatible with Unity IAP
+- [ ] No duplicate entitlement grant
+- [ ] No unfinished transactions remaining (all purchases confirmed)
+- [ ] No double grant of consumables
+
+---
+
+## Step 12 — Questions to Ask (only when required)
+
+Ask only when the information cannot be inferred:
+
+1. Which product IDs are consumable, non-consumable, or subscription?
+2. Does the backend currently validate using the SK1 receipt bundle (base64 + `/verifyReceipt`)? If so, a backend migration to JWS validation is required.
+3. Does the plugin intercept App Store promotional purchases (`paymentQueue:shouldAddStorePayment:forProduct:`)?
+4. Are any subscriptions using promotional offer signing (`SKPaymentDiscount`)? If so, this is a hard blocker.
+5. Should the skill preserve the old public C# billing API as a compatibility facade?
+6. Should native ObjC/Swift plugin files be kept, disabled, or removed after migration validation?
+
+If enough information can be inferred, proceed with a best-effort plan and mark uncertain items as **TODO**.

--- a/skills/implement-in-app-purchases/references/path-implement-iap-d2c.md
+++ b/skills/implement-in-app-purchases/references/path-implement-iap-d2c.md
@@ -1,0 +1,664 @@
+# Implement Unity IAP D2C Capabilities (Third-Party Payment Provider)
+
+## Table of Contents
+
+- [Trigger Phrases](#trigger-phrases)
+- [Prerequisites (verify before any changes)](#prerequisites-verify-before-any-changes)
+- [Step 1 — Project Scan](#step-1--project-scan)
+- [Step 2 — Product Discovery](#step-2--product-discovery)
+- [Step 3 — IAPManager with PaymentProvider](#step-3--iapmanager-with-paymentprovider)
+- [Step 4 — Remote Catalog](#step-4--remote-catalog)
+- [Step 5 — Deep Link Setup](#step-5--deep-link-setup)
+- [Step 6 — Purchase Handling](#step-6--purchase-handling)
+- [Step 7 — Product Type Behavior](#step-7--product-type-behavior)
+- [Step 8 — Cloud Save Integration](#step-8--cloud-save-integration)
+- [Step 9 — Verification Report](#step-9--verification-report)
+- [Step 10 — Manual Steps (always include in report)](#step-10--manual-steps-always-include-in-report)
+
+Use this reference when the user explicitly asks to add IAP D2C Capabilities (third-party payment provider such as Stripe or Coda) to a project. This path is valid only when the project has no IAP, or already has `com.unity.purchasing` v5.x installed.
+
+**Not valid when:** the project has IAP v4, native Google Billing, or a third-party IAP package — resolve those first via `pre-check.md` before returning to this path.
+
+## Trigger Phrases
+
+- "Add IAP D2C Capabilities"
+- "Integrate Stripe / Coda payments"
+- "Add third-party payment provider"
+- "Set up web-based IAP checkout"
+- "Add Unity payment provider"
+
+## Prerequisites (verify before any changes)
+
+| Requirement | Detail |
+|---|---|
+| Unity Editor | **2022.3 or later** — IAP 5.4 does not support older Editor versions |
+| `com.unity.purchasing` | **v5.4+** |
+| `com.unity.services.authentication` | **v3.7.1+** — IAP D2C Capabilities will not initialize without this version or later |
+| `com.unity.services.core` | **v1.18.0+** — required by IAP 5.4 |
+| Unity Gaming Services initialized | `UnityServices.InitializeAsync()` and sign-in must complete **before** IAP D2C Capabilities initialization |
+| Unity Deployment package | Required to deploy product catalogs to the Remote Catalog service — install via **Window > Package Manager > Unity Registry > Deployment** |
+| Unity Cloud project linked | Project must be connected to a Unity Cloud organization |
+| Payment provider account | Developer must have a Stripe or Coda account connected in the Unity Cloud IAP dashboard |
+| Unity Cloud IAP dashboard setup | Products must be created and deployed to the Remote Catalog in Unity Cloud before the client can fetch them |
+
+If any prerequisite is missing, stop and list the missing items for the user before writing any code.
+
+## Step 1 — Project Scan
+
+Search the project for existing IAP and economy signals before writing any code.
+
+### 1a — Existing IAP detection
+
+Search `Packages/manifest.json` for `com.unity.purchasing`:
+- If **v5.4+** found → proceed, IAP D2C Capabilities will be added alongside.
+- If **v5.0–5.3** found → inform the user that v5.4+ is required, instruct them to upgrade `com.unity.purchasing` to v5.4+ via Package Manager, and continue once the upgrade is confirmed.
+- If **absent** → proceed, IAP D2C Capabilities will be added fresh.
+
+### 1b — Unity Authentication detection
+
+Search `Packages/manifest.json` for `com.unity.services.authentication`. If absent, inform the user it must be installed — IAP D2C Capabilities will not initialize without a signed-in player.
+
+### 1c — Inventory and economy scan
+
+Search `Assets/**/*.cs` for:
+```
+\bcoins\b|\bgems\b|\blives\b|\binventory\b|\bcurrency\b
+PlayerData|SaveAsync|CloudSave|SaveDataAsync|SaveGame
+```
+
+### 1d — Shop UI scan
+
+Search `Assets/**/*.unity`, `*.prefab` for shop-related GameObjects and scripts:
+```
+Shop|Store|Purchase|Buy|IAP|Product
+```
+
+## Step 2 — Product Discovery
+
+### If existing `.ucat` files are found
+
+Locate `Assets/**/*.ucat` files. Each file is a JSON product definition (see format below). Use them as-is.
+
+### If existing IAP 5 `ProductDefinition` objects are found
+
+These are local store products — IAP D2C Capabilities uses a Remote Catalog instead. Inform the user that existing local product definitions need to be re-created as `.ucat` files deployed to Unity Cloud, and that product IDs (`uSKU`) should match the existing IDs to preserve store history.
+
+### If no product definitions exist
+
+**Stop and ask:**
+
+> "Please provide the first IAP product ID and type — for example `com.mygame.coins100` as Consumable — and tell me which inventory field, currency, or item should be credited after purchase."
+
+- Default to Consumable if type is not provided, but state the assumption explicitly.
+- **If any Subscription products are provided or detected**, exclude them from the implementation and warn the user:
+
+  > "The following products were skipped because subscriptions are not supported by IAP D2C Capabilities in v5.4+: [list]. Only Consumable and NonConsumable products will be implemented."
+
+  Continue with the remaining Consumable and NonConsumable products. If no supported products remain after exclusion, stop and inform the user.
+
+### Product definition format (`.ucat`)
+
+IAP D2C Capabilities products are defined as JSON files with the `.ucat` extension under `Assets/` — not defined in code. Each file defines one product. The local `.ucat` shape is fed by `Editor/Authoring/Core/Model/CatalogItem.cs`; on upload the SDK converts it to the wire DTO (`CatalogItemDto.cs`) — see "Local vs uploaded shape" below.
+
+**Identity — filename drives it:**
+
+The `.ucat` filename (without extension) is the source of truth for two identifiers on load (`Editor/Authoring/IO/CatalogItemLoader.cs`):
+
+- **`CatalogListingId` = `"catalog/" + <filename-stem>`**. Always. This is the id passed to `PurchaseProduct(catalogListingId)` and matched against the remote catalog. It is **never** stored in the `.ucat` JSON body (`[IgnoreDataMember, JsonIgnore]` — see `CatalogItem.cs:41-42`); the `catalog/` prefix is added by the SDK, not the developer.
+- **`uSKU` = the JSON `uSKU` field if present, otherwise `<filename-stem>`**. Omit `uSKU` from the JSON when you want it to match the filename (the common case). Include it only when the store SKU must differ from the filename (e.g. legacy IDs you can't rename). On save, if `uSKU` equals the filename stem, the writer strips it out again to keep the file lean.
+
+So a file named `coins_100.ucat` with no `uSKU` field gives you `uSKU = "coins_100"` and `CatalogListingId = "catalog/coins_100"` for free.
+
+```json
+{
+  "type": "Consumable",
+  "productDetails": [
+    {
+      "language": "en_US",
+      "title": "100 Coins",
+      "subtitle": "Best value",
+      "description": "A pack of 100 coins.",
+      "badge": { "text": "Popular", "imageUrl": "https://example.com/badges/popular.png" }
+    }
+  ],
+  "pricing": [
+    { "currencyCode": "USD", "amount": 1.99 },
+    { "currencyCode": "EUR", "amount": 1.79, "webshopPrice": 1.49 }
+  ],
+  "imageUrl": "https://example.com/img/coins100.png",
+  "storeIdOverrides": [
+    { "store": "apple",  "value": "com.mygame.coins100.ios" },
+    { "store": "google", "value": "com.mygame.coins100.android" }
+  ],
+  "isWebshopAvailable": true,
+  "categories": ["currency", "starter"],
+  "hdImages": [
+    { "url": "https://example.com/hd/coins100.png", "altText": "100 coins bundle" }
+  ],
+  "promotion": {
+    "type": "Sale",
+    "startsAt": "2026-12-01T00:00:00Z",
+    "endsAt": "2026-12-15T23:59:59Z"
+  }
+}
+```
+
+(Add `"uSKU": "..."` explicitly only when overriding the filename-derived value.)
+
+**Top-level fields:**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `uSKU` | string |   | Product ID — equivalent to `ProductDefinition.id` in standard IAP. **Optional in the JSON body** — defaults to the filename stem. Include it only to override. Pattern `^[a-zA-Z0-9._-]+$`, max 141 chars. |
+| `type` | enum | ✓ | `"Consumable"`, `"NonConsumable"`, or `"Subscription"`. |
+| `productDetails` | array | ✓ | ≥1 entry. See sub-schema below. |
+| `pricing` | array | ✓ | ≥1 entry. See sub-schema below. |
+| `imageUrl` | string | | HTTPS URL, max 2048 chars. Recommended for shop UI. |
+| `storeIdOverrides` | array | | Per-store SKU overrides. See sub-schema below. |
+| `isWebshopAvailable` | bool | | **Local toggle only** — never uploaded. Opts the item into the webshop schema variant. When `true`, the SDK adds the `UnityRemoteCatalogWebshop` `$schema` URL and emits `categories` / `hdImages` / `promotion` on upload. When `false`, those webshop fields are stripped on upload and any server-side webshop data is erased. |
+| `categories` | string[] | | Webshop taxonomy. Only meaningful when `isWebshopAvailable=true`. |
+| `hdImages` | array | | Webshop hero images. Only meaningful when `isWebshopAvailable=true`. See sub-schema below. |
+| `promotion` | object | | Webshop promotion overlay. Only meaningful when `isWebshopAvailable=true`. See sub-schema below. |
+
+**`productDetails[]`:** `language` (required, enum e.g. `en_US`, `fr_FR`), `title` (required, 1–50 chars), `subtitle` (optional, 1–50 chars), `description` (optional, 1–250 chars), `badge` (optional, `{ text (required), imageUrl (optional HTTPS) }`).
+
+**`pricing[]`:** `currencyCode` (required, ISO 4217 e.g. `"USD"`), `amount` (required, decimal in major units — `1.99`, not micros), `webshopPrice` (optional, decimal in major units — set only when a webshop-only price differs from `amount`; values below `0.001` are treated as unset).
+
+**`storeIdOverrides[]`:** `store` (required, enum: `"apple"`, `"google"`, `"xbox"`, `"applemacos"`), `value` (required, the store-specific SKU).
+
+**`hdImages[]`:** `url` (required, HTTPS), `altText` (optional).
+
+**`promotion`:** `type` (required, enum: `"Sale"`, `"Bonus"`, `"Limited"`), `startsAt` (optional, ISO 8601 UTC), `endsAt` (optional, ISO 8601 UTC).
+
+**Local vs uploaded shape.** The `.ucat` on disk is what devs edit; the payload sent to the Live Content admin API is converted by `LiveContentConfigClient.ConvertToDto`:
+
+- `amount` and `webshopPrice` go from decimal major units on disk (`1.99`) to micros integer on the wire (`1990000`). Rounding: `Math.Round(amount * 1_000_000, MidpointRounding.AwayFromZero)`.
+- `$schema` is populated by the SDK on upload — never in the on-disk `.ucat`:
+  - Always: `https://services.api.unity.com/schema-registry/v1/schemas/UnityRemoteCatalog/versions/1.1.0`
+  - Added when `isWebshopAvailable=true`: `https://services.api.unity.com/schema-registry/v1/schemas/UnityRemoteCatalogWebshop/versions/1.1.0`
+- `isWebshopAvailable` is never uploaded — the server infers webshop-ness from the `$schema` array.
+- `categories`, `hdImages`, `promotion` are only emitted on upload when `isWebshopAvailable=true`. Toggling it off and re-uploading erases the server-side webshop data.
+
+Remind the user that `.ucat` files must be **deployed to the Remote Catalog** via Unity Cloud dashboard or the Deployment package before the client can fetch them.
+
+### Product definition format (`.catalog.csv`)
+
+An alternative to per-item `.ucat` JSON is a single `.catalog.csv` file at any location under `Assets/`. The parser is `Editor/Authoring/Core/IO/CatalogCsvParser.cs`; each row is aggregated by `CatalogListingId` into the same `CatalogItem` model as the `.ucat` path, so uploaded output is identical.
+
+**Columns (23):**
+
+| Column | Maps to | Aggregation |
+|---|---|---|
+| `CatalogListingId` | catalog listing id — row-identity key. If provided, it **must include the `catalog/` prefix** (e.g. `catalog/coins_100`). If blank, the parser derives it as `"catalog/" + Sku`. | per-item |
+| `Sku` | `uSKU` — required. Also seeds `CatalogListingId` when that column is blank. | per-item |
+| `ProductType` | `type` (Consumable / NonConsumable / Subscription) | per-item |
+| `Language` | `productDetails[].language` | per-row |
+| `Title` | `productDetails[].title` | per-row |
+| `Subtitle` | `productDetails[].subtitle` | per-row |
+| `Description` | `productDetails[].description` | per-row |
+| `BadgeText` | `productDetails[].badge.text` | per-row |
+| `BadgeImageUrl` | `productDetails[].badge.imageUrl` | per-row |
+| `CurrencyCode` | `pricing[].currencyCode` | per-row |
+| `Amount` | `pricing[].amount` (decimal major units, e.g. `1.99`) | per-row |
+| `WebshopPrice` | `pricing[].webshopPrice` (decimal major units) | per-row |
+| `ImageUrl` | `imageUrl` | per-item |
+| `GoogleOverride` | `storeIdOverrides[store="google"].value` | per-item |
+| `AppleOverride` | `storeIdOverrides[store="apple"].value` | per-item |
+| `XboxStoreOverride` | `storeIdOverrides[store="xbox"].value` | per-item |
+| `MacAppStoreOverride` | `storeIdOverrides[store="applemacos"].value` | per-item |
+| `IsWebshopAvailable` | `isWebshopAvailable` (local toggle — see .ucat notes) | per-item |
+| `Category` | `categories[]` (one category per row) | per-row, aggregated |
+| `HdImageUrl` | `hdImages[].url` (one image per row) | per-row, aggregated |
+| `HdImageAltText` | `hdImages[].altText` | per-row, aggregated |
+| `PromotionType` | `promotion.type` (Sale / Bonus / Limited) | per-item, first row wins, conflicts on later rows flagged |
+| `PromotionStartsAt` | `promotion.startsAt` (ISO 8601 UTC) | per-item, first row wins |
+| `PromotionEndsAt` | `promotion.endsAt` (ISO 8601 UTC) | per-item, first row wins |
+
+**Aggregation rules:**
+- **per-item** columns (Sku, ProductType, imageUrl, overrides, IsWebshopAvailable, Promotion*): set once on the first row of a given `CatalogListingId`. Subsequent rows are conflict-checked and flagged if they disagree.
+- **per-row** columns without aggregation (Language/Title/Subtitle/Description/Badge*/CurrencyCode/Amount/WebshopPrice): one `productDetails` or `pricing` entry per row.
+- **per-row, aggregated** (Category, HdImageUrl, HdImageAltText): each row contributes one entry to the corresponding array on the item.
+
+**Minimal example (one product, EN + FR localizations, one price):**
+
+```csv
+CatalogListingId,Sku,ProductType,Language,Title,Description,CurrencyCode,Amount,ImageUrl
+coins_100,com.mygame.coins100,Consumable,en_US,100 Coins,A pack of 100 coins.,USD,1.99,https://example.com/img/coins100.png
+coins_100,com.mygame.coins100,Consumable,fr_FR,100 Pièces,Un lot de 100 pièces.,EUR,1.79,
+```
+
+The same amount/schema conversion applies on upload as for `.ucat`.
+
+## Step 3 — IAPManager with PaymentProvider
+
+### Key difference from standard IAP 5
+
+IAP D2C Capabilities uses a `PaymentProvider.Name` parameter when obtaining the `StoreController`:
+
+```csharp
+// Standard IAP 5
+_storeController = UnityIAPServices.StoreController();
+
+// IAP D2C Capabilities — pass the payment provider name
+_storeController = UnityIAPServices.StoreController(PaymentProvider.Name);
+```
+
+`PaymentProvider.Name` is a constant that identifies the third-party provider integration. It does **not** return the display name of the provider (Stripe/Coda).
+
+### Initialization sequence
+
+IAP D2C Capabilities requires Unity Gaming Services and player sign-in to complete **before** `StoreController` is obtained. Follow this order:
+
+1. `await UnityServices.InitializeAsync()`
+2. Sign the player in via Unity Authentication
+3. Only after sign-in succeeds: obtain `StoreController(PaymentProvider.Name)` and call `Connect()`
+
+Do not call `StoreController(PaymentProvider.Name)` before the player is authenticated.
+
+**Anonymous sign-in warning:** Do not use anonymous sign-in as the authentication method for D2C purchases. Anonymous sign-in does not persist purchases after the session token is lost — if the player reinstalls the app or clears app data, their purchase history becomes unrecoverable. Use a persistent identity method (e.g., Unity Authentication with a linked account, or your own identity provider).
+
+### Coexistence with existing Apple / Google StoreController
+
+If the project already has a `StoreController` for Apple App Store or Google Play (standard IAP 5):
+
+- **Always create a new, separate `StoreController`** scoped to `PaymentProvider.Name`. Never modify or replace the existing one.
+- The two controllers are independent — they manage different products on different billing backends and do not interfere with each other.
+- After the new IAP D2C Capabilities `StoreController` is successfully created and connected, **prompt the user:**
+
+  > "An existing Apple/Google StoreController was found. Would you like to:
+  > - **Keep both** — run Apple/Google billing and IAP D2C Capabilities side by side (existing products stay on Apple/Google, new products use IAP D2C Capabilities)
+  > - **Remove the Apple/Google StoreController** — migrate fully to IAP D2C Capabilities (note: existing Apple/Google products and purchase history will no longer be managed by the app)"
+
+- If the user chooses **keep both**: leave the existing `StoreController` and its initialization code untouched. Document the dual-controller setup in code comments.
+- If the user chooses **remove**: wrap the existing `StoreController` code in `#if !USE_IAP_D2C_ONLY` guards — do not delete it. Mark it `[Obsolete]` and document the removal decision. Instruct the user to also retire the corresponding products in App Store Connect / Play Console as needed.
+
+### Checking eligible payment providers
+
+Before initiating purchase, use `GetEligiblePaymentProviders()` to confirm that at least one payment provider is available for the current user and region. Call this after `Connect()` and `FetchProducts()` succeed:
+
+```csharp
+var eligible = await store.PaymentProviderStoreExtendedService?.GetEligiblePaymentProviders();
+if (eligible == null || eligible.Providers.Count == 0)
+{
+    // No payment providers available — hide purchase UI or show an error
+    return;
+}
+
+if (!eligible.PaymentOptionPopupEnabled)
+{
+    // Only one provider available — proceed directly without showing the picker UI
+}
+```
+
+`EligiblePaymentProviders.Providers` is a priority-ordered list of provider names. If `PaymentOptionPopupEnabled` is false, there is only one provider and the built-in picker UI should be suppressed.
+
+### Built-in payment options picker UI
+
+Unity IAP 5.4 ships a ready-made Purchase Options UI that presents the player with all eligible payment options (native App Store/Google Play, D2C payment provider, webshop). **Use `ShowPurchaseOption` as the primary purchase entry point** — it is the recommended integration path for D2C payments.
+
+Obtain `IPaymentOptionProvider` once after connect and store it:
+
+**UGUI** (for projects using Unity UI):
+```csharp
+var m_PaymentOptionProvider = store.PaymentProviderStoreExtendedService?.GetPaymentOptionProviderUGUI();
+```
+
+**UI Toolkit** (for projects using UI Toolkit):
+```csharp
+var m_PaymentOptionProvider = store.PaymentProviderStoreExtendedService?.GetPaymentOptionProviderUITK(hostDocument);
+```
+
+Then initiate purchase with the `catalogListingId`:
+```csharp
+public async void Buy(string catalogListingId)
+{
+    var eligibility = await store.PaymentProviderStoreExtendedService?.GetEligiblePaymentProviders();
+    if (eligibility?.Providers.Count > 0)
+    {
+        // Show the Purchase Options UI — lets the player pick native, D2C, or webshop
+        await m_PaymentOptionProvider.ShowPurchaseOption(catalogListingId);
+    }
+    else if (m_NativeStore != null)
+    {
+        // No PSP available — fall back to a NATIVE StoreController (App Store / Google Play).
+        // `store` above is scoped to PaymentProvider.Name, so calling PurchaseProduct on it
+        // would still route through the PSP flow (not native billing). The fallback must use
+        // a separate native-scoped StoreController that the app kept alive alongside `store` —
+        // see "Coexistence with existing Apple / Google StoreController" above.
+        m_NativeStore.PurchaseProduct(catalogListingId);
+    }
+    else
+    {
+        // No PSP available AND no native controller — the sale can't proceed.
+        // Surface the error to the caller so it can show an appropriate message.
+        Debug.LogWarning($"No payment path available for {catalogListingId}.");
+    }
+}
+```
+
+`GetEligiblePaymentProviders()` returns an `EligiblePaymentProviders` bundle. An empty `Providers` list means no routing rules match the player or no payment providers are available for their region.
+
+**Do not call `PurchaseProduct` on the PSP-scoped `StoreController` as a "native fallback"** — it routes through the payment provider store regardless. Native billing requires a separate `StoreController()` (default constructor = platform default). Projects that already have an Apple/Google `StoreController` should reuse it here; greenfield D2C-only projects have no native fallback path and should surface a "payment unavailable" error instead.
+
+`EligiblePaymentProviders` also exposes `PaymentOptionPopupEnabled` (server-driven killswitch) — check it before showing the picker if you want to respect the server's suppression.
+
+### Interpreting the picker result
+
+`ShowPurchaseOption(catalogListingId)` returns `Task<string?>`. The returned string is the identifier of whatever the player picked:
+
+- `IPaymentOptionProvider.NativeAlias` (`"native"`) — the platform default (App Store / Google Play) at click time.
+- `IPaymentOptionProvider.WebshopAlias` (`"webshop"`) — the "Continue with webshop" button (only appears when the listing has a webshop; see `PaymentProviderProductMetadata.hasWebshop` below).
+- A specific PSP identifier (`"stripe"`, `"codapay"`, …) — the player picked a payment provider directly.
+- `null` — the player dismissed the picker (X button / backdrop tap).
+
+The cross-product overload `ShowPurchaseOption(IReadOnlyList<PurchaseOption>)` returns `Task<PurchaseOption?>` — each `PurchaseOption` is `(StoreName, CatalogListingId, Badge?)` and the returned value is the chosen one (or null on cancel). Failures surface as `PurchaseChoiceFailedException` on the awaited task (carries the `PurchaseOption Choice` and the inner exception).
+
+### Provider memory
+
+The SDK remembers the last payment provider used by a player on a given device and pre-selects it the next time the Purchase Options picker is shown. This is intentional UX — returning players skip the picker and go straight to their previous provider.
+
+Implications to be aware of:
+
+- **Not a bug:** If the picker appears to skip showing options, the player has a remembered provider. This is expected behavior.
+- **Testing:** After switching providers in the Unity Dashboard, test devices may still route to the previously remembered provider. Clear app data on the device to reset provider memory during testing.
+- **No override API:** There is no programmatic way to clear or override provider memory at runtime. If your UX requires always showing the full picker, present a "Change payment method" option that re-invokes `ShowPurchaseOption` — the picker will still show the remembered provider pre-selected, but the player can change it.
+
+### IAPManager responsibilities
+
+Same as standard IAP 5 (see `path-add-iap-to-new-project.md` Step 4), with these additions:
+- Hold the `PaymentProvider.Name`-scoped `StoreController` instance.
+- Hold the `IPaymentOptionProvider` instance (UGUI or UI Toolkit, matching project's UI system).
+- Expose `Buy(string catalogListingId)` — calls `ShowPurchaseOption(catalogListingId)` if eligible, falls back to `PurchaseProduct(catalogListingId)` if not.
+- Expose `RestorePurchases()` only if NonConsumable products exist.
+- Ensure `UnityServices.InitializeAsync()` and player sign-in both complete before `StoreController(PaymentProvider.Name)` is obtained and `Connect()` is called.
+- Call `GetEligiblePaymentProviders()` after connect and use the result to gate purchase UI visibility.
+- **Only automatic entitlement delivery is supported.** Do not implement server-authoritative grant logic in this path unless the user explicitly requests it.
+
+## Step 4 — Remote Catalog
+
+IAP D2C Capabilities products come from Unity Cloud, not a local `List<ProductDefinition>`. Use `RemoteCatalogProvider` to fetch them:
+
+```csharp
+// 1. Create the provider
+var catalogProvider = new RemoteCatalogProvider();
+
+// 2. Fetch catalog — no parameters needed, fetches all configured providers
+var result = await catalogProvider.FetchRemoteCatalog();
+
+if (!result.Success)
+    throw result.Exception;
+
+// 3. Pass fetched definitions to the StoreController
+var productDefinitions = catalogProvider.GetProducts();
+_storeController.FetchProducts(productDefinitions);
+```
+
+- `FetchRemoteCatalog` fetches the catalog deployed to the Unity Cloud environment configured in **Edit > Project Settings > Services > Environments** (Development / Staging / Production).
+- Call `FetchRemoteCatalog` after `Connect()` succeeds.
+- `catalogProvider.GetProducts()` returns `List<ProductDefinition>` — pass directly to `store.FetchProducts()`.
+- If `result.Success` is false, do not proceed — surface the error to the user.
+
+### CatalogListing and multiple offers per product
+
+IAP D2C Capabilities supports products with multiple purchasable offers, each identified by a `catalogListingId`. A `CatalogListing` groups a `ProductDefinition` with its metadata and availability flag:
+
+```csharp
+// Look up the Product that owns a given catalogListingId (set in Unity Cloud dashboard).
+// GetProductByCatalogListingId returns the Product; grab the specific CatalogListing off it.
+var product = _storeController.GetProductByCatalogListingId("coins_100_offer_usd");
+if (product != null
+    && product.catalogListings.TryGetValue("coins_100_offer_usd", out var listing)
+    && listing.availableToPurchase)
+{
+    // listing.definition  — ProductDefinition (id, type, catalogListingId)
+    // listing.metadata    — ProductMetadata (localizedTitle, localizedPriceString, etc.)
+    _storeController.PaymentProvidersExtendedPurchaseService?
+        .PurchaseProduct("coins_100_offer_usd", PaymentProvider.Name);
+}
+```
+
+Use `catalogListingId` when a single product (uSKU) has multiple regional or promotional offers. If products have only one offer each, `GetProductById(uSKU)` is sufficient and `CatalogListing` lookup is not needed.
+
+### Iterating catalog listings on a fetched product
+
+After `OnProductsFetched` fires, each `Product` object exposes a `catalogListings` dictionary. Iterate its values to enumerate all available offers for that product:
+
+```csharp
+void OnProductsFetched(List<Product> products)
+{
+    foreach (var product in products)
+    {
+        foreach (var catalogListing in product.catalogListings.Values)
+        {
+            Debug.Log($"ID: {catalogListing.definition.id} - Price: {catalogListing.metadata.localizedPriceString}");
+        }
+    }
+}
+```
+
+`product.catalogListings` is a `Dictionary<string, CatalogListing>` keyed by `catalogListingId`. Use `.Values` to iterate all listings, or index directly by ID when the listing ID is known.
+
+### Webshop-aware product metadata
+
+Products fetched through the PaymentProvider store carry an extended metadata type, `PaymentProviderProductMetadata`, that surfaces webshop-specific fields alongside the standard `ProductMetadata`. Retrieve it via the extension method on `ProductMetadata`:
+
+```csharp
+var pspMeta = product.metadata.GetPaymentProviderProductMetadata();
+if (pspMeta?.hasWebshop == true)
+{
+    // The listing has a webshop configured; you can render a "Continue with webshop" button
+    // and/or a "save X% in the webshop" badge.
+    var webshopPrice = pspMeta.localizedWebshopPrice;      // decimal? — null when no webshop price
+    var webshopPriceString = pspMeta.webshopPriceString;   // pre-formatted for the current locale
+}
+```
+
+Returns `null` when the product wasn't fetched through the PaymentProvider store. The built-in picker already reads `hasWebshop` to decide whether to append the webshop button on the single-listing form — this API is for custom UIs that need the same signal.
+
+### Direct webshop launch (no picker)
+
+Skip the picker entirely and open the webshop for a specific listing (or the generic Unity webshop when `catalogListingId` is null):
+
+```csharp
+await store.PaymentProvidersExtendedPurchaseService?
+    .RedirectToWebshop("coins_100_offer_usd");
+```
+
+The SDK fetches the webshop URL, runs the registered compliance callback (`SetComplianceCheck`), and opens the URL on approval. Network failures propagate as exceptions on the returned `Task`; compliance rejection routes through the standard `OnPurchaseFailed` path.
+
+## Step 5 — Deep Link Setup
+
+IAP D2C Capabilities launches the device's mobile browser to handle payment. After payment, the browser must redirect back to the game via a deep link.
+
+### Choosing a deep link scheme
+
+**Use app-scheme deep links** (e.g., `mygame://iapresult/okay`) rather than URL-scheme deep links (e.g., `https://mygame.com/iapresult`).
+
+URL-scheme deep links require the domain to be verified by Google (Digital Asset Links). App-scheme deep links avoid this requirement and are simpler to configure.
+
+**Prompt the user:**
+
+> "What redirect URL did you configure in the Unity Cloud IAP payment provider dashboard? For example: `mygame://iapresult/okay`. If you haven't set one yet, set it in the dashboard first before continuing."
+
+### Registering the deep link scheme
+
+Unity IAP 5.4 provides a programmatic API to register the deep link scheme directly, without editing `AndroidManifest.xml` manually:
+
+```csharp
+// Pass the SCHEME ONLY (the part before "://"), not the full redirect URL.
+store.PaymentProviderStoreExtendedService?.SetDeepLinkScheme("mygame");
+```
+
+Call `SetDeepLinkScheme` before `Connect()`. The SDK matches incoming deep links against `<scheme>:` — passing the full URL (e.g. `"mygame://iapresult/okay"`) produces the prefix `"mygame://iapresult/okay:"` which will never match. Register only the scheme portion of whatever redirect URL is configured in the Unity Cloud IAP payment provider dashboard.
+
+### AndroidManifest.xml (required in addition to `SetDeepLinkScheme`)
+
+Android also requires the scheme to be declared in `AndroidManifest.xml` so the OS routes the browser redirect back to the app. `SetDeepLinkScheme` alone is not sufficient on Android — both are needed.
+
+If the project does not have a custom `AndroidManifest.xml`, instruct the user to enable it: **Edit > Project Settings > Player > Publishing Settings > Custom Main Manifest**.
+
+Add an intent filter for the deep link scheme inside the `<activity>` element:
+
+```xml
+<intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="mygame" android:host="iapresult" />
+</intent-filter>
+```
+
+Replace `mygame` and `iapresult` with the scheme and host from the user's configured redirect URL.
+
+### Proxy HTML page (recommended for production)
+
+On some Android devices and iOS configurations, the OS silently drops a direct app-scheme redirect originating from a payment provider domain. To avoid missed redirects, host a lightweight proxy HTML page on a domain you control and use its URL as the Success Redirect URL in the Unity Cloud payment provider dashboard:
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>Redirecting…</title></head>
+<body>
+<script>
+  // Replace with your app-scheme deep link
+  window.location = "mygame://iapresult/okay";
+</script>
+<p>Redirecting back to the app…</p>
+</body>
+</html>
+```
+
+How to set this up:
+
+1. Host the HTML file at a stable HTTPS URL you control (e.g., `https://mygame.com/iap-redirect.html`).
+2. In the Unity Cloud IAP dashboard, set **Success Redirect URL** to the HTTPS proxy URL — **not** the app-scheme URL directly.
+3. The proxy page's JavaScript immediately redirects the browser to the app-scheme URL (`mygame://iapresult/okay`), which the OS routes back into the app.
+4. The `AndroidManifest.xml` intent filter and `SetDeepLinkScheme` registration remain the same — they handle the final app-scheme leg of the redirect.
+
+**When to skip this:** If you are testing in the Unity Editor or on a controlled device where direct app-scheme redirects work reliably, the proxy is optional. For production builds targeting a broad range of Android and iOS devices, the proxy is recommended.
+
+### Unity Editor
+
+In the Unity Editor, the purchase callback is received directly without a browser redirect — no additional setup is required for Editor testing.
+
+### Google Play external link validation (dev/QA only)
+
+If testing on Android and running into external link validation issues, the following scripting define can be added for dev/QA builds only:
+
+```
+IAP_SKIP_EXTERNAL_LINK_VALIDATION
+```
+
+**Location:** Edit > Project Settings > Player > Scripting Define Symbols
+
+**WARNING:** Do not include this define in production builds — it violates Google Play policies.
+
+## Step 6 — Purchase Handling
+
+Purchase handling follows the same save-before-confirm contract as standard IAP 5. See **Step 5 — Purchase Handling Contract** in `path-add-iap-to-new-project.md` for the full rules.
+
+IAP D2C Capabilities-specific notes:
+
+- **Checkout presentation mode:** By default, the payment flow opens in the device's external browser. Unity IAP 5.4 also supports an in-app WebView via `CheckoutPresentationMode`. Set the mode on `IPaymentProvidersExtendedService` before purchase:
+
+  ```csharp
+  // External browser (default)
+  store.PaymentProviderStoreExtendedService?.SetCheckoutPresentationMode(CheckoutPresentationMode.ExternalBrowser);
+
+  // In-app WebView
+  store.PaymentProviderStoreExtendedService?.SetCheckoutPresentationMode(CheckoutPresentationMode.WebView);
+  ```
+
+  When using `ExternalBrowser`, the game is suspended during payment and resumes via the deep link redirect. When using `WebView`, the game remains active and the WebView is dismissed on completion. `OnPurchasePending` fires in both cases after the payment is processed.
+
+- `OnPurchaseDeferred` fires if the payment is not immediately completed. Do not grant — show pending UI.
+- Always confirm (`ConfirmPurchase`) only after entitlement is granted and saved. For consumables, Unity IAP D2C Capabilities prevents re-purchase until the previous order is confirmed.
+
+### Apple and Google external purchase compliance
+
+Apple and Google allow external web payments only in select regions and under their own program rules. Unity does not perform compliance on your behalf — the developer is responsible for eligibility and disclosure requirements.
+
+Three compliance tools are available:
+
+**1. Gate purchases with a compliance callback**
+
+Register a callback via `SetComplianceCheck` that runs before any purchase is initiated. Return `false` to block the purchase for ineligible players:
+
+```csharp
+store.PaymentProvidersExtendedPurchaseService?.SetComplianceCheck(async (context) =>
+{
+    bool isEligible = await CheckRegionalEligibility(context);
+    return isEligible;
+});
+```
+
+The callback runs for `PurchaseProduct` and `Purchase` calls only — it does **not** gate `GenerateURL`.
+
+**2. Disclose the checkout URL before opening it**
+
+Some Apple and Google program rules require showing or disclosing the checkout URL to the player before redirecting. Use `GenerateURL` to obtain the URL without opening it, then call `PurchaseProduct` separately to open the checkout:
+
+```csharp
+// Get the URL without opening checkout
+string url = await store.PaymentProvidersExtendedPurchaseService.GenerateURL(catalogListingId);
+
+// Disclose or display the URL to the player, then proceed
+store.PaymentProvidersExtendedPurchaseService.PurchaseProduct(catalogListingId, PaymentProvider.Name);
+```
+
+If `GenerateURL` was already called for the same listing, `PurchaseProduct` reuses the same order — no duplicate charge.
+
+**3. Attach Apple/Google transaction tokens**
+
+Some programs require reporting transaction tokens back to Apple or Google. Attach tokens when calling `GenerateURL`:
+
+```csharp
+var tokens = new List<PaymentProviderToken>
+{
+    new PaymentProviderToken { store = "apple", token = appleToken, type = "acquisition" },
+    new PaymentProviderToken { store = "google", token = googleToken }
+};
+await store.PaymentProvidersExtendedPurchaseService.GenerateURL(catalogListingId, tokens);
+```
+
+Tokens are stored with the order and surfaced in the `order.paid` webhook payload under `externalTransactionTokens`. You can supply up to two tokens per order (e.g., one for EU, one for Japan).
+
+## Step 7 — Product Type Behavior
+
+Same rules as standard IAP 5 (see `path-add-iap-to-new-project.md` Step 6), with one restriction:
+
+**Subscriptions are not supported by IAP D2C Capabilities in v5.4+.** Skip any subscription products, warn the user which ones were excluded, and continue with Consumable and NonConsumable products only. Document excluded subscriptions as a TODO in the verification report for when subscription support is added.
+
+## Step 8 — Cloud Save Integration
+
+Same rules as standard IAP 5 — see `path-add-iap-to-new-project.md` Step 7. Save must complete before `ConfirmPurchase` is called.
+
+## Step 9 — Verification Report
+
+After applying changes, produce a report with these sections:
+
+1. **Files changed** — list with nature of each change
+2. **Product IDs, types, and `.ucat` files** — catalog summary
+3. **Reward mapping** — product ID → field/method credited
+4. **Deep link scheme configured** — scheme, host, AndroidManifest entry
+5. **Save behavior** — which save method is called, when
+6. **Restore behavior** — which products are restorable, how
+7. **Pending / deferred handling** — confirmation of save-before-confirm and deferred UI
+8. **Manual steps still required** — listed below
+
+## Step 10 — Manual Steps (always include in report)
+
+These cannot be automated and must be completed by the developer:
+
+1. **Unity Cloud IAP dashboard — product catalog** — create products and deploy to the Remote Catalog via **Services > Deployment** in the Unity Editor.
+2. **Payment provider account** — connect Stripe or Coda account in Unity Cloud IAP dashboard (**IAP > Payment Providers > Connect**). Request enablement from Unity Client Partner with your organization ID if not yet enabled.
+3. **Redirect URLs** — set the Success Redirect URL (and optionally Cancel Redirect URL) in the payment provider dashboard (e.g., `mygame://iapresult/okay`). The Cancel Redirect URL adds a back button to the checkout page.
+4. **Entitlement delivery method** — in the Unity Dashboard under **IAP > Payment Providers > Entitlement Delivery Method**, select how purchases are fulfilled server-side:
+   - **Your own server webhooks** — enter your webhook URL; Unity IAP sends `order.paid` events for server-side grant and fulfillment.
+   - **Cloud Code module** — select a deployed Cloud Code module and endpoint to handle fulfillment without managing your own backend.
+   - If client-side only (SDK fulfillment via `ConfirmPurchase`), no configuration is needed here — but note that server-side fulfillment is recommended for production.
+5. **Routing rules** — in the Unity Dashboard under **IAP > Payment Providers > Provider routing**, add at least one routing rule to activate a payment provider for your players. Without a routing rule no payment provider is offered, even if a provider account is connected. Configure platform, country, and rollout percentage per rule.
+6. **Environment selection** — confirm the correct environment (Development / Staging / Production) is set in **Edit > Project Settings > Services > Environments**.
+7. **Android deep link verification** — if using URL-scheme deep links, complete Google Digital Asset Links domain verification. (Avoided if using app-scheme deep links.)
+8. **Platform compliance review** — external web payments and third-party payment providers are permitted in select regions only. Developer is responsible for determining eligibility and meeting Apple and Google program requirements before shipping.
+9. **Prohibited business / content review** — review Stripe's Prohibited/Restricted Businesses list and Coda's Prohibited Content Policy for compliance.

--- a/skills/implement-in-app-purchases/references/platform-notes.md
+++ b/skills/implement-in-app-purchases/references/platform-notes.md
@@ -1,0 +1,204 @@
+# Unity IAP Platform-Specific Notes
+
+## Table of Contents
+
+- [Apple App Store Extensions](#apple-app-store-extensions)
+- [Google Play Store Extensions](#google-play-store-extensions)
+- [Apple JWS Representation (Server-Side Validation)](#apple-jws-representation-server-side-validation)
+- [SubscriptionInfo Platform Nuances](#subscriptioninfo-platform-nuances)
+- [Cross-Platform Best Practices](#cross-platform-best-practices)
+- [Platform Extension Availability](#platform-extension-availability)
+
+## Apple App Store Extensions
+
+Access via `store.AppleStoreExtendedPurchaseService` (for purchase features) and `store.AppleStoreExtendedService` (for store features).
+
+### Promotional Purchases
+
+Apple can present purchases from the App Store product page. Intercept and handle them:
+
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+{
+    store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += (product) =>
+    {
+        // Player tapped "Buy" on App Store product page
+        // You can delay the purchase (e.g., show a loading screen first)
+        Debug.Log($"Promotional purchase intercepted: {product.definition.id}");
+
+        // When ready, continue the purchase
+        store.AppleStoreExtendedPurchaseService.ContinuePromotionalPurchases();
+    };
+}
+```
+
+**CRITICAL:** If you subscribe to `OnPromotionalPurchaseIntercepted`, you MUST eventually call `ContinuePromotionalPurchases()` or the purchase will hang indefinitely.
+
+### Ask-to-Buy (Parental Approval)
+
+On devices with Family Sharing and a child account, purchases may require parental approval:
+
+```csharp
+store.OnPurchaseDeferred += (deferredOrder) =>
+{
+    // Purchase is waiting for parental approval
+    // Show UI: "Purchase pending approval"
+    // Do NOT grant content yet
+    Debug.Log("Purchase deferred - awaiting approval");
+};
+```
+
+The purchase will complete later (triggering `OnPurchasePending`) when approved, or fail when rejected.
+
+For testing in sandbox:
+
+```csharp
+// Simulate Ask-to-Buy in the editor/sandbox
+store.AppleStoreExtendedPurchaseService.simulateAskToBuy = true;
+```
+
+### Offer Code Redemption
+
+Present the Apple offer code redemption sheet:
+
+```csharp
+store.AppleStoreExtendedPurchaseService.PresentCodeRedemptionSheet();
+```
+
+### Entitlement Revocation
+
+Listen for revoked entitlements (e.g., refund granted):
+
+```csharp
+store.AppleStoreExtendedPurchaseService.OnEntitlementRevoked += (productId) =>
+{
+    Debug.Log($"Entitlement revoked for: {productId}");
+    // Remove the content/feature from the player
+};
+```
+
+### Store Capabilities
+
+```csharp
+// Check if the device can make payments (parental controls may block)
+bool canPay = store.AppleStoreExtendedService.canMakePayments;
+
+// Set App Account Token for server-to-server verification
+store.AppleStoreExtendedService.SetAppAccountToken(Guid.NewGuid());
+
+// Fetch storefront info (StoreKit 2 only)
+store.AppleStoreExtendedService.FetchStorefront(
+    (storefront) => Debug.Log($"Storefront: {storefront.CountryCode}"),
+    (error) => Debug.LogError($"Storefront error: {error}")
+);
+```
+
+## Google Play Store Extensions
+
+Access via `store.GooglePlayStoreExtendedPurchaseService` (for purchase features) and `store.GooglePlayStoreExtendedService` (for store features).
+
+### Subscription Upgrade/Downgrade
+
+Change a player's subscription tier:
+
+```csharp
+// Get the current subscription order and the new product
+Order currentOrder = /* the player's current subscription order */;
+Product newProduct = store.GetProductById("com.mygame.vip_annual");
+
+store.GooglePlayStoreExtendedPurchaseService.UpgradeDowngradeSubscription(
+    currentOrder,
+    newProduct,
+    GooglePlayReplacementMode.ChargeFullPrice
+);
+```
+
+### GooglePlayReplacementMode Values
+
+| Mode | Behavior |
+|---|---|
+| `UnknownReplacementMode` | Default |
+| `WithTimeProration` | Remaining time is adjusted |
+| `ChargeProratedPrice` | Prorated charge for the upgrade |
+| `WithoutProration` | New plan starts at next billing |
+| `ChargeFullPrice` | Full price charged immediately |
+| `Deferred` | Change takes effect at next billing |
+
+### Obfuscated IDs
+
+Set obfuscated account/profile IDs for fraud detection:
+
+```csharp
+store.GooglePlayStoreExtendedService.SetObfuscatedAccountId("hashed_account_id");
+store.GooglePlayStoreExtendedService.SetObfuscatedProfileId("hashed_profile_id");
+```
+
+Retrieve them from an order:
+
+```csharp
+string accountId = store.GooglePlayStoreExtendedPurchaseService.GetObfuscatedAccountId(order);
+string profileId = store.GooglePlayStoreExtendedPurchaseService.GetObfuscatedProfileId(order);
+```
+
+### Deferred Payment Events
+
+```csharp
+store.GooglePlayStoreExtendedPurchaseService.OnDeferredPaymentUntilRenewalDate += (deferredOrder) =>
+{
+    Debug.Log($"Payment deferred until renewal: {deferredOrder.SubscriptionOrdered.definition.id}");
+};
+```
+
+## Apple JWS Representation (Server-Side Validation)
+
+For server-side Apple receipt validation (replacing the deprecated `CrossPlatformValidator`):
+
+```csharp
+store.OnPurchasePending += (pendingOrder) =>
+{
+    // Access the JWS-signed transaction
+    string jws = pendingOrder.Info.Apple?.jwsRepresentation;
+    // Send to your server for validation with Apple's App Store Server API (v2)
+    ValidateOnServer(jws);
+};
+```
+
+The `jwsRepresentation` contains a signed JSON Web Signature that can be verified using Apple's public keys.
+
+## SubscriptionInfo Platform Nuances
+
+| Method | Apple | Google |
+|---|---|---|
+| `GetPurchaseDate()` | Returns the **renewal date** (most recent renewal) | Returns the **original purchase date** |
+| `GetCancelDate()` | Returns actual cancellation date | Returns `DateTime.MinValue` (not supported) |
+
+Always check `IsSubscribed()` first — if the result is `Result.Unsupported`, the platform doesn't provide that information.
+
+## Cross-Platform Best Practices
+
+| Concern | Recommendation |
+|---|---|
+| Restore button | Required on iOS (Apple guideline). Add a "Restore Purchases" button that calls `store.RestoreTransactions()`. |
+| Receipt validation | **Google Play:** Use `CrossPlatformValidator(GooglePlayTangle.Data(), Application.identifier)` for local validation. **Apple (StoreKit 2):** Local validation via `CrossPlatformValidator` is a **no-op** — use `order.Info.Apple?.jwsRepresentation` for server-side validation instead. |
+| Pending purchases | Always handle `OnPurchasePending` and call `ConfirmPurchase`. Unconfirmed purchases persist across launches. |
+| Product IDs | Use reverse-domain naming: `com.company.game.product` |
+| Testing | Use sandbox accounts (Apple) and license testing accounts (Google) for testing without real charges. |
+| Subscriptions | Always check `IsSubscribed()` at app launch, not just purchase time. Subscriptions can expire or be cancelled externally. |
+
+## Platform Extension Availability
+
+| Extension | iOS | Android | Editor |
+|---|---|---|---|
+| `AppleStoreExtendedService` | Available | `null` | `null` |
+| `AppleStoreExtendedPurchaseService` | Available | `null` | `null` |
+| `GooglePlayStoreExtendedService` | `null` | Available | `null` |
+| `GooglePlayStoreExtendedPurchaseService` | `null` | Available | `null` |
+
+**CRITICAL:** Always null-check platform extensions before use:
+
+```csharp
+if (store.AppleStoreExtendedPurchaseService != null)
+{
+    store.AppleStoreExtendedPurchaseService.OnPromotionalPurchaseIntercepted += HandlePromo;
+}
+```

--- a/skills/implement-in-app-purchases/references/pre-check.md
+++ b/skills/implement-in-app-purchases/references/pre-check.md
@@ -1,0 +1,205 @@
+# Pre-Check: Project Scan and Path Routing
+
+## Table of Contents
+
+- [Ambiguous Intent](#ambiguous-intent)
+- [IAP D2C Capabilities (Direct-to-Customer, Third-Party Payment Provider)](#iap-d2c-capabilities-direct-to-customer-third-party-payment-provider)
+- [Scan Order (standard IAP paths)](#scan-order-standard-iap-paths)
+- [Routing Summary](#routing-summary)
+
+  Scan steps: [1 — Third-Party IAP Package Check](#1--third-party-iap-package-check-highest-priority) · [2 — Native Google Billing](#2--native-google-billing-check) · [2b — Native iOS StoreKit](#2b--native-ios-storekit-check) · [3 — Unity IAP v4](#3--unity-iap-v4-check) · [4 — Unity IAP v5 Already Installed](#4--unity-iap-v5-already-installed) · [5 — No IAP Detected](#5--no-iap-detected)
+  Third-party sub-checks: [1a Essential Kit](#1a--essential-kit-conversion-supported) · [1b UniPay](#1b--unipay-assessment-path) · [1c RevenueCat](#1c--revenuecat-assessment-path) · [1d Adapty](#1d--adapty-assessment-path)
+
+Run this scan before doing anything else. Do not read any other reference file or make any changes until routing is resolved.
+
+## Ambiguous Intent
+
+If the user's prompt does not clearly indicate which billing backend they want — for example:
+
+- "Add a StoreController for me"
+- "Add a purchase manager"
+- "Set up IAP"
+- "Help me add in-app purchases"
+- "Upgrade to latest IAP"
+
+**Stop and ask before scanning or routing:**
+
+> "Would you like to implement purchasing using:
+> - **Apple App Store / Google Play** (standard platform billing), or
+> - **IAP D2C Capabilities** (third-party payment provider such as Stripe or Coda via Unity Cloud)?"
+
+Do not assume a default. Route only after the user confirms their intent.
+
+---
+
+## IAP D2C Capabilities (Direct-to-Customer, Third-Party Payment Provider)
+
+If the user explicitly asks for IAP D2C Capabilities, Stripe/Coda payment integration, or a third-party payment provider, **do not follow the standard scan order below**. Instead:
+
+- If the project has IAP v4, native Google Billing, or a third-party IAP package → resolve those blockers first using the standard scan order, then return here.
+- If the project has no IAP, or has `com.unity.purchasing` **v5.4+** → route to [path-implement-iap-d2c.md](path-implement-iap-d2c.md).
+- If the project has `com.unity.purchasing` **v5.0–5.3** → inform the user that IAP D2C Capabilities require v5.4+, instruct them to upgrade via Package Manager, and continue once the upgrade is confirmed.
+
+---
+
+## Scan Order (standard IAP paths)
+
+Run scans in this exact order. The first match wins — stop scanning and route immediately.
+
+---
+
+### 1 — Third-Party IAP Package Check (highest priority)
+
+#### 1a — Essential Kit (conversion supported)
+
+Search `Packages/manifest.json` and `Packages/packages-lock.json` for `com.voxelbusters.essentialkit`.
+
+**If found → only one path is valid:**
+
+> Route to [convert-essentialkit.md](convert-essentialkit.md)
+
+Inform the user that Essential Kit was detected and that the conversion path will be used. Do not offer any other path.
+
+---
+
+#### 1b — UniPay (assessment path)
+
+Search `Packages/manifest.json`, `Packages/packages-lock.json`, and `Assets/Plugins/` for UniPay signals:
+
+```
+com\.flobuk\.unipay|UniPay|Assets/Plugins/UniPay|Assets/Plugins/SIS
+```
+
+**If found → only one path is valid:**
+
+> Route to [convert-unipay.md](convert-unipay.md)
+
+Inform the user that UniPay was detected and that the assessment path will be used. Do not offer any other path.
+
+---
+
+#### 1c — RevenueCat (assessment path)
+
+Search `Packages/manifest.json` and `Packages/packages-lock.json` for `com.revenuecat.purchases-unity`.
+
+**If found → only one path is valid:**
+
+> Route to [convert-revenuecat.md](convert-revenuecat.md)
+
+Inform the user that RevenueCat was detected and that the assessment path will be used. Do not offer any other path.
+
+---
+
+#### 1d — Adapty (assessment path)
+
+Search `Packages/manifest.json`, `Packages/packages-lock.json`, and `Assets/` for Adapty signals:
+
+```
+com\.adapty|Assets/Adapty|AdaptySDK
+```
+
+**If found → only one path is valid:**
+
+> Route to [convert-adapty.md](convert-adapty.md)
+
+Inform the user that Adapty was detected and that the assessment path will be used. Do not offer any other path.
+
+---
+
+### 2 — Native Google Billing Check
+
+Search the following locations:
+
+- `Assets/**/*.cs` for: `AndroidJavaObject|AndroidJavaClass|BillingClient|BillingManager|GoogleBilling|BillingBridge`
+- `Assets/Plugins/Android/**/*.java`, `*.kt` for: `com\.android\.billingclient`
+- `mainTemplate.gradle`, `launcherTemplate.gradle`, `baseProjectTemplate.gradle` for: `com\.android\.billingclient:billing`
+
+**If found → only one path is valid:**
+
+> Route to [path-convert-native-google-billing.md](path-convert-native-google-billing.md)
+
+Inform the user that native Google Billing was detected and that the conversion path will be used. If `com.unity.purchasing` is absent or not the latest stable version, instruct the user to install or upgrade to the latest stable version via Package Manager before proceeding.
+
+Do not offer any other path.
+
+---
+
+### 2b — Native iOS StoreKit Check
+
+Search the following for native StoreKit signals:
+
+- `Assets/Plugins/iOS/**/*.m`, `*.mm`, `*.h`, `*.swift` for: `SKProductsRequest|SKPaymentQueue|SKPaymentTransaction|SKPaymentTransactionObserver|Product\.products|Transaction\.currentEntitlements`
+- `Assets/**/*.cs` for: `DllImport.*__Internal` combined with IAP-related method names, or `UnitySendMessage` calls associated with StoreKit
+
+**If found → only one path is valid:**
+
+> Route to [path-convert-native-storekit.md](path-convert-native-storekit.md)
+
+Inform the user that a native iOS StoreKit plugin was detected and that the conversion path will be used. If `com.unity.purchasing` is absent or not the latest stable version, instruct the user to install or upgrade via Package Manager before proceeding.
+
+Do not offer any other path.
+
+---
+
+### 3 — Unity IAP v4 Check
+
+Search `Packages/manifest.json` for `com.unity.purchasing` with a version matching `4\.`.
+
+Also search `Assets/**/*.cs` for legacy v4 API patterns:
+
+```
+IStoreListener|UnityPurchasing\.Initialize|ConfigurationBuilder
+```
+
+**If found → only one path is valid:**
+
+> Route to [migration-v4-to-v5.md](migration-v4-to-v5.md)
+
+Inform the user that Unity IAP v4 was detected and that the v4→v5 migration path will be used. Do not offer any other path.
+
+---
+
+### 4 — Unity IAP v5 Already Installed
+
+If none of the above matched, search `Packages/manifest.json` for `com.unity.purchasing` with a version matching `5\.`:
+
+**If found → inform the user:**
+
+> "This project already has Unity IAP v5 installed. You can extend the existing setup — for example, add new products, add platform-specific features, or integrate IAP D2C Capabilities. What would you like to do?"
+
+Then route based on the user's answer. Do not automatically route to the new-project path — the project already has IAP configured.
+
+---
+
+### 5 — No IAP Detected
+
+If none of the above matched and `com.unity.purchasing` is absent from `manifest.json`:
+
+**→ only one path is valid:**
+
+> Route to [path-add-iap-to-new-project.md](path-add-iap-to-new-project.md)
+
+---
+
+## Routing Summary
+
+| What is detected | Valid path |
+|---|---|
+| Essential Kit (`com.voxelbusters.essentialkit`) | Convert Essential Kit billing → IAP 5 — see convert-essentialkit.md |
+| UniPay (FLOBUK) | Assessment — see convert-unipay.md |
+| RevenueCat | Assessment — see convert-revenuecat.md |
+| Adapty | Assessment — see convert-adapty.md |
+| Native Google BillingClient | Convert native Google Billing → IAP 5 — see path-convert-native-google-billing.md |
+| Native iOS StoreKit plugin (`SKPaymentQueue` / `DllImport("__Internal")`) | Convert native StoreKit → IAP 5 — see path-convert-native-storekit.md |
+| `com.unity.purchasing` v4 or v4 API patterns | Migrate IAP v4 → v5 |
+| `com.unity.purchasing` v5 already installed | Ask user what to extend — do not auto-route |
+| No IAP detected | Add Unity IAP 5 to new project |
+| User explicitly requests IAP D2C Capabilities / payment provider | See IAP D2C Capabilities section above |
+
+---
+
+## Also check: Codeless catalog presence
+
+Regardless of which route above wins, check whether `Assets/Resources/IAPProductCatalog.json` exists. This is the **Codeless IAP** catalog and is independent of the routing decision — but if it is present and `enableCodelessAutoInitialization` is true, adding a scripted `StoreController` creates a race condition with `CodelessIAPStoreListener`.
+
+Surface the catalog's presence and auto-init flag to the user before generating scripted IAP code. See [codeless-catalog.md](codeless-catalog.md) for the race condition details and the three mitigation options.


### PR DESCRIPTION
## Summary
- Re-lands the `implement-in-app-purchases` skill that was reverted in #20, now aligned with the Unity IAP 5.4 pre-GA API surface (includes `IPaymentProvidersStoreExtendedService` → `IPaymentProvidersExtendedService` rename).
- Adds a top-level README, native-StoreKit conversion path, IAP-D2C path, and migration guides (Adapty, EssentialKit, RevenueCat, UniPay).

## Test plan
- [ ] CI green
- [ ] `skills/implement-in-app-purchases/SKILL.md` discoverable by the skill loader
- [ ] Spot-check reference files render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)