### PR TITLE
LevelPlay skill v0.8.0: version-aware ILRD, rewarded load lifecycle, and improved activation

### DIFF
--- a/skills/levelplay-unity-integration/CHANGELOG.md
+++ b/skills/levelplay-unity-integration/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.8.0 — 2026-08-05 — Version-aware ILRD (SDK 9.5.0) + rewarded load lifecycle
+## v0.8.0 — 2026-08-05 — Version-aware ILRD (SDK 9.5.0), rewarded load lifecycle, and improved activation
 
-Two accuracy updates reflecting current LevelPlay SDK behavior.
+Accuracy and activation updates reflecting current LevelPlay SDK behavior.
 
 **Impression-level revenue (ILRD) — SDK 9.5.0 API change**
 - ILRD now documents both delivery mechanisms: the single global `LevelPlay.OnImpressionDataReady` event (SDK 9.4.x and earlier) and the per-ad-instance `OnAdImpressionDataReady` events on each ad object (SDK 9.5.0+), which replace the global event.
@@ -12,6 +12,10 @@ Two accuracy updates reflecting current LevelPlay SDK behavior.
 **Rewarded ad load lifecycle**
 - Clarified that `LoadAd()` must be called explicitly; the SDK does not auto-manage rewarded loading (unlike the legacy IronSource API).
 - Reframed the guidance so explicit, publisher-triggered loading is the default, with eager preloading documented as an optional pattern. Applies to `references/rewarded-api.md` and the loading-strategy guidance in `SKILL.md`.
+
+**Description and activation**
+- Reworked the skill description to increase activation on general ad and monetization requests, not only when a developer names LevelPlay.
+- Added guidance at the top of the skill directing the agent to run it as an interactive, step-by-step workflow and use the reference files, rather than answering from general knowledge.
 
 ## v0.7.0 — 2026-06-12 — Initial public beta release
 

--- a/skills/levelplay-unity-integration/CHANGELOG.md
+++ b/skills/levelplay-unity-integration/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.8.0 — 2026-08-05 — Version-aware ILRD (SDK 9.5.0) + rewarded load lifecycle
+
+Two accuracy updates reflecting current LevelPlay SDK behavior.
+
+**Impression-level revenue (ILRD) — SDK 9.5.0 API change**
+- ILRD now documents both delivery mechanisms: the single global `LevelPlay.OnImpressionDataReady` event (SDK 9.4.x and earlier) and the per-ad-instance `OnAdImpressionDataReady` events on each ad object (SDK 9.5.0+), which replace the global event.
+- The global event still exists but is deprecated on SDK 9.5.0+ and generates a compiler warning.
+- Updated the initialization step and the rewarded/interstitial/banner references to direct SDK 9.5.0+ users to the per-instance approach.
+
+**Rewarded ad load lifecycle**
+- Clarified that `LoadAd()` must be called explicitly; the SDK does not auto-manage rewarded loading (unlike the legacy IronSource API).
+- Reframed the guidance so explicit, publisher-triggered loading is the default, with eager preloading documented as an optional pattern. Applies to `references/rewarded-api.md` and the loading-strategy guidance in `SKILL.md`.
+
 ## v0.7.0 — 2026-06-12 — Initial public beta release
 
 First release of the LevelPlay Unity integration skill, released as public beta.

--- a/skills/levelplay-unity-integration/SKILL.md
+++ b/skills/levelplay-unity-integration/SKILL.md
@@ -248,7 +248,7 @@ Verify these are working before proceeding."
 - Do not provide C# code until they confirm all steps are complete
 
 **If they answer YES:**
