### PR TITLE
docs(unity-cli): align skill to CLI 1.0.0-beta.2

### DIFF
--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -6,7 +6,33 @@ each entry notes the CLI version the skill was aligned to.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased] — aligned to CLI `0.1.0-beta.8` (2026-06-25)
+## [Unreleased] — aligned to CLI `1.0.0-beta.2` (2026-07-21)
+
+Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-beta.2`. The CLI's own `[Unreleased]` changes (e.g. the universal `--json` shorthand) are intentionally **not** documented yet — they aren't in the shipped `1.0.0-beta.2` binary.
+
+### Added
+
+- **`unity shell`** — interactive REPL that boots the CLI once and runs many commands in a warm process (enter commands without the `unity` prefix; `exit` / `quit` / Ctrl-D to leave).
+- **`unity list`** — top-level discovery of a connected Editor's registered tools (name, description, group, parameter schema); introspection-only companion to `unity command`.
+- **`unity diagnose proxy`** — redacted, paste-safe proxy diagnostic report for support (`--json`; a copy is written to the logs dir).
+- **`unity pipeline upgrade`**, **`unity pipeline list-versions`**, and **`unity pipeline install --package-version <v>`** — upgrade the Pipeline package only when the registry is newer, list all published versions, and pin a specific version. Documented that the flag is `--package-version` (not `--version`, which collides with the global `-V, --version`), and the multi-editor selection behavior.
+- **`unity editor module remove` / `unity editors module remove`** — remove installed modules by id (`-m`, repeatable; `-y`, `-a`).
+- **`unity install-modules`** `--reinstall`, `-f` / `--force`, and `--retries <n>` (env `UNITY_INSTALL_RETRIES`); **`--no-elevate`** (env `UNITY_NO_ELEVATE`, Windows) on `install` / `install-modules`.
+- Global **`--log-proxy` / `--no-log-proxy`** (env `UNITY_LOG_PROXY`) — per-request redacted proxy logging.
+- **`unity doctor`** environment health checks (PATH presence, `unity`-binary shadowing, Windows long-path support).
+- Exit code **`143`** (SIGTERM) in the exit-code table.
+
+### Changed
+
+- **`--instance <host:port>` removed** from `unity command`, `unity mcp` (and dev-only `eval`) — the CLI discovers running Editors itself; target via the project directory or `--project-path`.
+- **Exit codes** — the `cloud` / `auth` commands map an auth failure to `3` and any other operational failure to `6` (previously `1`); `unity build` interrupts exit `130` (SIGINT) / `143` (SIGTERM).
+- **`unity license`** recognizes service-account sessions (`status` reports "Signed in: yes (service account)"); `activate` default/`--personal` fail up front for service accounts, pointing to the unattended modes; `return` now returns serial-activated licenses too, with per-license partial results.
+- **`unity install` / `install-modules`** continue past a failed item and report a per-item result (✓/✗/·), with an `items[]` breakdown in NDJSON.
+- **`unity upgrade`** detects package-manager installs (points at the owning manager instead of self-replacing); the "update available" notice is suppressed there.
+- **`unity analytics`** first-run prompt now requires an explicit `y`/`n` (Enter re-asks); **`unity language`** dropped the regional variants Spanish (Latin America), French (Canada), and Portuguese (Portugal).
+- Refreshed the latest-version note to `1.0.0-beta.2`; noted the move to 1.0 versioning at `1.0.0-beta.1`.
+
+## CLI `0.1.0-beta.8` (2026-06-25)
 
 ### Added
 

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -58,6 +58,8 @@ These work on every command:
 | `--verbose` | Print full error details (stack trace + cause chain) on failure. Also via `UNITY_VERBOSE`. |
 | `--proxy <url>` | HTTP/HTTPS/SOCKS/PAC proxy URL for this invocation. Also via `UNITY_PROXY`. Takes precedence over standard `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` env vars and the persisted `proxy.json` setting. |
 | `--proxy-disable` | Disable proxy for this invocation, ignoring all sources (env vars, persisted config, system settings). |
+| `--log-proxy` | Log one redacted entry per outbound request (host-only URL, resolved proxy, auth source, status, duration) to `proxy-request.json` — for reproducing proxy issues for support. Also via `UNITY_LOG_PROXY=1` or the persisted `proxyRequestLogging` setting. |
+| `--no-log-proxy` | Opt a single invocation out of proxy request logging when it's enabled globally. |
 
 **Always use `--format json` when you need to parse output programmatically.**
 
@@ -84,6 +86,9 @@ All CLI env vars use the `UNITY_` prefix. A CLI flag always overrides the corres
 | `UNITY_SERVICE_ACCOUNT_SECRET` | — | Service account client secret for non-interactive (CI) auth. |
 | `UNITY_PROXY` | `--proxy` | HTTP/HTTPS/SOCKS/PAC proxy URL. Takes precedence over `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` and the persisted `proxy.json` setting. |
 | `UNITY_NO_UPDATE_CHECK` | — | Disable the background "update available" check (see `unity config update-check`). |
+| `UNITY_LOG_PROXY` | `--log-proxy` | Log one redacted entry per outbound request to `proxy-request.json`. Truthy values: `1`, `true`. |
+| `UNITY_NO_ELEVATE` | `--no-elevate` | Windows: skip the elevated (UAC) install helper for `install` / `install-modules` — for user-writable locations and CI shells that can't answer a UAC prompt. |
+| `UNITY_INSTALL_RETRIES` | `--retries` | Number of times `install-modules` retries a module whose download/validation fails. `0` disables retries. |
 
 **CI service account auth:** Set both `UNITY_SERVICE_ACCOUNT_ID` and `UNITY_SERVICE_ACCOUNT_SECRET` to skip the browser OAuth flow — this keeps the secret out of the process argument list and shell history. These map to the `--client-id` / `--secret-from-stdin` inputs of `unity auth login`, but reading the credentials from the environment isn't a full login: it doesn't run the interactive flow or persist credentials to the keyring.
 
@@ -110,7 +115,10 @@ This works at every level of the command hierarchy.
 | 3 | Authentication failure |
 | 4 | Precondition not met (e.g. no license active, floating server not configured) |
 | 6 | Command-specific failure |
-| 130 | Interrupted (Ctrl+C) |
+| 130 | Interrupted — Ctrl+C / SIGINT (128 + 2) |
+| 143 | Terminated by SIGTERM (128 + 15) — e.g. `kill` or a CI/runner timeout. Emitted by long-running commands that install a signal handler to clean up first (currently `unity build`, which scrubs the temporary Android keystore). |
+
+The `cloud` and `auth` commands map an authentication failure (expired/missing session, rejected sign-in) to `3`, and any other operational failure (network, server error) to `6` — so scripts can reliably tell "sign in again" apart from a genuine command failure.
 
 ---
 
@@ -128,8 +136,8 @@ flags, environment variables, and exit codes above apply throughout. Every comma
 | `projects` (list / create / new / clone / open / link / require / upgrade / export / import / pin), `releases`, `templates` | [projects-templates.md](references/projects-templates.md) |
 | `config` (proxy / update-check), `hub install` | [config-hub.md](references/config-hub.md) |
 | `run`, `test`, `build` | [build-run-test.md](references/build-run-test.md) |
-| `logs`, `doctor`, `env`, `cache`, `analytics`, `changelog`, `language`, `completion`, `bug`, `upgrade`, `self-uninstall` | [diagnostics-maintenance.md](references/diagnostics-maintenance.md) |
-| `mcp` (+ `configure`), connected editors (`pipeline` / `command` / `status`), development-only (`eval` / `cloud-pipeline` / `collab`) | [integration-advanced.md](references/integration-advanced.md) |
+| `logs`, `doctor`, `env`, `cache`, `analytics`, `changelog`, `language`, `completion`, `bug`, `upgrade`, `self-uninstall`, `diagnose proxy` | [diagnostics-maintenance.md](references/diagnostics-maintenance.md) |
+| `mcp` (+ `configure`), connected editors (`pipeline` / `command` / `status` / `list`), `shell`, development-only (`eval` / `cloud-pipeline` / `collab`) | [integration-advanced.md](references/integration-advanced.md) |
 
 ## Common workflows
 
@@ -329,6 +337,6 @@ unity logs --follow --level info
 - `unity <version> [path]` is a shorthand for `unity open [path] --editor-version <version>`. Works with `lts`, `latest`, or a full version string like `6000.0.47f1`.
 - The CLI supports kubectl-style plugins: any `unity-<name>` binary on PATH is callable as `unity <name>`.
 - Terminal output is hardened against control-character / escape-sequence injection from server-provided values (project titles, editor versions, module names) — C0 controls and non-SGR escape sequences are stripped from table/list/tree output, while SGR color/style codes are preserved.
-- The CLI is currently in **beta** (latest: `0.1.0-beta.8`). Once GA ships, the `UNITY_CLI_CHANNEL=beta` part of the install command can be dropped.
+- The CLI is currently in **beta** (latest: `1.0.0-beta.2`). It moved to 1.0 versioning at `1.0.0-beta.1`; it's still a beta, so keep `UNITY_CLI_CHANNEL=beta` in the install command until GA ships, after which that part can be dropped.
 - As of beta.8 the CLI checks in the background for a newer version and prints an unobtrusive "update available" notice (interactive sessions only; never delays a command). Turn it off with `unity config update-check off` or the `UNITY_NO_UPDATE_CHECK` env var.
 - Outbound HTTP from every CLI command honors the resolved proxy (see `unity config proxy`). Inspect what the CLI actually resolved with `unity env --format json` or `unity doctor --format json` — both surface the active proxy URL, its source, and auth source.

--- a/skills/unity-cli/references/auth-license-cloud.md
+++ b/skills/unity-cli/references/auth-license-cloud.md
@@ -63,7 +63,7 @@ unity license activate --floating                   # lease a seat from the conf
 unity license activate --file ./Unity_lic.ulf       # offline activation from a .ulf / .xml file
 unity license activate --generate-request ./req.alf # write an offline activation request (air-gapped)
 
-# Return the active assigned/subscription licenses (prompts to confirm; --yes skips)
+# Return the active licenses — assigned/subscription AND serial-activated (prompts to confirm; --yes skips)
 unity license return
 unity license return --yes
 
@@ -75,6 +75,8 @@ unity license server status    # reachability + available seats
 `list` columns: product, license type (`Floating` / `Assigned` / `ULF`), organization, and expiry. `status` prints a one-glance summary — the active license(s) and whether you're signed in — and exits non-zero (`4`) when no license is active, so it works as a scriptable health check. The first licensing command downloads the Unity licensing client on demand; as of `0.1.0-beta.8`, if the client is unavailable `list` reports a clear error and exits non-zero (matching `status`), rather than printing an empty list.
 
 `activate` takes a single mode flag (combining them is a usage error). The default (no flag) and `--personal` activate the signed-in user's entitlements — sign in first with `unity auth login`. `--personal` also requires `--accept-eula` to acknowledge the Unity Personal license terms. `--serial` / `--file` work offline without sign-in. `--floating` requires a configured floating license server (exit `4` if none is set). `--generate-request` writes a `.alf` request for air-gapped activation instead of activating. `return` returns the active licenses, prompting for confirmation first — pass `--yes` to skip (required in non-interactive shells and with `--json`). All honor `--json` / `--format` and exit non-zero on failure (`2` bad usage, `3` sign-in required, `4` floating not configured, `6` licensing-client error).
+
+**Service accounts.** The `license` commands recognize service-account sessions (`UNITY_SERVICE_ACCOUNT_ID` / `UNITY_SERVICE_ACCOUNT_SECRET`, or `unity auth login --client-id`): `unity license status` reports `Signed in: yes (service account)` and includes the auth mode in JSON. Unity's licensing backend does **not** accept service-account tokens for license activation, so with a service-account session the default entitlement mode and `--personal` fail up front — before contacting the licensing client — with guidance toward the unattended options (`--floating`, `--file`, `--generate-request`, or a perpetual `--serial`). `unity license return` lists and returns serial-activated licenses too (not just assigned/subscription seats) — important for CI machines that activate per run — and returns each license individually, so when only some can be freed it reports what succeeded (in text and in the JSON `returned` / `failed` fields) instead of an all-or-nothing failure.
 
 `unity license server list` shows the configured floating license server (from the `licensingServiceBaseUrl` machine setting; a pure settings read, no client download). `unity license server status` contacts that server and reports reachability plus available seats — exit `4` when no server is configured, `6` when configured but unreachable.
 
@@ -100,6 +102,8 @@ unity cloud project list --format json
 # Override the active organization for a single call
 unity cloud project list --cloud-org <id-or-name>   # also via UNITY_CLOUD_ORG env var
 ```
