### PR TITLE
fix(unity-cli): make SKILL.md YAML frontmatter parseable by strict parsers

### DIFF
--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-cli
-description: Use when interacting with Unity CLI from the terminal, or to control a running/connected Unity Editor from the command line — create or modify GameObjects, edit scenes and assets, inspect the hierarchy, and run C# in a live Editor instead of hand-editing scene or asset files. Also: install, upgrade or uninstall editors, create, list or open projects, manage modules, manage licenses, check auth status, read logs, browse Unity releases, build/test projects, configure the Unity MCP server for AI agents, or run any other Unity CLI operation. For a guided idea-to-running-project flow for a brand-new game, use the new-unity-project skill instead.
+description: Use when interacting with Unity CLI from the terminal, or to control a running/connected Unity Editor from the command line — create or modify GameObjects, edit scenes and assets, inspect the hierarchy, and run C# in a live Editor instead of hand-editing scene or asset files. Also install, upgrade or uninstall editors, create, list or open projects, manage modules, manage licenses, check auth status, read logs, browse Unity releases, build/test projects, configure the Unity MCP server for AI agents, or run any other Unity CLI operation. For a guided idea-to-running-project flow for a brand-new game, use the new-unity-project skill instead.
 allowed-tools:
   - Bash
 ---


### PR DESCRIPTION
## Problem

Installing the skills with `npx skills add Unity-Technologies/skills` skips the `unity-cli` skill entirely:

```
⚠ Skipped .../skills/unity-cli/SKILL.md — YAML parse error: Nested mappings are not allowed in compact mappings at line 2, column 14:
description: Use when interacting with Unity CLI from the terminal, or to contr…
```

## Cause

The `description:` value is an unquoted (plain) YAML scalar containing `Also: install`. In YAML a **colon-space (`: `) is the mapping indicator**, so a strict parser — the one `npx skills` uses — reads it as an attempt to open a nested mapping inside the `description` value and rejects the whole document. Lenient parsers tolerate it, which is why it wasn't caught locally. It's the only skill description in the repo with a colon-space.

## Fix

Drop the colon (`Also: install` → `Also install`). One character, no meaning lost, and the description stays unquoted and colon-space-free like every other skill.

## Verification

- Confirmed no remaining `: ` in the description value.
- `Also install, upgrade or uninstall editors, …` reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)