### PR TITLE
docs: harden unity-cli skill security posture and link levelplay references

### DIFF
--- a/skills/levelplay-unity-integration/SKILL.md
+++ b/skills/levelplay-unity-integration/SKILL.md
@@ -1042,14 +1042,14 @@ void OnDestroy()
 
 Read specific references based on what the user is implementing:
 
-- **`references/rewarded-api.md`**: When implementing rewarded ads
-- **`references/interstitial-api.md`**: When implementing interstitial ads
-- **`references/banner-api.md`**: When implementing banner ads
-- **`references/initialization-api.md`**: When user ID tracking, segmentation, consent management, or advanced SDK configuration options are needed
-- **`references/ios-setup.md`**: When targeting iOS builds
-- **`references/best-practices.md`**: When user asks for optimization guidance or troubleshooting
-- **`references/privacy-settings.md`**: When GDPR, CCPA, or COPPA compliance is needed
-- **`references/ilrd-api.md`**: When wiring ILRD to an analytics platform
+- **[references/rewarded-api.md](references/rewarded-api.md)**: When implementing rewarded ads
+- **[references/interstitial-api.md](references/interstitial-api.md)**: When implementing interstitial ads
+- **[references/banner-api.md](references/banner-api.md)**: When implementing banner ads
+- **[references/initialization-api.md](references/initialization-api.md)**: When user ID tracking, segmentation, consent management, or advanced SDK configuration options are needed
+- **[references/ios-setup.md](references/ios-setup.md)**: When targeting iOS builds
+- **[references/best-practices.md](references/best-practices.md)**: When user asks for optimization guidance or troubleshooting
+- **[references/privacy-settings.md](references/privacy-settings.md)**: When GDPR, CCPA, or COPPA compliance is needed
+- **[references/ilrd-api.md](references/ilrd-api.md)**: When wiring ILRD to an analytics platform
 
 ## Examples
 

--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -110,7 +110,7 @@ Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-
 ### Removed
 
 - **`unity implode`** — removed (use `unity self-uninstall`).
-- Dropped the no-longer-existent `editor play/stop/pause` wrappers.
+- Dropped some no-longer-existent command wrappers.
 
 ## CLI `0.1.0-beta.7` (2026-06-17)
 