+
+**Exit codes.** The `cloud` and `auth` commands map an authentication failure (expired or missing session, rejected sign-in) to `3`, and any other operational failure (network, server error) to `6` — so scripts can distinguish "sign in again" from a genuine command failure. `unity auth status` / `logout` follow the same convention.
 
 ---
 

--- a/skills/unity-cli/references/build-run-test.md
+++ b/skills/unity-cli/references/build-run-test.md
@@ -118,6 +118,8 @@ Keystore flags are validated together. Secrets passed as command-line flags surf
 
 **Versioning** — `semantic` and `tag` derive the version from git tags/history; `custom` requires an explicit `--build-version`; a dirty working tree is rejected unless `--allow-dirty-build` is passed.
 
+**Interrupt exit codes** — interrupting `unity build` exits with the conventional signal code (`130` for Ctrl-C / SIGINT, `143` for SIGTERM) rather than a generic `1`, so callers and CI can tell an aborted build apart from a failed one. The temporary Android keystore is scrubbed before exit.
+
 ```bash
 # With --format json, stdout includes newline-delimited JSON progress frames before the final envelope:
 unity build /path/to/MyProject --target StandaloneOSX --execute-method Builder.Build --format json

--- a/skills/unity-cli/references/diagnostics-maintenance.md
+++ b/skills/unity-cli/references/diagnostics-maintenance.md
@@ -39,7 +39,21 @@ unity doctor --format json
 unity doctor --tail 50
 ```
 