-- **Optional — Analytics: ILRD Wiring.** Ask this question verbatim — do not summarize or rephrase it: "Do you use an analytics or attribution platform (Firebase, AppsFlyer, Adjust, Singular, or custom backend) that needs ad revenue data? If yes, the init script will include a logging stub for Impression Level Revenue (ILRD) — 3 lines of code, no analytics platform setup required yet. (Yes / No / Not sure — defaults to yes)" Record the answer.
+- **Optional — Analytics: ILRD Wiring.** Ask this question verbatim — do not summarize or rephrase it: "Do you use an analytics or attribution platform (Firebase, AppsFlyer, Adjust, Singular, or custom backend) that needs ad revenue data? If yes, the integration will include a logging stub for Impression Level Revenue (ILRD) — a few lines of code, no analytics platform setup required yet. (Yes / No / Not sure — defaults to yes)" Record the answer.
 - Proceed with initialization code.
 
 LevelPlay SDK must be initialized before loading or showing any ads. Initialization should happen early in the application lifecycle.
@@ -313,10 +313,17 @@ public class LevelPlayInitializer : MonoBehaviour
 2. In Unity Inspector, find the "App Key" field
 3. Paste your App Key from Step 5 into that field
 
-**If the user answered Yes or Not Sure to ILRD in Step 7**, also subscribe before Init. Add these lines inside `Start()` (before `LevelPlay.Init(appKey)`):
+**If the user answered Yes or Not Sure to ILRD in Step 7**, wire up impression-level revenue. How you subscribe depends on the SDK version — check it in **Ads Mediation > Network Manager**:
+
+- **SDK 9.5.0+ (current):** subscribe per ad instance using `OnAdImpressionDataReady` on each ad object (rewarded, interstitial, banner) when you create it — not here in the initializer. The global event below is deprecated on 9.5.0+ and generates a compiler warning. See `references/ilrd-api.md` for the per-instance setup, then skip the snippet below.
+- **SDK 9.4.x and earlier:** use the global event below, registered before `LevelPlay.Init()`.
+
+For **SDK 9.4.x and earlier**, add these lines inside `Start()` (before `LevelPlay.Init(appKey)`):
 
 ```csharp
-// MUST be registered BEFORE LevelPlay.Init() to avoid losing early impressions.
+// SDK 9.4.x and earlier only. On 9.5.0+ use per-instance OnAdImpressionDataReady instead.
+// Recommended: register as early as possible, before LevelPlay.Init(). Subscribing in
+// OnInitSuccess also works, since impressions only fire after an ad is shown.
 // Callback fires on a BACKGROUND thread — see references/ilrd-api.md for
 // thread-safe forwarding patterns and a Firebase example.
 LevelPlay.OnImpressionDataReady += OnImpressionDataReady;
@@ -389,7 +396,7 @@ void OnDestroy()
 }
 ```
 
-**If the user answered Yes or Not Sure to ILRD in Step 7**, add the same ILRD subscription code shown in Option 1 above: subscribe before `LevelPlay.Init(...)`, add the stub handler method, and unsubscribe in `OnDestroy()`.
+**If the user answered Yes or Not Sure to ILRD in Step 7**, wire up ILRD following the version-aware guidance in Option 1 above — per ad instance via `OnAdImpressionDataReady` on SDK 9.5.0+, or the global event before `LevelPlay.Init(...)` (with a stub handler and unsubscribe in `OnDestroy()`) on SDK 9.4.x and earlier.
 
 Replace `"YOUR_APP_KEY_HERE"` with your actual App Key from Step 5 (the alphanumeric string copied from the LevelPlay dashboard).
 
@@ -423,7 +430,7 @@ This keeps ad code isolated in `LevelPlayInitializer.cs` while `GameManager` con
 
 **Note:** `LevelPlayInitializer.Awake()` calls `DontDestroyOnLoad(gameObject)`, which will mark this entire GameObject — including your GameManager and any other components on it — as persistent across scenes. Ensure this is compatible with your scene management strategy.
 
