### PR TITLE
docs(unity-cli): document driving a running Editor (headless/warm/one-shot) + [CliCommand] authoring

### DIFF
--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -22,6 +22,9 @@ Tracks the CLI's `1.0.0-beta.3` release. The CLI's own `[Unreleased]` changes (d
 - Environment variables **`UNITY_NO_CONSENT_PROMPT`** (suppress the first-run consent prompt without recording a choice) and **`UNITY_NO_CRASH_REPORT`** (disable anonymous crash/error reporting).
 - Global **`--json`** shorthand (accepted on every command) in the global-flags table.
 - OSC 9;4 taskbar progress note for `unity install` on interactive terminals.
+- **Driving a running Editor** — three patterns: **persistent headless** (launch the Editor binary in `-batchmode` *without* `-quit`; it stays resident and serves the Pipeline API — drive it with `unity command`/`list`/`eval --project-path`), **warm/interactive** (`unity open`, which registers with `unity status` as `ready`), and **one-shot CI** (`unity run --command <name>` boots a batch Editor, runs one command, exits). Notes that a bare `unity run` is *not* persistent (batch runs to completion and exits) and — verified — that a batch-mode Editor serves commands but is **not** listed by `unity status`. Closes a gap where the Connected Editors section assumed a running Editor without saying how to get one.
+- **Authoring custom `[CliCommand]` tools** — `[CliCommand]` / `[CliArg]` in the `Unity.Pipeline.Commands` namespace (assembly `Unity.Pipeline`), with `MainThreadRequired` / `RuntimeOnly` as **named properties on `[CliCommand]`** (not separate attributes); worked example, and hot-registration via `unity command recompile` → `unity list`.
+- **Editor-side `eval` / `eval_file`** — noted the runtime-discoverable production path via `unity command eval`, distinct from the dev-only top-level `unity eval`.
 
 ### Changed
 

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -47,6 +47,61 @@ unity mcp configure vscode --dry-run
 
 > **Promoted to production in `0.1.0-beta.8`.** In earlier betas these were development-only (and the Pipeline package was Unity-internal). They now talk to any running Unity Editor over its Pipeline server, and the supporting Editor-side package (`com.unity.pipeline`) is resolved from the **Unity (UPM) registry** and added to the project's `Packages/manifest.json` — no internal access or manual setup required. The Editor defines each command's parameters, help, and error messages, so the commands a connected Editor exposes are usable without a CLI update.
 
+**Why drive a live Editor instead of a fresh batch job?** `command`, `list`, and `eval` round-trip
+against an already-loaded Editor in roughly **200–600 ms with no script recompile and no domain
+reload** — far cheaper than a cold `unity run` per action. That makes it practical for an agent to
+create GameObjects, edit assets, run a test, or evaluate C# iteratively within a single warm session.
+
+#### Getting an Editor to drive
+
+`command`, `list`, `eval`, and `status` attach to an **already-running** Editor with the Pipeline
+package — they connect to its Pipeline server, they don't start one. One gotcha up front: a bare
+`unity run <project>` (**without** `--command`) is *not* a way to get one — it runs batch mode to
+completion and exits on its own (the log ends `Exiting batchmode successfully now!`). Use one of the
+three patterns below. Any resident Editor (batch or GUI) then answers in ~200–600 ms with no recompile
+and no domain reload, so an agent can iterate in a single session.
+
+**Persistent headless (no GUI) — agent / SSH build box.** Launch the Editor binary directly in batch
+mode and **omit `-quit`** so it stays resident and keeps serving the Pipeline API. The binary lives
+inside the install dir reported by `unity editors --installed` (`location`).
+
+```bash
+unity pipeline install --project-path /path/to/MyProject
+# macOS: the `location` is the .app bundle; the executable is inside it. (Linux: <editor>/Editor/Unity)
+UNITY=/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity
+"$UNITY" -batchmode -projectPath /path/to/MyProject -logFile editor.log &   # NO -quit → stays resident
+# Drive it — target the project explicitly (see the status caveat):
+unity command --project-path /path/to/MyProject                            # list what it exposes
+unity list    --project-path /path/to/MyProject                            # discover tools
+unity command eval "return Application.unityVersion;" --project-path /path/to/MyProject
+```
+
+> **`unity status` caveat (verified):** a batch-mode Editor launched this way *does* serve commands,
+> but is **not** listed by `unity status` (its lockfile heartbeat differs from a GUI Editor's). Confirm
+> reachability with `unity command`/`unity list --project-path <project>`, not `unity status`.
+
+**Warm / interactive.** Use an Editor you already have open, or `unity open <project>` (GUI, stays
+resident). Unlike the batch case, its Pipeline server *does* register with `unity status` (state
+`ready`), so `unity status` gates readiness. Drive it the same way (the CLI auto-discovers it; pass
+`--project-path` to disambiguate when several are open).
+
+```bash
+unity open /path/to/MyProject
+unity status --format json                                 # wait until an instance shows state "ready"
+unity command eval "return Application.unityVersion;"
+```
+
+**One-shot (CI).** `unity run <project> --command <name> -- <args>` boots a batch Editor, runs one
+registered command, prints its result, and exits — a fresh boot each time (no warm reuse). Parse with
+`--format ndjson`, since the Editor writes its own log to stdout alongside the result.
+
+```bash
+unity run /path/to/MyProject --command spawn_light --format ndjson -- --name Sun
+```
+
+A resident Editor (headless or GUI) holds a license seat until it exits; the one-shot path releases it
+on exit.
+
 #### pipeline (alias: pipe) — manage the Unity Pipeline package
 
 ```bash
@@ -103,13 +158,20 @@ unity command <command> --runtime-path /path/to/port-file
 unity command editor_play --timeout 60
 ```
 
+Some projects (and Pipeline package versions) register an `eval` — and `eval_file` — command on the
+Editor side, so you can run C# through the connected Editor in a production build:
+`unity command eval "return Application.unityVersion;"` or `unity command eval_file snippet.cs`.
+Availability depends on the Editor/package, so discover it at runtime with `unity command` / `unity list`
+rather than assuming it. This is distinct from the dev-only top-level `unity eval` (below), which is
+absent from production builds.
+
 If no editor with a reachable Pipeline server is found, the command errors with guidance (make sure the editor is running and its Pipeline server is up).
 
 `unity command` no longer accepts `--instance <host:port>` — the CLI discovers running Editors itself, so run from the project directory or pass `--project-path` to target one.
 
 #### list — discover a connected Editor's tools
 
-`unity list` queries the connected Unity Editor (via the Pipeline package) and prints every registered tool with its name, description, group, and parameter schema. Use it to discover what's callable in the current Editor session without reading source code — especially when the project registers custom `[CliCommand]` tools. Unlike `unity command` (which lists *and* runs), `list` is discovery/introspection only.
+`unity list` queries the connected Unity Editor (via the Pipeline package) and prints every registered tool with its name, description, group, and parameter schema. Use it to discover what's callable in the current Editor session without reading source code — especially when the project registers custom `[CliCommand]` tools (see *Authoring custom `[CliCommand]` tools* below). Unlike `unity command` (which lists *and* runs), `list` is discovery/introspection only.
 
 ```bash
 unity list
@@ -130,6 +192,43 @@ unity status --project megacity
 ```
 
 Reads the lockfile the Pipeline package writes per running Editor (faster and more CI-friendly than `pipeline list`). Stale-heartbeat instances are reported as `unreachable` without an HTTP probe. With `--format json`/`ndjson`, emits a `success: false` envelope (`STATUS_NO_INSTANCES` / `STATUS_ALL_UNREACHABLE`) and a non-zero exit when no Editor is reachable, so CI scripts can gate on Editor availability.
+
+#### Authoring custom `[CliCommand]` tools
+
+The command surface is extensible from the **project** side: tag a `static` method with `[CliCommand]`
+and it becomes callable via `unity command <name>` (warm) or `unity run --command <name>` (one-shot),
+and discoverable via `unity list` — no CLI release required. Parameters, help text, and errors are
+surfaced to the CLI automatically. `[CliCommand]` and `[CliArg]` live in the `Unity.Pipeline.Commands`
+namespace (assembly `Unity.Pipeline`, from `com.unity.pipeline`); `MainThreadRequired` and `RuntimeOnly`
+are **named properties on `[CliCommand]`**, not separate attributes.
+
+```csharp
+using Unity.Pipeline.Commands;   // [CliCommand] / [CliArg] — assembly: Unity.Pipeline
+using UnityEngine;
+
+public static class MyPipelineCommands
+{
+    // Warm:     unity command spawn_light --name Sun
+    // One-shot: unity run <project> --command spawn_light -- --name Sun
+    [CliCommand("spawn_light", "Create a GameObject with a Light component",
+                MainThreadRequired = true /* default true; set false only for thread-safe work */)]
+    public static string SpawnLight([CliArg("name", "GameObject name")] string name = "Light")
+    {
+        var go = new GameObject(name, typeof(Light));
+        return go.name;
+    }
+}
+```
+
+- The method must be `static` (any accessibility works). Place it in an **Editor** assembly (an
+  `Editor/` folder, or an asmdef that references `Unity.Pipeline`) so it loads with the Pipeline server.
+- `MainThreadRequired` defaults to **true** — keep it for anything that reads or mutates engine/editor
+  state (scene graph, assets, serialized objects); set it `false` only for pure, thread-safe work.
+- `RuntimeOnly = true` hides the command from an Editor server's listing (Player/dev-build only); reach
+  such a command with `unity command <name> --runtime <name>`.
+- After adding or changing a command, rebuild with `unity command recompile` (poll
+  `unity command recompile_status` until `completed`), then `unity list` to confirm it registered. The
+  Pipeline package also ships built-in commands, including `eval` / `eval_file` (run C# in the Editor).
 
 ---
 
@@ -193,7 +292,10 @@ The commands below are **absent from the published production CLI** — they onl
 
 ### eval — evaluate a C# expression in a running editor
 
-Requires a connected Editor with the Pipeline package (see *Connected Editors* above).
+Requires a connected Editor with the Pipeline package (see *Connected Editors* above). This is the
+**dev-only top-level** `eval`, absent from production builds; for production, prefer the Editor-side
+`eval` command reachable via `unity command eval` when the connected Editor exposes it (see the
+`command` section above).
 
 ```bash
 unity eval 'Application.version'

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -225,7 +225,7 @@ public static class MyPipelineCommands
 - `MainThreadRequired` defaults to **true** — keep it for anything that reads or mutates engine/editor
   state (scene graph, assets, serialized objects); set it `false` only for pure, thread-safe work.
 - `RuntimeOnly = true` hides the command from an Editor server's listing (Player/dev-build only); reach
-  such a command with `unity command <name> --runtime <name>`.
+  such a command with `unity command <command> --runtime <runtime>`. 
 - After adding or changing a command, rebuild with `unity command recompile` (poll
   `unity command recompile_status` until `completed`), then `unity list` to confirm it registered. The
   Pipeline package also ships built-in commands, including `eval` / `eval_file` (run C# in the Editor).


### PR DESCRIPTION
## docs(unity-cli): document driving a running Unity Editor (headless, warm, one-shot), verified end-to-end

### TL;DR

Our `unity-cli` skill documented the surface for driving a running Unity Editor from the terminal (`pipeline` / `command` / `list` / `eval`) but never told the reader how to get a driveable Editor, or how to extend the command surface. This PR closes that gap — and every flow here was **run against a live Unity 6000.3.11f1 Editor on CLI 1.0.0-beta.3 before merge**, which corrected the draft twice as the real behavior came to light. Docs only; no behavior change.

### Why this matters

"Drive a live Editor from the terminal" is the fastest-growing agent/CI pattern for Unity: a resident Editor answers `command`/`eval` in **~200–600 ms with no recompile and no domain reload**, versus a multi-minute cold boot per action. It's how an AI agent — or an SSH build box — creates GameObjects, edits assets, runs a test, or evaluates C# iteratively. This skill is the reference customers and internal teams reach for, so a missing "how do I start and extend this" step is a real dead end.

### The gap, and what we added

| Gap | Fix in this PR |
|---|---|
| No guidance on how to get a **driveable Editor** | New "Getting an Editor to drive" subsection — three patterns |
| **Custom `[CliCommand]` tools** referenced but never taught | New "Authoring custom `[CliCommand]` tools" subsection with a verified example |
| Only the dev-only top-level `unity eval` was documented | Documented the production `unity command eval` / `eval_file` path |

### Three patterns, stated correctly

Verification pinned down exactly how each launch mode behaves:

- **Persistent headless** — launch the Editor binary in `-batchmode` **without `-quit`**; it stays resident and serves the Pipeline API. Drive it with `unity command` / `list` / `eval --project-path`. This is the agent / SSH-build-box path.
- **Warm / interactive** — `unity open <project>` (GUI, stays resident); registers with `unity status` as `ready`.
- **One-shot CI** — `unity run <project> --command <name> -- <args>` boots a batch Editor, runs one command, prints its result, exits.

Two footguns are called out explicitly because both bit during verification: a **bare `unity run`** (no `--command`) is *not* persistent — it runs batch to completion and exits; and a **batch-mode Editor serves commands but is not listed by `unity status`** (different lockfile heartbeat), so you confirm reachability with `unity command`/`list --project-path`, not `status`.

### Verified end-to-end (evidence)

Against a real Editor, on the target CLI version, before merge:

- ✅ Persistent headless: `Unity -batchmode -projectPath … -logFile …` (no `-quit`) stayed resident 3+ min; `unity command`/`unity list --project-path` reached it (port 7800); `unity command eval "return Application.unityVersion;"` returned `6000.3.11f1`.
- ✅ Warm: `unity open` → `unity status` reports the instance `ready` → `unity command` lists 140 tools → `unity list` returns 140.
- ✅ `eval_file` exists; top-level `unity eval` is correctly **absent** in production (dev-only).
- ✅ Custom `[CliCommand]`: authored a command → `unity command recompile` → registered (tool count 140 → 141) → invoked it, got the expected result.
- ✅ One-shot: `unity run … --command … -- …` booted a batch Editor, ran the command, returned the result, exited 0.
- ✅ Confirmed footguns: bare `unity run` exited on its own; a batch Editor was not visible to `unity status` despite serving commands.

### Corrections verification forced (before merge, not after)

1. **`[CliCommand]` attribute API.** `MainThreadRequired` / `RuntimeOnly` are **named properties on `[CliCommand]`**, not separate attributes; namespace is `Unity.Pipeline.Commands` (assembly `Unity.Pipeline`). The example now compiles as written.
2. **The `unity status` visibility caveat for batch Editors** — discovered empirically, now documented so readers don't conclude a working headless Editor is "down."

### Scope decisions (intentionally left out)

To keep the skill self-contained and resilient to CLI churn, we did **not** write reference docs into the user's project or edit their `CLAUDE.md`, and we defer command discovery to runtime (`unity command` / `unity list`) rather than enumerating a catalogue that ages badly.

### Changes (docs only)

All in `skills/unity-cli/references/integration-advanced.md`, plus three CHANGELOG bullets under the current `1.0.0-beta.3` entry:

1. "Getting an Editor to drive" (persistent headless / warm / one-shot) + a latency/"why" note.
2. "Authoring custom `[CliCommand]` tools" with a compile-verified example and hot-registration via `unity command recompile` → `unity list`.
3. Editor-side `eval` / `eval_file` note, and a cross-reference from the dev-only top-level `eval`.

### Unrelated finding (heads-up, not in this PR)

While on 1.0.0-beta.3 I hit `unity projects close` → `unknown command 'close'`, yet the shipped skill (CHANGELOG + `projects-templates.md`) lists it as a beta.3 command. Likely a CLI `[Unreleased]` item documented a version early. Worth a separate look; not touched here.

### Risk

Documentation only — no scripts, workflows, or CLI behavior change. Every flow was executed against a live Editor before merge.