-`unity doctor` reports real session state (matching `unity auth status`) and surfaces the resolved proxy URL, its source, and auth source.
+`unity doctor` reports real session state (matching `unity auth status`) and surfaces the resolved proxy URL, its source, and auth source. It also runs environment health checks and reports pass/warn per check (in every output format): whether the `unity` binary's directory is actually on `PATH` (the top post-install pitfall on Windows, where a new terminal is needed), whether multiple `unity` binaries shadow each other on `PATH`, and whether Windows long-path support is enabled.
+
+---
+
+### Diagnose proxy — proxy diagnostic report
+
+```bash
+# Print a redacted, paste-safe proxy diagnostic report for support
+unity diagnose proxy
+
+# Machine-readable
+unity diagnose proxy --json
+```
+
+Reports the resolved proxy and where it came from, PAC configuration, CA bundle, and credential-store and Kerberos checks — redacted so it's safe to paste into a support ticket. A copy is also written to the logs directory. For per-request proxy logging over the course of a repro, use the global `--log-proxy` flag (or `UNITY_LOG_PROXY=1`), which writes one redacted entry per outbound request to `proxy-request.json`.
 
 ---
 
@@ -68,7 +82,7 @@ unity cache clean --yes
 
 ### Analytics — usage/telemetry consent
 