-**If the user answered Yes or Not Sure to ILRD in Step 7**, add the ILRD subscription to `LevelPlayInitializer.cs` as shown in Option 1 above. No changes needed in `GameManager`.
+**If the user answered Yes or Not Sure to ILRD in Step 7**, wire up ILRD following the version-aware guidance in Option 1 above (on SDK 9.5.0+ the per-instance subscriptions live in the ad manager classes, not `LevelPlayInitializer.cs`). No changes needed in `GameManager`.
 
 Before testing, ensure you've entered your actual App Key in the Unity Inspector's App Key field on the LevelPlayInitializer component (see Option 1's After Creating steps above).
 
@@ -665,9 +672,9 @@ Example (skipped):
 rewardedAd = new LevelPlayRewardedAd(adUnitId);
 ```
 
-**Impression Level Revenue Tracking:** If the user answered Yes or Not Sure to ILRD in Step 7, the ILRD callback was wired up in the init script. See `references/ilrd-api.md` to forward the data to the analytics platform (Firebase, AppsFlyer, Adjust, Singular, or custom backend).
+**Impression Level Revenue Tracking:** If the user answered Yes or Not Sure to ILRD in Step 7, the ILRD callback was wired up during setup (per ad instance on SDK 9.5.0+, or globally in the init script on SDK 9.4.x and earlier). See `references/ilrd-api.md` to forward the data to the analytics platform (Firebase, AppsFlyer, Adjust, Singular, or custom backend).
 
-If the user said "No" to ILRD and wants to add it now, see `references/ilrd-api.md` — subscribe to `LevelPlay.OnImpressionDataReady` **before** the existing `LevelPlay.Init()` call.
+If the user said "No" to ILRD and wants to add it now, see `references/ilrd-api.md` — how you subscribe depends on the SDK version: per ad instance via `OnAdImpressionDataReady` on SDK 9.5.0+, or the global `LevelPlay.OnImpressionDataReady` (before `LevelPlay.Init()`) on SDK 9.4.x and earlier.
 
 ### 10. Testing and Validation
 
@@ -734,7 +741,7 @@ Mock ads in Unity Editor fire most callbacks, but not all:
 - `OnAdExpanded` / `OnAdCollapsed` - Banner expand/collapse not simulated
 - `OnAdLeftApplication` - No real ad redirect in Editor
 - `OnAdInfoChanged` - Mock ads don't update ad info dynamically
-- `LevelPlay.OnImpressionDataReady` (ILRD) - No impression data generated in Editor
+- ILRD impression callback (`OnAdImpressionDataReady` on 9.5.0+, or global `LevelPlay.OnImpressionDataReady` on 9.4.x and earlier) - No impression data generated in Editor
 
 This means you can test your happy-path flow in Editor, but must test error handling on real devices.
 
@@ -895,9 +902,9 @@ Your existing ad formats will continue to work while you add new ones. You can a
 ### Loading Strategy
 
 **Rewarded Ads:**
-- Load immediately after SDK initialization (load proactively means load early and keep ads preloaded)
-- Reload immediately after showing or when ad fails to load
-- Always keep a rewarded ad ready to show
+- `LoadAd()` must be called explicitly — the SDK no longer auto-manages loading as it did in the legacy IronSource API
+- Create the ad object and subscribe events in `OnInitSuccess`; trigger `LoadAd()` from a publisher-controlled point (a button, scene entry, or gameplay moment)
+- Reloading after close is optional and publisher-controlled, not automatic; see `references/rewarded-api.md` for both the explicit and eager preload patterns
 
 **Interstitial Ads:**
 - Load proactively before natural break points

--- a/skills/levelplay-unity-integration/SKILL.md
+++ b/skills/levelplay-unity-integration/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: levelplay-unity-integration
-description: Use when integrating LevelPlay (IronSource) ads into a Unity project — installing the Ads Mediation package, resolving native dependencies, initializing the SDK, or implementing rewarded ads, interstitials, or banners. Also use for LevelPlay-related errors, privacy compliance (GDPR, CCPA, COPPA), iOS setup (ATT, SKAdNetwork), or impression-level revenue tracking (ILRD).
+description: Adds ads and monetization to a Unity game using the LevelPlay Mediation SDK (installed via the Ads Mediation UPM package). Use when a developer asks about adding ads to a Unity game, implementing rewarded, interstitial, or banner ads, setting up ad mediation, configuring ad networks, installing or updating the Ads Mediation package, troubleshooting LevelPlay namespace errors, resolving Android gradle or iOS CocoaPods dependency issues for ads, configuring ATT or privacy settings for ad compliance, tracking impression-level revenue (ILRD), initializing the LevelPlay SDK, or setting up ad unit IDs. Also use when a developer wants to monetize their Unity game with ads, asks how to get started with LevelPlay, ads, or mediation, or needs help with any part of the LevelPlay integration workflow including platform-specific setup for iOS or Android.
 ---
 
 # LevelPlay Unity package/SDK Integration
+
+Treat this as an interactive workflow to run with the developer, not as background reference. Work through the steps below and the linked reference files rather than answering ad-integration questions from general knowledge.
 
 The C# scripts generated in this skill are MonoBehaviour files for the user to save to their project, not for inline execution.
 

--- a/skills/levelplay-unity-integration/references/banner-api.md
+++ b/skills/levelplay-unity-integration/references/banner-api.md
@@ -612,7 +612,7 @@ LevelPlayBannerPosition.Center
 
 All events are properties of the `LevelPlayBannerAd` object.
 
-**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from `LevelPlay.OnImpressionDataReady` which runs on a background thread.
+**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from the ILRD impression callback (see `references/ilrd-api.md`), which runs on a background thread.
 
 #### `OnAdLoaded`
 Fired when a banner ad is loaded.

--- a/skills/levelplay-unity-integration/references/ilrd-api.md
+++ b/skills/levelplay-unity-integration/references/ilrd-api.md
@@ -32,7 +32,62 @@ For more information about the Impression Level Revenue (ILR) SDK feature and pr
 
 ## Implementation
 
-### Basic ILR Setup
+ILRD is delivered differently depending on your SDK version. Check your version in **Ads Mediation > Network Manager**.
+
+| SDK version | ILRD delivery | Where you subscribe |
+|-------------|---------------|---------------------|
+| **9.5.0+ (current)** | Per ad instance — `OnAdImpressionDataReady` on each ad object (`LevelPlayRewardedAd`, `LevelPlayInterstitialAd`, `LevelPlayBannerAd`) | When you create each ad |
+| **9.4.x and earlier** | Single global event — `LevelPlay.OnImpressionDataReady` | Once, before `LevelPlay.Init()` |
+
+On SDK 9.5.0+, the global `LevelPlay.OnImpressionDataReady` still exists but is **deprecated and generates a compiler warning** — use the per-instance `OnAdImpressionDataReady` event instead.
+
+### SDK 9.5.0+ (current): Per-Instance Setup
+
+Subscribe to `OnAdImpressionDataReady` on each ad object right after you create it, before you load or show it, so no impression is missed — typically inside the ad manager classes from `rewarded-api.md` / `interstitial-api.md` / `banner-api.md`. There is no "before Init" ordering concern with the per-instance event; you subscribe when the ad is created.
+
+```csharp
+using UnityEngine;
+using Unity.Services.LevelPlay;
+
+public class RewardedAdManager : MonoBehaviour
+{
+    private LevelPlayRewardedAd rewardedAd;
+    private string adUnitId = "YOUR_REWARDED_AD_UNIT_ID";
+
+    void Start()
+    {
+        rewardedAd = new LevelPlayRewardedAd(adUnitId);
+
+        // ILRD (SDK 9.5.0+): subscribe per ad instance.
+        // Fires on a BACKGROUND thread — do not call Unity APIs directly here.
+        rewardedAd.OnAdImpressionDataReady += OnImpressionDataReady;
+
+        // ... register other event listeners and call LoadAd() as usual
+    }
+
+    void OnDestroy()
+    {
+        if (rewardedAd != null)
+        {
+            rewardedAd.OnAdImpressionDataReady -= OnImpressionDataReady;
+            // ... unsubscribe other events
+        }
+    }
+
+    private void OnImpressionDataReady(LevelPlayImpressionData impressionData)
+    {
+        // Runs on a background thread — see "Integration with Third-Party Analytics".
+        if (impressionData == null) return;
+        Debug.Log($"ILRD - {impressionData.AdNetwork} / {impressionData.AdFormat} / ${impressionData.Revenue}");
+    }
+}
+```
+
+Repeat the same `OnAdImpressionDataReady` subscription on your interstitial and banner ad objects. Every ad format reports its own impressions through its own instance event.
+
+### SDK 9.4.x and earlier (legacy): Global Event Setup
+
+On older SDKs, use the single global `LevelPlay.OnImpressionDataReady` event, registered **before** `LevelPlay.Init()`:
 
 ```csharp
 using UnityEngine;
@@ -82,10 +137,11 @@ public class ImpressionRevenueManager : MonoBehaviour
 }
 ```
 
-**Key points:**
+**Key points (global event — SDK 9.4.x and earlier only):**
 - Declare the listener **BEFORE** initializing the LevelPlay SDK to avoid any loss of information
 - Callback runs on a **background thread**
 - Don't call Unity APIs directly in the callback
+- On SDK 9.5.0+ this global event is deprecated — use the per-instance `OnAdImpressionDataReady` shown above instead
 
 ### Accessing Impression Data
 
@@ -104,13 +160,30 @@ private void ImpressionDataReadyEvent(LevelPlayImpressionData impressionData)
 
 ## API Reference
 
-### Event
+### Events
 
-#### `LevelPlay.OnImpressionDataReady`
+#### `adObject.OnAdImpressionDataReady` (SDK 9.5.0+ — current)
 
-Fired when an impression occurs and revenue data is available.
+Per-instance event on each ad object (`LevelPlayRewardedAd`, `LevelPlayInterstitialAd`, `LevelPlayBannerAd`). Fired when that ad reports an impression with revenue data.
 
 **Signature:** `event Action<LevelPlayImpressionData>`
+
+**Usage:**
+```csharp
+// Subscribe after creating the ad object. Fires on a background thread.
+rewardedAd.OnAdImpressionDataReady += ImpressionDataReadyEvent;
+```
+
+**Important:**
+- Subscribe when you create the ad object; unsubscribe in `OnDestroy()`
+- Callback runs on **background thread**
+- Each ad format reports through its own instance event
+
+#### `LevelPlay.OnImpressionDataReady` (SDK 9.4.x and earlier — deprecated in 9.5.0+)
+
+Single global event. Fired when any impression occurs and revenue data is available.
+
+**Signature:** `static event Action<LevelPlayImpressionData>`
 
 **Usage:**
 ```csharp