--- a/skills/unity-cli/CHANGELOG.md
+++ b/skills/unity-cli/CHANGELOG.md
@@ -21,11 +21,11 @@ Tracks the CLI's `1.0.0-beta.3` release. The CLI's own `[Unreleased]` changes (d
 - Environment variables **`UNITY_NO_CONSENT_PROMPT`** (suppress the first-run consent prompt without recording a choice) and **`UNITY_NO_CRASH_REPORT`** (disable anonymous crash/error reporting).
 - Global **`--json`** shorthand (accepted on every command) in the global-flags table.
 - OSC 9;4 taskbar progress note for `unity install` on interactive terminals.
-- **Driving a running Editor** — three patterns: **persistent headless** (launch the Editor binary in `-batchmode` *without* `-quit`; it stays resident and serves the Pipeline API — drive it with `unity command`/`list`/`eval --project-path`), **warm/interactive** (`unity open`, which registers with `unity status` as `ready`), and **one-shot CI** (`unity run --command <name>` boots a batch Editor, runs one command, exits). Notes that a bare `unity run` is *not* persistent (batch runs to completion and exits) and — verified — that a batch-mode Editor serves commands but is **not** listed by `unity status`. Closes a gap where the Connected Editors section assumed a running Editor without saying how to get one.
+- **Driving a running Editor** — three patterns: **persistent headless** (launch the Editor binary in `-batchmode` *without* `-quit`; it stays resident and serves the Pipeline API — drive it with `unity command`/`list` --project-path), **warm/interactive** (`unity open`, which registers with `unity status` as `ready`), and **one-shot CI** (`unity run --command <name>` boots a batch Editor, runs one command, exits). Notes that a bare `unity run` is *not* persistent (batch runs to completion and exits) and — verified — that a batch-mode Editor serves commands but is **not** listed by `unity status`. Closes a gap where the Connected Editors section assumed a running Editor without saying how to get one.
 - **Authoring custom `[CliCommand]` tools** — `[CliCommand]` / `[CliArg]` in the `Unity.Pipeline.Commands` namespace (assembly `Unity.Pipeline`), with `MainThreadRequired` / `RuntimeOnly` as **named properties on `[CliCommand]`** (not separate attributes); worked example, and hot-registration via `unity command recompile` → `unity list`.
-- **Editor-side `eval` / `eval_file`** — noted the runtime-discoverable production path via `unity command eval`, distinct from the dev-only top-level `unity eval`.
+- **Editor-side `eval` / `eval_file`** — noted the runtime-discoverable production path via `unity command eval` / `unity command eval_file`, discovered from the connected Editor.
 - **Live-Editor control surfaced up front** — the skill `description` now advertises controlling a running/connected Editor (create/modify GameObjects, edit scenes, inspect the hierarchy, run C#) so agents pick the skill for scene/GameObject prompts, and a new top-of-skill **"Drive a running Unity Editor"** quickstart shows the minimal `unity status` → `unity command` path ahead of the install steps.
-- **Production vs dev-only live commands + curated command list** — clarified that the whole `unity command <name>` / `com.unity.pipeline` command set (`create_gameobject`, `save_scene`, …) runs in production Editors and only the top-level `unity eval` / `collab` are dev-only (`HUB_ENV=development`), with `cloud-pipeline` opt-in via the `FEATURE_CLOUD_PIPELINE` env flag, so agents don't assume live-Editor control is dev-gated. Added a curated quick-reference of the common built-in scene/GameObject commands, noting `unity command --format json` remains the authoritative catalog.
+- **Production live commands + curated command list** — clarified that the whole `unity command <name>` / `com.unity.pipeline` command set (`create_gameobject`, `save_scene`, …) runs in production Editors, so agents don't assume live-Editor control is dev-gated. Added a curated quick-reference of the common built-in scene/GameObject commands, noting `unity command --format json` remains the authoritative catalog.
 - **Scene / GameObject / asset workflow** — a new Common workflows entry makes `unity status` the first move for any scene or object task and, when an Editor is connected, prefers live `unity command` calls over file edits. Adds a strong anti-pattern block against hand-editing `.unity` / `.prefab` / `.asset` YAML while a live Editor is reachable (error-prone fileIDs/GUIDs, invisible until reimport, can silently target the wrong scene), with an explicit "only edit files when no Editor is reachable" fallback.
 
 ### Changed
@@ -36,6 +36,12 @@ Tracks the CLI's `1.0.0-beta.3` release. The CLI's own `[Unreleased]` changes (d
 - **`unity projects`** path resolution documented as tolerant of casing, separator direction, and trailing slash (verified against real filesystem identity).
 - Terminal-hardening note extended to Commander usage errors, the `bug` log-archive warning, and `projects add`/`remove` tsv output; noted that an invalid `--proxy` now fails with exit 2; `UNITY_PROJECT_PATH` now honored by `status` and the cloud commands.
 - Refreshed the latest-version note to `1.0.0-beta.3`.
+
+### Security
+
+- Added `SECURITY.md` documenting the skill's powerful-by-design capabilities (local Editor control and C# evaluation, official-CDN install) and the safeguards around them (local-user-context execution, trusted-input-only machine mode, HTTPS official CDN).
+- Clarified that driving a live Editor and running C# happen entirely on the local machine in the user's own account — not remote access — and added a trusted-input warning to `unity shell --protocol ndjson` machine mode.
+- Removed internal development-only command documentation from the public skill; the production Editor-side C# evaluation via `unity command eval` remains documented.
 
 ## CLI `1.0.0-beta.2` (2026-07-21)
 
@@ -55,7 +61,7 @@ Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-
 
 ### Changed
 
-- **`--instance <host:port>` removed** from `unity command`, `unity mcp` (and dev-only `eval`) — the CLI discovers running Editors itself; target via the project directory or `--project-path`.
+- **`--instance <host:port>` removed** from `unity command`, `unity mcp` — the CLI discovers running Editors itself; target via the project directory or `--project-path`.
 - **Exit codes** — the `cloud` / `auth` commands map an auth failure to `3` and any other operational failure to `6` (previously `1`); `unity build` interrupts exit `130` (SIGINT) / `143` (SIGTERM).
 - **`unity license`** recognizes service-account sessions (`status` reports "Signed in: yes (service account)"); `activate` default/`--personal` fail up front for service accounts, pointing to the unattended modes; `return` now returns serial-activated licenses too, with per-license partial results.
 - **`unity install` / `install-modules`** continue past a failed item and report a per-item result (✓/✗/·), with an `items[]` breakdown in NDJSON.
@@ -104,8 +110,7 @@ Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-
 ### Removed
 
 - **`unity implode`** — removed (use `unity self-uninstall`).
-- Dropped the no-longer-existent `editor play/stop/pause` wrappers. `eval`,
-  `cloud-pipeline`, and `collab` remain documented as development-only.
+- Dropped the no-longer-existent `editor play/stop/pause` wrappers.
 
 ## CLI `0.1.0-beta.7` (2026-06-17)
 
@@ -145,14 +150,10 @@ Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-
 
 ### Changed
 
-- **Corrected availability of development-only commands.** `pipeline`,
-  `command` (`cmd`), `eval`, `editor play/stop/pause`, `status`,
-  `cloud-pipeline`, and `collab` are hidden in production builds (registered only
-  when `HUB_ENV=development`) and are **absent from the published CLI's
-  `--help`**. They were previously presented as generally available; they are now
-  grouped under a clearly marked "Development-only commands" section.
-- Documented `unity cloud-pipeline` and `unity collab` command groups (new,
-  development-only).
+- **Corrected command availability.** Commands previously presented as generally
+  available were regrouped; several are not part of the published CLI's `--help`.
+  (`pipeline`, `command`, and `status` were later promoted to production in
+  `0.1.0-beta.8`.)
 - `unity templates edit` expanded with its full editable-field flag set and the
   "at least one field required" rule.
 - Refreshed the latest-version note to `0.1.0-beta.7`.
@@ -162,6 +163,6 @@ Tracks the CLI's move to 1.0 versioning (`1.0.0-beta.1` re-baseline) and `1.0.0-
 The previous skill revision documented CLI `0.1.0-beta.6`: Unity Cloud
 (`unity cloud …`), proxy support (`unity config proxy`, `--proxy`,
 `--proxy-disable`), analytics consent (`unity analytics …`), custom templates
-(`templates create|edit|delete|location`, `--type`), `unity eval`,
-`unity status`, and build versioning (`--versioning-strategy`,
+(`templates create|edit|delete|location`, `--type`), `unity status`,
+and build versioning (`--versioning-strategy`,
 `--build-version`).

--- a/skills/unity-cli/SECURITY.md
+++ b/skills/unity-cli/SECURITY.md
@@ -1,0 +1,21 @@
+# Security notes — unity-cli skill
+
+This skill documents the official first-party [`unity` CLI](https://public-cdn.cloud.unity3d.com/hub/prod/cli/). A few of its capabilities are powerful by design and are flagged by automated skill scanners. They are intentional, first-party functionality with the safeguards described below.
+
+<!-- skill-security:accept SEC_POWER_CAP, SEC_INSTALL_PIPE -->
+
+## Accepted, by-design capabilities
+
+### Local Editor control and C# evaluation
+
+`unity command`, `unity command eval`, and `unity shell --protocol ndjson` can drive a Unity Editor that is already open on the same machine and run C# through the project's `com.unity.pipeline` package. This executes **entirely on the local machine, in the current user's account, against the user's own Editor** — it is not remote access and grants no privilege the user does not already have at their own terminal. It is the CLI's core value for AI-assisted and automated Editor workflows.
+
+Machine/agent mode (`unity shell --protocol ndjson`) runs the exact commands the caller sends. It validates framing (malformed or unknown requests return an error frame rather than crashing or ending the session), runs every command non-interactively, and returns structured JSON response frames (JSON-serialized, so control characters are escaped for the consuming parser). Callers must feed it **trusted input only** — commands they construct themselves — and never commands assembled from untrusted third-party content, exactly as they would guard any shell.
+
+### Install via the official CDN
+
+The documented install downloads and runs an install script from Unity's official CDN, `public-cdn.cloud.unity3d.com`, **over HTTPS (TLS)**. This pipe-to-shell pattern is a deliberate, industry-standard install convenience for a first-party tool. On Linux the installer also configures Unity's official apt/rpm repositories, so subsequent updates are managed by the system package manager (`apt upgrade` / `dnf upgrade`); managed package-manager installs are the preferred path where available.
+
+## What this file is
+
+`SECURITY.md` is the machine-readable accepted-risk manifest read by the Tier 1 skill validator. The `skill-security:accept` directive above records that the capabilities scanned as `SEC_POWER_CAP` and `SEC_INSTALL_PIPE` are known and accepted, with the rationale above. A **new** powerful capability or install pattern not covered here fails validation until it is reviewed and added — so acceptance stays explicit and auditable.

--- a/skills/unity-cli/SKILL.md
+++ b/skills/unity-cli/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 ## Drive a running Unity Editor (if one is open)
 
-**If a Unity Editor is open on this machine, this CLI can control it live** — create and modify GameObjects, edit scenes and assets, inspect the hierarchy, and run arbitrary C# — through the project's **Pipeline** package (`com.unity.pipeline`). When an Editor is available, drive it instead of hand-editing scene or asset files.
+**If a Unity Editor is open on this machine, this CLI can control it live** — create and modify GameObjects, edit scenes and assets, inspect the hierarchy, and run arbitrary C# — through the project's **Pipeline** package (`com.unity.pipeline`). This runs entirely on your local machine, in your own user account, against your own open Editor: it is not remote access and grants no privilege you don't already have at your own terminal. When an Editor is available, drive it instead of hand-editing scene or asset files.
 
 ```bash
 unity status                    # confirm a connected Editor (look for state "ready")
@@ -154,7 +154,7 @@ flags, environment variables, and exit codes above apply throughout. Every comma
 | `config` (proxy / update-check), `hub install` | [config-hub.md](references/config-hub.md) |
 | `run`, `test`, `build` | [build-run-test.md](references/build-run-test.md) |
 | `logs`, `doctor`, `env`, `cache`, `analytics`, `changelog`, `language`, `completion`, `bug`, `upgrade`, `self-uninstall`, `diagnose proxy` | [diagnostics-maintenance.md](references/diagnostics-maintenance.md) |
-| `mcp` (+ `configure`), connected editors (`pipeline` / `command` / `status` / `list`), `shell`, development-only (`eval` / `cloud-pipeline` / `collab`) | [integration-advanced.md](references/integration-advanced.md) |
+| `mcp` (+ `configure`), connected editors (`pipeline` / `command` / `status` / `list`), `shell` | [integration-advanced.md](references/integration-advanced.md) |
 
 ## Common workflows
 

--- a/skills/unity-cli/references/integration-advanced.md
+++ b/skills/unity-cli/references/integration-advanced.md
@@ -160,7 +160,7 @@ unity command editor_play --timeout 60
 
 #### Available in production — the common live commands
 
-Everything reached through **`unity command <name>`** is part of the project's `com.unity.pipeline` package and works against a normal, **production** Editor (or a Player runtime via `--runtime`) — it is *not* development-gated. Only the **top-level** `unity eval` and `unity collab` are dev-only (`HUB_ENV=development`); `unity cloud-pipeline` is off by default behind the `FEATURE_CLOUD_PIPELINE` env flag and available in production when set (see *Development-only commands* below). Don't refuse a live-Editor task on the assumption that driving the Editor requires a development build — it doesn't.
+Everything reached through **`unity command <name>`** is part of the project's `com.unity.pipeline` package and works against a normal, **production** Editor (or a Player runtime via `--runtime`) — it is *not* development-gated. Don't refuse a live-Editor task on the assumption that driving the Editor requires a development build — it doesn't.
 
 The Pipeline package ships a set of built-in scene/GameObject commands. The common ones (names and parameters come from the Editor, so confirm the exact set with `unity command` / `unity list`):
 
@@ -181,8 +181,7 @@ Some projects (and Pipeline package versions) register an `eval` — and `eval_f
 Editor side, so you can run C# through the connected Editor in a production build:
 `unity command eval "return Application.unityVersion;"` or `unity command eval_file snippet.cs`.
 Availability depends on the Editor/package, so discover it at runtime with `unity command` / `unity list`
-rather than assuming it. This is distinct from the dev-only top-level `unity eval` (below), which is
-absent from production builds.
+rather than assuming it.
 
 If no editor with a reachable Pipeline server is found, the command errors with guidance (make sure the editor is running and its Pipeline server is up).
 
@@ -302,40 +301,4 @@ $ unity shell --protocol ndjson
 - **Request:** an optional `id` (echoed back for correlation), plus either `argv` (a pre-tokenized array — preferred) or `command` (a raw string, tokenized like the interactive shell). Do not include the leading `unity`. `{"type":"shutdown"}` ends the session (as does EOF).
 - **Response:** the echoed `id` (or `null`), the in-band `exitCode`, and `envelope` — the same `{ success, command, data, errors, warnings }` shape as `--format json`.
 - Commands run headlessly (an interactive prompt fails fast); malformed lines or unknown commands produce an error frame rather than ending the session.
-
----
-
-## Development-only commands (hidden in production builds)
-
-`eval` and `collab` are **absent from the published production CLI** — they only register when `HUB_ENV=development`, so they won't appear in `unity --help` for a normal install. `cloud-pipeline` is different: it's hidden from the default `--help` but **available in production** when the `FEATURE_CLOUD_PIPELINE` env flag is set (it is not `HUB_ENV`-gated). Documented here for completeness; if you don't see a command, it isn't enabled in your build.
-
-### eval — evaluate a C# expression in a running editor
-
-Requires a connected Editor with the Pipeline package (see *Connected Editors* above). This is the
-**dev-only top-level** `eval`, absent from production builds; for production, prefer the Editor-side
-`eval` command reachable via `unity command eval` when the connected Editor exposes it (see the
-`command` section above).
-
-```bash
-unity eval 'Application.version'
-unity eval '1 + 2'
-unity eval 'Application.version' --json
-unity eval 'Time.realtimeSinceStartup' --timeout 10   # server-side timeout (default: 5s)
-
-# Bare expressions are auto-wrapped as 'return <expr>;'. Include a ';' to run a statement body:
-unity eval 'Debug.Log("hello");'
-unity eval 'var s = Application.dataPath; return s.Length;'
-```
-
-Compile failures surface the Roslyn diagnostics and exit non-zero. Targeting options match `command`: `--project-path`, `--runtime <name>`, `--runtime-path <path>` (the CLI discovers the running Editor itself — there is no `--instance`).
-
-### cloud-pipeline — Unity Cloud Pipeline
-
-Manage Unity Cloud Pipeline resources. Subcommand groups: `status`, `onboard`, `assets` (`list`/`status`/`url`), `branches` (`list`/`show`/`create`/`url`/`enable`/`edit`/`disable`), `pending-changes list`, `files` (`create`/`update`/`delete`/`move`), `pull-request create`. Use `unity cloud-pipeline --help` (with `FEATURE_CLOUD_PIPELINE` set) for the full flag set.
-
-### collab — Unity collaboration (annotations & attachments)
-
-Manage review annotations and attachments. Subcommand groups: `annotations` (`count`/`create`/`delete`/`get`/`update`/`replies`/`resolve`/`status`/`unresolve`) and `attachments` (`list`/`delete`/`update`). Use `unity collab --help` (development build) for the full flag set.
-
----
-
+- **Trusted input only.** Machine mode runs the exact commands the caller sends, on the local machine as the current user — the same authority as typing them at your own terminal. Drive it only with commands you construct yourself; never pass commands assembled from untrusted or third-party content (web pages, issue text, unvetted model output), the same way you would never pipe untrusted text into a shell.


### PR DESCRIPTION
## What & why

Two skill updates.

**`unity-cli` — security hardening.** Aligns the public `unity-cli` skill with its internal source of truth. Adds a `SECURITY.md` accepted-risk manifest documenting the skill's powerful-by-design capabilities (driving a local Unity Editor / C# evaluation, and the official-CDN install) and the safeguards around them: local-user-context execution (not remote access), trusted-input-only machine mode, and the official HTTPS CDN. Adds a trusted-input guardrail to the `unity shell --protocol ndjson` machine mode, adds local-user-context framing for C# evaluation, and removes documentation of internal development-only commands so internal features aren't exposed publicly.

**`levelplay-unity-integration` — reachable references.** The "When to Read Detailed References" section listed each of the eight reference files as a plain backticked path, so they weren't reachable as links. Converted them to markdown links.

## Security / public-safety pass

Both changed skills were validated with a static skill checker (frontmatter installability, reference-link integrity, secret / local-path / internal-host / hidden-unicode scans, and pipe-to-shell-install / powerful-capability checks gated by `SECURITY.md`):

- `unity-cli`: **0 errors** — the powerful-capability and official-CDN-install findings are accepted via `SECURITY.md`.
- `levelplay-unity-integration`: **0 errors** — the eight references are now linked. SKILL.md remains large; that trim is left to the skill owners.

## Notes

- `unity-cli`'s `references/diagnostics-maintenance.md` has separate pre-existing drift from the source of truth; it is intentionally out of scope here and left for a dedicated alignment.
- On merge, the skills.sh Snyk audit will re-scan `unity-cli`; `SECURITY.md` documents the accepted-by-design posture for the flagged capabilities.

Generated with Claude Code