-The CLI defaults to **opt-out**. On the first interactive run a y/N prompt is shown once before any data is collected; non-interactive, CI, piped, and `--quiet` contexts silently keep the opt-out default.
+The CLI defaults to **opt-out**. On the first interactive run a prompt is shown once before any data is collected; it now requires an explicit `y` or `n` — pressing Enter alone re-asks instead of silently recording the opt-out default, so an accidental keystroke can't lock in an answer. Ctrl-C skips the prompt and keeps the opt-out default. Non-interactive, CI, piped, and `--quiet` contexts silently keep the opt-out default.
 
 ```bash
 # Show current consent status
@@ -112,7 +126,7 @@ unity language --set zh-hans
 unity lang --set ko
 ```
 
-On a TTY with no flags, shows an interactive selection prompt.
+On a TTY with no flags, shows an interactive selection prompt. The regional variants Spanish (Latin America), French (Canada), and Portuguese (Portugal) are no longer offered; Spanish, French, and Portuguese (Brazil) remain.
 
 ---
 
@@ -169,6 +183,8 @@ unity upgrade --dry-run
 # Rollback to previous version
 unity upgrade --rollback
 ```
+
+`unity upgrade` detects how the CLI was installed: the `curl | sh` install keeps upgrading itself in place, while on a package-manager install it points you at the owning manager instead of replacing the binary (and the background "update available" notice is suppressed there). `--check`, `--changelog`, and `--dry-run` still work everywhere.
 
 ---
 

--- a/skills/unity-cli/references/editors-install.md
+++ b/skills/unity-cli/references/editors-install.md
@@ -188,8 +188,8 @@ unity install 6000.0.47f1 -m android ios          # space-separated
 unity install 6000.0.47f1 -m android -m ios       # repeated flag (same effect)
 
 # Windows: skip the elevated (UAC) install helper — for user-writable install locations
-# and CI shells where a UAC prompt can't be answered (installs into protected paths then
-# fail with a permission error instead of prompting). Also via UNITY_NO_ELEVATE=1.
+# and CI shells where a UAC prompt can't be answered (installing into a protected path then
+# fails with a permission error instead of prompting). Also via UNITY_NO_ELEVATE=1.
 unity install 6000.0.47f1 --no-elevate --yes --accept-eula
 ```
 