@@ -122,6 +195,7 @@ LevelPlay.OnImpressionDataReady += ImpressionDataReadyEvent;
 - Register **BEFORE** `LevelPlay.Init()`
 - Callback runs on **background thread**
 - Fires for all ad formats (Rewarded, Interstitial, Banner)
+- **Deprecated in SDK 9.5.0+** (generates a compiler warning) — use the per-instance event above instead
 
 ### Data Type
 
@@ -165,7 +239,7 @@ private void ImpressionDataReadyEvent(LevelPlayImpressionData impressionData)
 
 ## Thread Safety
 
-**CRITICAL:** `OnImpressionDataReady` runs on a background thread. This means:
+**CRITICAL:** the ILRD callback (`OnAdImpressionDataReady` on 9.5.0+, or `OnImpressionDataReady` on 9.4.x and earlier) runs on a background thread. This means:
 
 **❌ DO NOT:**
 - Call Unity APIs directly (e.g., `GameObject.Find()`, `transform.position`)
@@ -217,7 +291,7 @@ After you implement the ImpressionDataListener, you can send the impression data
 
 ## Best Practices
 
-1. **Register before Init**: Always register `OnImpressionDataReady` before calling `LevelPlay.Init()`
+1. **Subscribe correctly for your SDK version**: On SDK 9.5.0+, subscribe to each ad's `OnAdImpressionDataReady` when you create the ad. On SDK 9.4.x and earlier, register the global `LevelPlay.OnImpressionDataReady` before calling `LevelPlay.Init()`
 2. **Handle background thread**: Don't call Unity APIs directly in the callback
 3. **Check for null values**: Revenue and other properties may be null - always check before using
 4. **Protect against crashes**: Add null checks to avoid potential crashes
