### PR TITLE
docs(unity-cli): drop production-gated projects close from the skill

### DIFF
--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -14,7 +14,6 @@ Tracks the CLI's `1.0.0-beta.3` release. The CLI's own `[Unreleased]` changes (d
 
 - **`unity editors running`** — list running Editor instances and the project each has open (version + PID; cross-platform; an empty list is exit 0).
 - **`unity projects size [project]`** — on-disk footprint by top-level folder (`-a, --all`; `--json` emits raw bytes).
-- **`unity projects close <project>`** — gracefully quit the running editor that has a project open (`--timeout <seconds>` default 30, `--force`).
 - **`unity run --command <name>`** — execute a registered `[CliCommand]` Editor command headlessly (arguments after `--` parsed against its `[CliArg]` schema; requires `com.unity.pipeline`).
 - **`unity install --list-components`** — list an editor's available modules and exit (a drop-in alias for `unity modules list <version>`).
 - **`unity bug` non-interactive flags** — `--title`, `--description`, `--steps` (repeatable), `--reproducibility <first-time|sometimes|always>`, `--email`.

--- a/skills/unity-cli/references/projects-templates.md
+++ b/skills/unity-cli/references/projects-templates.md
@@ -143,20 +143,6 @@ unity projects size --all --json
 
 Human output uses readable units; `--json` (and `--format ndjson`) emit raw byte counts.
 
-#### projects close
-
-Close the running editor that has a project open — asks the editor to quit gracefully and reports what happened (project, PID, method):
-
-```bash
-# Ask the editor to quit gracefully (default 30-second wait)
-unity projects close /path/to/MyProject
-
-# Bound the graceful wait, then force-terminate if it won't exit (unsaved changes are lost)
-unity projects close /path/to/MyProject --timeout 15 --force
-```
-
-`--timeout <seconds>` bounds the graceful wait (default 30); `--force` terminates the process when it can't or won't exit — a graceful termination first, then a hard kill (on Unix, SIGTERM then SIGKILL) — and warns that unsaved changes are lost. Closing a project that isn't open is a no-op (exit 0); a close that fails exits non-zero. Honors the global `--format human|json|tsv|ndjson`.
-
 #### projects require
 
 Ensure the editor version required by a project is installed, installing it if needed:


### PR DESCRIPTION
## What & why

Aligns the public `unity-cli` skill with the released `unity` CLI (`1.0.0-beta.3`) by removing `unity projects close`, which is gated out of production builds and therefore isn't available in the shipped binary. Documenting it sends agents and users on the released CLI down an "unknown command" path. No other skills are affected.

## Changes

- Removed: the `#### projects close` reference section in `skills/unity-cli/references/projects-templates.md`.
- Removed: the `unity projects close` "Added" bullet in `skills/unity-cli/CHANGELOG.md`.

## Also updated

- `README.md` — N/A
- other skills — N/A (no references to `projects close`)

## Security / public-safety pass

- Frontmatter parse gate (strict `yaml`): pass
- Public-safety scan (no internal hosts/SSH/Jira keys/dev-only commands/credentials/local paths): pass — deletion-only diff (0 added lines)
- Hidden-Unicode (W021 / U+FE0F): scanned & clean
- Install commands (W011/W012): untouched — accepted inherent risk, unchanged
- Security review: deletion-only doc change, no attack surface introduced

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