--- a/skills/unity-cli/references/editors-install.md
+++ b/skills/unity-cli/references/editors-install.md
@@ -129,9 +129,16 @@ unity editors module add 6000.0.47f1 --all          # Install every available mo
 unity editors module add 6000.0.47f1 --module android --child-modules   # Include child modules
 unity editors module add 6000.0.47f1 --module android --accept-eula      # Accept EULAs automatically
 
+# Remove installed modules from an editor by id (-m/--module, repeatable)
+unity editors module remove 6000.0.47f1 --module android --module ios
+unity editor module remove 6000.0.47f1 -m android -a arm64   # disambiguate side-by-side installs
+unity editors module remove 6000.0.47f1 -m android --yes     # skip the confirm prompt (required non-interactively)
+
 # Refresh module list for a manually located editor
 unity editors module refresh 6000.0.47f1
 ```
+
+`module remove` prompts to confirm before deleting the module files; `-y` / `--yes` skips the prompt and is required in non-interactive mode. Supports `-a` / `--architecture` to disambiguate side-by-side installs and the global `--format human|json|tsv|ndjson`.
 
 #### editor add (single path, with module-fetch control)
 
@@ -179,7 +186,14 @@ unity install 6000.0.47f1 --dry-run --format json
 # Space-separated module values after a single -m are equivalent to repeating -m
 unity install 6000.0.47f1 -m android ios          # space-separated
 unity install 6000.0.47f1 -m android -m ios       # repeated flag (same effect)
+
+# Windows: skip the elevated (UAC) install helper — for user-writable install locations
+# and CI shells where a UAC prompt can't be answered (installs into protected paths then
+# fail with a permission error instead of prompting). Also via UNITY_NO_ELEVATE=1.
+unity install 6000.0.47f1 --no-elevate --yes --accept-eula
 ```
+
+When installing an editor with several modules, a failed module no longer aborts the whole batch — `unity install` (and `unity install-modules`) continue with the remaining items and exit non-zero if any failed. Each editor and module is listed as installed (✓), failed (✗), or pending (·); the NDJSON `result` frame carries the same breakdown as an `items` array (each entry has `uid`, `name`, `kind`, `status`), so scripts can tell exactly which modules succeeded even on a non-zero exit.
 
 **NDJSON progress frames** for `unity install` and `unity install-modules` include a `phase: 'download' | 'install'` field so scripts can switch to an indeterminate spinner during the install phase (which is genuinely indeterminate — NSIS on Windows only reports success/failure). During the install phase, `pct` is locked at 50 and only jumps to 100 on completion. Module download/install progress is nested under the parent editor via `parentItemUid`, so consumers see one editor group with its modules rather than one group per module.
 
@@ -229,9 +243,25 @@ unity install-modules --editor-version 6000.0.47f1 --module android --no-cm
 
 # Accept EULAs and dry-run
 unity install-modules --editor-version 6000.0.47f1 --all --accept-eula --dry-run