@@ -228,12 +302,14 @@ After you implement the ImpressionDataListener, you can send the impression data
 ### Issue: Callback never fires
 
 **Possible causes:**
-- Not registered before `LevelPlay.Init()`
+- **SDK 9.5.0+:** not subscribed to the ad instance's `OnAdImpressionDataReady`, or subscribed to a different ad object than the one shown
+- **SDK 9.4.x and earlier:** global `LevelPlay.OnImpressionDataReady` not registered before `LevelPlay.Init()`
 - SDK not initialized successfully
 - No ads shown yet
 
 **Solutions:**
-- Register callback before calling `Init()`
+- On 9.5.0+, subscribe to `OnAdImpressionDataReady` on the same ad object you load/show
+- On 9.4.x and earlier, register the global callback before calling `Init()`
 - Verify `OnInitSuccess` fires
 - Show an ad and check if callback fires
 
@@ -251,7 +327,7 @@ After you implement the ImpressionDataListener, you can send the impression data
 
 ## Testing Checklist
 
-- [ ] `OnImpressionDataReady` registered before `Init()`
+- [ ] Subscribed correctly for your SDK version (9.5.0+: per-instance `OnAdImpressionDataReady`; 9.4.x and earlier: global `OnImpressionDataReady` before `Init()`)
 - [ ] Callback fires when ads are shown
 - [ ] Revenue data is received (check for null)
 - [ ] Null checks added to prevent crashes

--- a/skills/levelplay-unity-integration/references/interstitial-api.md
+++ b/skills/levelplay-unity-integration/references/interstitial-api.md
@@ -513,7 +513,7 @@ if (LevelPlayInterstitialAd.IsPlacementCapped("level_complete"))
 
 All events are properties of the `LevelPlayInterstitialAd` object.
 
-**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from `LevelPlay.OnImpressionDataReady` which runs on a background thread.
+**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from the ILRD impression callback (see `references/ilrd-api.md`), which runs on a background thread.
 
 #### `OnAdLoaded`
 Fired when an interstitial ad is successfully loaded.
@@ -626,7 +626,7 @@ interstitialAd.OnAdInfoChanged += (adInfo) =>
 
 **Why it matters:** The updated `LevelPlayAdInfo` contains the latest revenue estimates and network information, which directly impacts your monetization. Always use the most recent `adInfo` when logging or analyzing ad performance.
 
-**If you're using ILRD** (`references/ilrd-api.md`): the `LevelPlayImpressionData` you receive in `OnImpressionDataReady` already contains the final revenue value, so `OnAdInfoChanged` is mostly useful for in-Editor debugging of the waterfall. Most publishers can leave it as a logging hook.
+**If you're using ILRD** (`references/ilrd-api.md`): the `LevelPlayImpressionData` you receive in the ILRD impression callback already contains the final revenue value, so `OnAdInfoChanged` is mostly useful for in-Editor debugging of the waterfall. Most publishers can leave it as a logging hook.
 
 ## Data Types
 

--- a/skills/levelplay-unity-integration/references/rewarded-api.md
+++ b/skills/levelplay-unity-integration/references/rewarded-api.md
@@ -35,7 +35,10 @@ public class RewardedAdManager : MonoBehaviour
 
     void Start()
     {
-        // Create the rewarded ad object using constructor
+        // Create the rewarded ad object and register event listeners.
+        // Do not call LoadAd() here — load is triggered explicitly by a publisher-controlled
+        // action (e.g. a button press, scene entry, or a point in gameplay where the ad
+        // should be available). See LoadAd() below.
         rewardedAd = new LevelPlayRewardedAd(adUnitId);
 
         // Register event listeners
@@ -47,9 +50,6 @@ public class RewardedAdManager : MonoBehaviour
         rewardedAd.OnAdClosed += OnAdClosed;
         rewardedAd.OnAdClicked += OnAdClicked;
         rewardedAd.OnAdInfoChanged += OnAdInfoChanged;   // Fires when the loaded ad updates after a new auction result
-
-        // Load the ad
-        LoadAd();
     }
 
     void OnDestroy()