+
+# Reinstall modules that are already installed (a repair)
+unity install-modules --editor-version 6000.0.47f1 --module android --reinstall
+
+# -f/--force implies --reinstall, auto-includes child modules, and skips confirmation prompts
+unity install-modules --editor-version 6000.0.47f1 --module android --force
+
+# Tune the automatic retry for modules whose download/validation fails intermittently
+# (default retries twice with backoff; 0 disables). Also via UNITY_INSTALL_RETRIES.
+unity install-modules --editor-version 6000.0.47f1 --module android --retries 3
+unity install-modules --editor-version 6000.0.47f1 --module android --retries 0
+
+# Windows: skip the elevated (UAC) install helper (also via UNITY_NO_ELEVATE=1)
+unity install-modules --editor-version 6000.0.47f1 --module android --no-elevate
 ```
 
 `--list` and `--all` are mutually exclusive. `--list` is also mutually exclusive with `--module`.
+
+A module whose download or validation fails intermittently — common for large modules such as Android SDK/NDK and OpenJDK — is retried automatically (up to twice with exponential backoff by default) instead of failing the whole run; already-installed modules are never re-downloaded, and retry attempts surface in both human and `--format ndjson` output.
 
 `--module android ios` (space-separated values after a single `--module`) and `--module android --module ios` (repeated flag) are equivalent — both install all listed modules.
 

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -14,10 +14,11 @@ New in `0.1.0-beta.8`. `unity mcp` starts a Model Context Protocol server, built
 # Start the MCP stdio server (usually launched by the AI client, not by hand)
 unity mcp
 
-# Pin the server to a specific Unity project / Editor instance
+# Pin the server to a specific Unity project (the CLI discovers the running Editor itself)
 unity mcp --project-path /path/to/MyProject
-unity mcp --instance localhost:55000
 ```
+
+`unity mcp` no longer accepts `--instance <host:port>`: talking to an Editor requires that Editor's per-instance auth token, which a bare host and port can't carry, so the CLI always discovers running Editors itself — run from the project directory or pass `--project-path` to target one. Editors launched to create a new project (`-createproject`) are discovered too.
 
 #### mcp configure — register the server in an AI client
 
@@ -49,16 +50,32 @@ unity mcp configure vscode --dry-run
 #### pipeline (alias: pipe) — manage the Unity Pipeline package
 
 ```bash
-# List the Editors the CLI can reach and the Pipeline package status of each
+# List the Editors the CLI can reach and the Pipeline package status of each.
+# Also shows each project's installed Pipeline version and flags when the registry has a newer one.
 unity pipeline list --format json
 
 # Install / update the Pipeline package into a project (auto-detects project if omitted)
 unity pipeline install
 unity pipeline install --project-path /path/to/MyProject
-unity pipeline install --force          # re-resolve to the latest version even if present
+unity pipeline install --force          # always rewrite the manifest to the latest version
+
+# Install a specific version (validated against the registry first; overwrites any pinned version).
+# NOTE: the flag is --package-version, NOT --version (which collides with the global -V, --version).
+unity pipeline install --package-version 0.3.0-exp.1
+
+# Upgrade the package to the latest, but only when the registry has a newer one
+# (otherwise reports it's already up to date and leaves manifest.json untouched).
+# Requires the package to be installed already.
+unity pipeline upgrade
+unity pipeline upgrade --project-path /path/to/MyProject
+
+# List every version published to the Unity registry, newest first (marks the current latest)
+unity pipeline list-versions --format json
 ```
 