@@ -68,6 +68,10 @@ public class RewardedAdManager : MonoBehaviour
         }
     }
 
+    // Call this from the trigger point in your game where you want the ad to be available —
+    // for example, from a UI button handler, on entering a scene, or at a natural moment
+    // in gameplay. Unlike the legacy IronSource rewarded video, the SDK does not load
+    // automatically; LoadAd() must always be called explicitly.
     public void LoadAd()
     {
         Debug.Log("Loading rewarded ad...");
@@ -122,8 +126,9 @@ public class RewardedAdManager : MonoBehaviour
     private void OnAdClosed(LevelPlayAdInfo adInfo)
     {
         Debug.Log("Rewarded ad closed");
-        // Load the next ad
-        LoadAd();
+        // LoadAd() is not called here automatically. If your game preloads rewarded ads
+        // eagerly (so one is always ready), call LoadAd() here. If load is triggered by
+        // a player action, wait for that action instead.
     }
 
     private void OnAdClicked(LevelPlayAdInfo adInfo)
@@ -466,7 +471,7 @@ if (LevelPlayRewardedAd.IsPlacementCapped("extra_lives"))
 
 All events are properties of the `LevelPlayRewardedAd` object.
 
-**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from `LevelPlay.OnImpressionDataReady` which runs on a background thread.
+**Threading:** All ad callbacks run on the Unity main thread, so you can safely call Unity APIs (update UI, access GameObjects, etc.) directly in these callbacks. This is different from the ILRD impression callback (see `references/ilrd-api.md`), which runs on a background thread.
 
 #### `OnAdLoaded`
 Fired when a rewarded ad is successfully loaded.
@@ -558,12 +563,10 @@ Fired when the rewarded ad is closed.
 rewardedAd.OnAdClosed += (adInfo) =>
 {
     Debug.Log("Rewarded ad closed");
-    // Resume game, load next ad
-    rewardedAd.LoadAd();
+    // Resume game. Whether to call LoadAd() here depends on your load strategy:
+    // call it if you preload eagerly; otherwise wait for the player's next load trigger.
 };
 ```
-
-**Best practice:** Load the next ad immediately in this callback.
 
 #### `OnAdClicked`
 Fired when the user clicks on the rewarded ad.
@@ -602,7 +605,7 @@ rewardedAd.OnAdInfoChanged += (adInfo) =>
 
 **Why it matters:** The updated `LevelPlayAdInfo` contains the latest revenue estimates and network information, which directly impacts your monetization. Always use the most recent `adInfo` when logging or analyzing ad performance.
 
-**If you're using ILRD** (`references/ilrd-api.md`): the `LevelPlayImpressionData` you receive in `OnImpressionDataReady` already contains the final revenue value, so `OnAdInfoChanged` is mostly useful for in-Editor debugging of the waterfall. Most publishers can leave it as a logging hook.
+**If you're using ILRD** (`references/ilrd-api.md`): the `LevelPlayImpressionData` you receive in the ILRD impression callback already contains the final revenue value, so `OnAdInfoChanged` is mostly useful for in-Editor debugging of the waterfall. Most publishers can leave it as a logging hook.
 
 ## Data Types
 
@@ -664,21 +667,40 @@ Contains error information when ad operations fail.
 
 ### Loading Strategy
 
-**Always keep a rewarded ad ready:**
+Unlike the legacy IronSource rewarded video (where the SDK managed loading automatically), the MADU rewarded API requires `LoadAd()` to be called explicitly. The ad object is created in `OnInitSuccess`, but loading is a separate step triggered by the publisher.
+
+**Explicit load pattern (matches official sample):**
 ```csharp
-// Load immediately after init
+// In OnInitSuccess: create the object and subscribe events only — do not load yet.
 void OnInitSuccess(LevelPlayConfiguration config)
 {
     rewardedAd = new LevelPlayRewardedAd(adUnitId);
     rewardedAd.OnAdLoaded += OnAdLoaded;
     rewardedAd.OnAdClosed += OnAdClosed;
-    rewardedAd.LoadAd();
+    // LoadAd() is called later, from a publisher-controlled trigger.
 }
 
-// Reload immediately after showing
-void OnAdClosed(LevelPlayAdInfo adInfo)
+// Example trigger: called from a UI button or a scene entry point.
+public void OnPlayerReachesRewardedAdOpportunity()
 {
     rewardedAd.LoadAd();
+}
+```
+
+**Eager preload pattern (optional):** If the game always needs a rewarded ad ready the moment the player reaches certain screens, call `LoadAd()` immediately in `OnInitSuccess` after creating the object, and optionally again in `OnAdClosed`. This is a valid choice but makes the manual load requirement less visible — use it consciously, not as a default.
+
+```csharp
+void OnInitSuccess(LevelPlayConfiguration config)
+{
+    rewardedAd = new LevelPlayRewardedAd(adUnitId);
+    rewardedAd.OnAdLoaded += OnAdLoaded;
+    rewardedAd.OnAdClosed += OnAdClosed;
+    rewardedAd.LoadAd(); // Eager preload — conscious choice, not automatic legacy behavior.
+}
+
+void OnAdClosed(LevelPlayAdInfo adInfo)
+{
+    rewardedAd.LoadAd(); // Reload immediately so one is ready for the next opportunity.
 }
 ```
 

--- a/skills/levelplay-unity-integration/references/rewarded-api.md
+++ b/skills/levelplay-unity-integration/references/rewarded-api.md
@@ -68,10 +68,8 @@ public class RewardedAdManager : MonoBehaviour
         }
     }
 
-    // Call this from the trigger point in your game where you want the ad to be available —
-    // for example, from a UI button handler, on entering a scene, or at a natural moment
-    // in gameplay. Unlike the legacy IronSource rewarded video, the SDK does not load
-    // automatically; LoadAd() must always be called explicitly.
+    // Call LoadAd() from a publisher-controlled trigger (e.g. a button or scene entry).
+    // The SDK does not auto-load, so LoadAd() must be called explicitly.
     public void LoadAd()
     {
         Debug.Log("Loading rewarded ad...");


### PR DESCRIPTION
## Summary
Accuracy and activation updates to the LevelPlay Unity integration skill, reflecting current SDK behaviour. Bumps the skill to v0.8.0. No migration content is included. Jira ticket: [MEDISDK-1614](https://jira.unity3d.com/browse/MEDISDK-1614).

## 1. Version-aware ILRD (SDK 9.5.0 API change)
The impression-level revenue API changed at SDK 9.5.0: the global `LevelPlay.OnImpressionDataReady` event is deprecated in favor of per-ad-instance `OnAdImpressionDataReady` events on each ad object.
- `references/ilrd-api.md` now documents both paths: per-instance (9.5.0+) and the global event (9.4.x and earlier, deprecated in 9.5.0+).
- The initialization step and the rewarded/interstitial/banner references give version-aware guidance and steer 9.5.0+ users to the per-instance approach.
- Confirmed with the SDK team (subscription timing and the per-instance model).

## 2. Rewarded ad load lifecycle
- Clarifies that `LoadAd()` must be called explicitly — the SDK does not auto-manage rewarded loading (unlike the legacy IronSource API).
- Explicit, publisher-triggered loading is presented as the default; eager preloading is documented as an optional pattern.
- Grounded in the official rewarded docs and the 9.5.0 SDK source, which agree.

## 3. Description and activation
- Reworks the skill description so it triggers on general ad and monetization requests, not only when a developer explicitly names LevelPlay.
- Adds a line at the top of the body directing the agent to run the skill as an interactive, step-by-step workflow and use the reference files, rather than answering from general knowledge.

## Scope
6 files under `skills/levelplay-unity-integration/` (SKILL.md, CHANGELOG.md, and 4 reference files). No other skills touched.