-`pipeline install` options: `--project-path <path>`, `--force`. The package is resolved from the Unity registry and written to `Packages/manifest.json`.
+`pipeline install` options: `--project-path <path>`, `--force`, `--package-version <version>`. The package is resolved from the Unity registry and written to `Packages/manifest.json`. Unlike `install --force` (which always rewrites to latest), `upgrade` compares the pinned version first.
+
+When multiple Editors are running, `install` and `upgrade` consider only the editors that actually need the operation (`install` → editors without the package; `upgrade` → editors behind the registry's latest). If exactly one needs it, that editor is chosen automatically; if none do, the command reports there's nothing to do; if several do, an interactive terminal shows a selector while non-interactive contexts (machine output, non-TTY, or `--non-interactive`) error and list the projects so you can pass `--project-path`.
 
 #### command (aliases: cmd, request) — send commands to a running Unity Editor
 
@@ -77,9 +94,8 @@ unity command editor_status --includeMemory true
 # Capture a Scene/Game view screenshot (forwarded to the Editor's screenshot command, new in beta.8)
 unity command screenshot --output ./shot.png --width 1920 --height 1080
 
-# Target a specific project / instance / Player runtime
+# Target a specific project (the CLI discovers the running Editor itself) or a Player runtime
 unity command editor_play --project-path /path/to/MyProject
-unity command editor_play --instance localhost:8765
 unity command <command> --runtime "MyGame"
 unity command <command> --runtime-path /path/to/port-file
 
@@ -88,6 +104,19 @@ unity command editor_play --timeout 60
 ```
 
 If no editor with a reachable Pipeline server is found, the command errors with guidance (make sure the editor is running and its Pipeline server is up).
+
+`unity command` no longer accepts `--instance <host:port>` — the CLI discovers running Editors itself, so run from the project directory or pass `--project-path` to target one.
+
+#### list — discover a connected Editor's tools
+
+`unity list` queries the connected Unity Editor (via the Pipeline package) and prints every registered tool with its name, description, group, and parameter schema. Use it to discover what's callable in the current Editor session without reading source code — especially when the project registers custom `[CliCommand]` tools. Unlike `unity command` (which lists *and* runs), `list` is discovery/introspection only.
+
+```bash
+unity list
+unity list --format json
+```
+
+Honors the global `--quiet` and `--no-banner` flags. On a connection failure it suggests `unity pipeline list` to diagnose.
 
 #### status — live state of connected editors
 
@@ -101,6 +130,27 @@ unity status --project megacity
 ```
 
 Reads the lockfile the Pipeline package writes per running Editor (faster and more CI-friendly than `pipeline list`). Stale-heartbeat instances are reported as `unreachable` without an HTTP probe. With `--format json`/`ndjson`, emits a `success: false` envelope (`STATUS_NO_INSTANCES` / `STATUS_ALL_UNREACHABLE`) and a non-zero exit when no Editor is reachable, so CI scripts can gate on Editor availability.
+
+---
+
+### Shell — interactive REPL
+
+`unity shell` boots the CLI once and runs many commands in the same warm process, avoiding the per-command startup cost of separate `unity …` invocations. Enter any command **without** the `unity` prefix.
+
+```bash
+unity shell
+# unity> status --format json
+# unity> config proxy http://proxy:8080
+# unity> config proxy            # the write above is visible to this read
+# unity> exit
+```
+
+- Arguments are tokenized shell-style (single/double quotes; unquoted Windows backslash paths are preserved).
+- Leave with `exit`, `quit`, or Ctrl-D; blank lines and `#` comments are ignored.
+- Ctrl-C cancels a cancellable running command (such as `build`) and returns to the prompt; for a command that doesn't yet support cancellation the first Ctrl-C is held (with a hint) and a second quick press force-quits the session.
+- The prompt shows the previous command's exit code when it was non-zero.
+- Interactive prompts (confirmations, sign-in) work inside the shell, and a write in one command (`auth logout`, `config`, `editors default`, …) is visible to the next.
+- Piped/scripted sessions (`… | unity shell`) run every line and always exit 0.
 
 ---
 
@@ -123,7 +173,7 @@ unity eval 'Debug.Log("hello");'
 unity eval 'var s = Application.dataPath; return s.Length;'
 ```
 
-Compile failures surface the Roslyn diagnostics and exit non-zero. Targeting options match `command`: `--project-path`, `--instance <host:port>`, `--runtime <name>`, `--runtime-path <path>`.
+Compile failures surface the Roslyn diagnostics and exit non-zero. Targeting options match `command`: `--project-path`, `--runtime <name>`, `--runtime-path <path>` (the CLI discovers the running Editor itself — there is no `--instance`).
 
 ### cloud-pipeline — Unity Cloud Pipeline
 

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -73,7 +73,7 @@ unity pipeline upgrade --project-path /path/to/MyProject
 unity pipeline list-versions --format json
 ```
 
-`pipeline install` options: `--project-path <path>`, `--force`, `--package-version <version>`. The package is resolved from the Unity registry and written to `Packages/manifest.json`. Unlike `install --force` (which always rewrites to latest), `upgrade` compares the pinned version first.
+`pipeline install` options: `--project-path <path>`, `--force`, `--package-version <version>`. The package is resolved from the Unity registry and written to `Packages/manifest.json`. Unlike `pipeline install --force` (which always rewrites to latest), `upgrade` compares the pinned version first.
 
 When multiple Editors are running, `install` and `upgrade` consider only the editors that actually need the operation (`install` → editors without the package; `upgrade` → editors behind the registry's latest). If exactly one needs it, that editor is chosen automatically; if none do, the command reports there's nothing to do; if several do, an interactive terminal shows a selector while non-interactive contexts (machine output, non-TTY, or `--non-interactive`) error and list the projects so you can pass `--project-path`.
 


### PR DESCRIPTION
## What & why

Aligns the `unity-cli` skill with the `unity` CLI, now at `1.0.0-beta.2` (was `0.1.0-beta.8`). No other skills are touched — the changed commands are all CLI-internal, and none are run by `new-unity-project` or any other skill.

The change set spans the CLI's `1.0.0-beta.1` (a comprehensive 1.0 re-baseline) and `1.0.0-beta.2`. The CLI's own `[Unreleased]` changes (e.g. the universal `--json` shorthand) are deliberately **not** documented yet — they aren't in the shipped `1.0.0-beta.2` binary. I confirmed the published latest via the beta channel manifest (`public-cdn.cloud.unity3d.com/hub/prod/cli/latest-beta.json` → `1.0.0-beta.2`). Every documented command/flag was verified against `apps/cli/src` and `apps/cli/docs`, not just the changelog.

## CLI changes propagated

- Added: `unity shell` (interactive REPL); `unity list` (connected-Editor tool discovery); `unity diagnose proxy` (redacted proxy report); `unity pipeline upgrade` / `list-versions` / `install --package-version`; `unity editor(s) module remove`; `install-modules --reinstall` / `-f,--force` / `--retries` (`UNITY_INSTALL_RETRIES`); `--no-elevate` (`UNITY_NO_ELEVATE`); global `--log-proxy` / `--no-log-proxy` (`UNITY_LOG_PROXY`); `unity doctor` environment health checks; exit code `143`.
- Changed: `--instance` removed from `command` / `mcp` / `eval` (CLI discovers Editors itself); cloud/auth exit codes `3` (auth) / `6` (operational); `unity build` interrupt exit codes `130` / `143`; `unity license` service-account recognition + fail-fast, `return` covers serial-activated licenses; `install` / `install-modules` continue-on-failure with per-item results; `unity upgrade` package-manager-install detection; analytics first-run prompt requires explicit y/n; `unity language` dropped regional variants (es-419, fr-CA, pt-PT); latest-version note → `1.0.0-beta.2`.
- Removed: none (no commands removed from the skill; `--instance` removal is documented under Changed).

## Deliberately not propagated

- The CLI's entire `[Unreleased]` section — not in the shipped `1.0.0-beta.2` binary.
- Internal refactors, alpha-only iteration, and bug fixes with no user-facing CLI surface (e.g. editors-list ordering, most Windows install-script BOM/PATH fixes).
- Security hardening already covered generically in the skill (installer injection, hub-install signer pinning, escape-sequence coverage).
- Dev-only `eval` / `cloud-pipeline` / `collab` — verified still production-gated in `cli.ts`; they stay documented as development-only.

## Changelog

`skills/unity-cli/CHANGELOG.md` updated with a new `[Unreleased] — aligned to CLI 1.0.0-beta.2` entry; the previous beta.8 entry demoted to a dated section.

## Security / public-safety pass

- Public-safety scan (no internal hosts / SSH / Jira keys / credentials / local paths): pass. Only `eval` / `cloud-pipeline` / `collab` appear, all explicitly labeled development-only.
- Hidden-Unicode (W021 / U+FE0F): scanned & clean.
- Install commands (W011/W012): untouched, still official public CDN over HTTPS — accepted inherent risk.
- `/security-review`: no findings (docs-only diff).

Generated with Claude Code
