### PR TITLE
Add UI skills: ui router plus ui-uitk, ui-ugui, ui-imgui

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ npx skills add Unity-Technologies/skills
 | `build-live-game` | Build and operate a live game with Unity Gaming Services — auth, cloud save, cloud code, economy, remote config, leaderboards, and more |
 | `implement-in-app-purchases` | Implement, configure, and debug Unity In-App Purchases (IAP) |
 | `levelplay-unity-integration` | Integrate LevelPlay (IronSource) ad mediation — rewarded, interstitial, and banner ads |
+| `ui` | Router for Unity UI work — detects the project's UI system and routes to `ui-uitk`, `ui-ugui`, or `ui-imgui` |
+| `ui-uitk` | UI Toolkit (Unity 6.0+) — author UXML/USS, flex layout, custom elements, Painter2D, runtime binding |
+| `ui-ugui` | uGUI — Canvas hierarchies, RectTransform anchoring, Layout Groups, prefab UI |
+| `ui-imgui` | IMGUI editor tooling — EditorWindows, custom Inspectors, PropertyDrawers |
 
 ## Usage
 

--- a/skills/ui-imgui/SKILL.md
+++ b/skills/ui-imgui/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: ui-imgui
 description: Unity IMGUI (Immediate Mode GUI) expert for legacy editor tools using OnGUI/immediate mode. Generates and modifies IMGUI EditorWindows, custom Inspectors, PropertyDrawers, and scripts with IMGUI code (OnGUI, OnInspectorGUI). Use when maintaining existing IMGUI editor code or when user explicitly requests IMGUI/OnGUI.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 ---
 
 **Before proceeding:** If the user is asking about creating a **new** editor window, custom inspector, or PropertyDrawer without explicitly mentioning IMGUI/OnGUI, recommend using UI Toolkit (CreateGUI) instead, as it's the modern approach. Only proceed with IMGUI if:

--- a/skills/ui-imgui/SKILL.md
+++ b/skills/ui-imgui/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: ui-imgui
+description: Unity IMGUI (Immediate Mode GUI) expert for legacy editor tools using OnGUI/immediate mode. Generates and modifies IMGUI EditorWindows, custom Inspectors, PropertyDrawers, and scripts with IMGUI code (OnGUI, OnInspectorGUI). Use when maintaining existing IMGUI editor code or when user explicitly requests IMGUI/OnGUI.
+---
+
+**Before proceeding:** If the user is asking about creating a **new** editor window, custom inspector, or PropertyDrawer without explicitly mentioning IMGUI/OnGUI, recommend using UI Toolkit (CreateGUI) instead, as it's the modern approach. Only proceed with IMGUI if:
+- User is modifying existing IMGUI code
+- User explicitly requests IMGUI/immediate mode
+- The project exclusively uses IMGUI for editor tools
+
+When activated, read the reference files:
+- [references/templates.md](references/templates.md) — EditorWindow, Inspector, PropertyDrawer templates
+- [references/gui-elements.md](references/gui-elements.md) — GUI elements, layout groups, styling
+
+## When to Use This Skill
+
+**IMPORTANT:** This skill is for **legacy IMGUI code only**. Use this skill when:
+
+- User is maintaining/updating **existing** IMGUI editor code (files with `OnGUI()`, `OnInspectorGUI()`)
+- User **explicitly requests** IMGUI/immediate mode GUI
+- Project exclusively uses IMGUI for all editor tools
+
+**Do NOT use this skill for:**
+- New editor windows (use UI Toolkit with `CreateGUI()` instead)
+- New custom inspectors (use UI Toolkit instead)
+- Requests that don't explicitly mention IMGUI or OnGUI
+
+**Legacy IMGUI is used for:**
+- **Editor windows** — `EditorWindow` classes with `OnGUI()`
+- **Custom inspectors** — `Editor`, `PropertyDrawer` classes with `OnInspectorGUI()`
+- **Debug overlays** — `OnGUI()` in MonoBehaviour (runtime)
+
+IMGUI is **not** for runtime game UI — use UI Toolkit or uGUI instead.
+
+## Scope
+
+**Generate only what is requested (for legacy IMGUI code):**
+
+| Request | Output | Note |
+|---------|--------|------|
+| Editor window (IMGUI/OnGUI) | `EditorWindow` with `OnGUI()` | Only if explicitly IMGUI |
+| Custom inspector (IMGUI) | `Editor` with `OnInspectorGUI()` | Only if explicitly IMGUI |
+| Property drawer (IMGUI) | `PropertyDrawer` with `OnGUI()` | Only if explicitly IMGUI |
+| Debug overlay | `MonoBehaviour` with `OnGUI()` | Runtime debugging |
+| Update existing IMGUI script | Modify existing OnGUI code | Always appropriate |
+
+**Clarify if ambiguous:**
+- "inspector" → Custom Editor for a specific type, or PropertyDrawer? **Also ask:** Should this use UI Toolkit (modern) or IMGUI (legacy)?
+- "editor window" → **First ask:** Should this use UI Toolkit (modern/CreateGUI) or IMGUI (legacy/OnGUI)?
+- "tool window" → EditorWindow with what functionality? Which UI system?
+
+## Conventions
+
+**Follow project patterns first.** Search existing editor scripts before applying defaults.
+
+| Type | Convention | Good | Bad |
+|------|------------|------|-----|
+| Script names | PascalCase | `MyToolWindow.cs` | `my-tool-window.cs` |
+| EditorWindow | `[Name]Window.cs` | `LevelEditorWindow.cs` | `LevelEditor.cs` |
+| Custom Editor | `[Type]Editor.cs` | `EnemyEditor.cs` | `EnemyInspector.cs` |
+| PropertyDrawer | `[Type]Drawer.cs` | `RangeDrawer.cs` | `RangePropertyDrawer.cs` |
+| Location | `Editor` folder | `Assets/Editor/` | `Assets/Scripts/` |
+
+**Editor folder is required** — Scripts using `UnityEditor` namespace must be in an `Editor` folder or they will fail to build.
+
+## Workflow
+
+1. **Analyze** — Determine script type needed (EditorWindow, Editor, PropertyDrawer, etc.)
+2. **Search** — Find existing editor scripts to match patterns
+3. **Follow project patterns** — Match folder structure and naming
+4. **Create script** — Use appropriate base class and attributes
+5. **Implement OnGUI** — Build the interface with layout groups
+
+## Script Structure
+
+### EditorWindow
+```
+[MenuItem attribute] → adds to menu
+ShowWindow() static method → opens window
+OnGUI() → draws interface
+OnEnable/OnDisable → initialization/cleanup
+```
+
+### Custom Editor
+```
+[CustomEditor attribute] → targets component type
+OnInspectorGUI() → draws inspector
+OnEnable() → cache SerializedProperties
+serializedObject.Update/ApplyModifiedProperties → undo support
+```
+
+### PropertyDrawer
+```
+[CustomPropertyDrawer attribute] → targets type or attribute
+OnGUI(Rect, SerializedProperty, GUIContent) → draws property
+GetPropertyHeight() → custom height if needed
+```
+
+## Key Rules
+
+- **Cache GUIStyle objects** — never create new GUIStyle in OnGUI (causes memory allocation every frame)
+- **Use SerializedProperty** — for proper undo/redo support in inspectors
+- **Call ApplyModifiedProperties()** — after any serialized object changes
+- **Use EditorGUILayout** — for editor scripts (auto-layout)
+- **Use GUILayout** — for runtime OnGUI
+- **Begin/End pairs** — always match BeginHorizontal with EndHorizontal, etc.
+- **Editor folder required** — scripts fail to build if not in Editor folder
+
+## Layout Basics
+
+**Horizontal grouping:**
+```csharp
+EditorGUILayout.BeginHorizontal();
+// elements appear side by side
+EditorGUILayout.EndHorizontal();
+```
+
+**Vertical grouping:**
+```csharp
+EditorGUILayout.BeginVertical("box");
+// elements appear stacked, with box style
+EditorGUILayout.EndVertical();
+```
+
+**Scroll view:**
+```csharp
+scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
+// scrollable content
+EditorGUILayout.EndScrollView();
+```
+
+**Foldout section:**
+```csharp
+showSection = EditorGUILayout.Foldout(showSection, "Section Name");
+if (showSection)
+{
+    EditorGUI.indentLevel++;
+    // section content
+    EditorGUI.indentLevel--;
+}
+```
+
+## Common Patterns
+
+**Button with action:**
+```csharp
+if (GUILayout.Button("Do Something"))
+{
+    // action here
+}
+```
+
+**Property field with label:**
+```csharp
+EditorGUILayout.PropertyField(myProperty, new GUIContent("Label"));
+```
+
+**Object reference field:**
+```csharp
+myObject = (MyType)EditorGUILayout.ObjectField("Label", myObject, typeof(MyType), true);
+```
+
+**Disabled group:**
+```csharp
+EditorGUI.BeginDisabledGroup(condition);
+// disabled elements
+EditorGUI.EndDisabledGroup();
+```
+
+## Best Practices
+
+- Use `SerializedObject` and `SerializedProperty` for undo support
+- Cache property references in `OnEnable()`
+- Use `EditorUtility.SetDirty()` only for non-serialized changes
+- Use `Undo.RecordObject()` before modifying objects directly
+- Use `EditorStyles` for consistent appearance
+- Use `GUILayout.FlexibleSpace()` to push elements apart
+
+See `references/templates.md` for complete script templates.
+See `references/gui-elements.md` for full element reference.

--- a/skills/ui-imgui/references/gui-elements.md
+++ b/skills/ui-imgui/references/gui-elements.md
@@ -1,0 +1,156 @@
+# IMGUI Elements and Layout
+
+## Common GUI Elements
+
+| Method | Use Case |
+|--------|----------|
+| `GUILayout.Label()` | Text display |
+| `GUILayout.Button()` | Clickable button |
+| `GUILayout.TextField()` | Text input |
+| `GUILayout.TextArea()` | Multi-line text input |
+| `GUILayout.Toggle()` | Checkbox |
+| `GUILayout.Slider()` | Value slider |
+| `GUILayout.SelectionGrid()` | Button grid selection |
+| `GUILayout.Toolbar()` | Toolbar buttons |
+
+## Editor-Specific Elements
+
+| Method | Use Case |
+|--------|----------|
+| `EditorGUILayout.PropertyField()` | Serialized property (auto) |
+| `EditorGUILayout.ObjectField()` | Object reference |
+| `EditorGUILayout.IntField()` | Integer input |
+| `EditorGUILayout.FloatField()` | Float input |
+| `EditorGUILayout.Vector3Field()` | Vector3 input |
+| `EditorGUILayout.ColorField()` | Color picker |
+| `EditorGUILayout.CurveField()` | Animation curve |
+| `EditorGUILayout.EnumPopup()` | Enum dropdown |
+| `EditorGUILayout.Popup()` | String dropdown |
+| `EditorGUILayout.Foldout()` | Collapsible section |
+| `EditorGUILayout.HelpBox()` | Info/warning/error box |
+
+## Layout Groups
+
+```csharp
+// Horizontal
+GUILayout.BeginHorizontal();
+GUILayout.Button("Left");
+GUILayout.Button("Right");
+GUILayout.EndHorizontal();
+
+// Vertical
+GUILayout.BeginVertical();
+GUILayout.Button("Top");
+GUILayout.Button("Bottom");
+GUILayout.EndVertical();
+
+// Scroll View
+scrollPos = GUILayout.BeginScrollView(scrollPos);
+// ... content
+GUILayout.EndScrollView();
+
+// Area (absolute positioning)
+GUILayout.BeginArea(new Rect(10, 10, 200, 100));
+// ... content
+GUILayout.EndArea();
+```
+
+## Editor Layout Groups
+
+```csharp
+// Foldout section
+showSection = EditorGUILayout.Foldout(showSection, "Section");
+if (showSection)
+{
+    EditorGUI.indentLevel++;
+    // ... content
+    EditorGUI.indentLevel--;
+}
+
+// Horizontal with flex space
+EditorGUILayout.BeginHorizontal();
+GUILayout.Label("Label");
+GUILayout.FlexibleSpace();
+GUILayout.Button("Action");
+EditorGUILayout.EndHorizontal();
+
+// Box group
+EditorGUILayout.BeginVertical("box");
+// ... content
+EditorGUILayout.EndVertical();
+```
+
+## Layout Options
+
+```csharp
+// Fixed width
+GUILayout.Button("Wide", GUILayout.Width(200));
+
+// Fixed height
+GUILayout.Button("Tall", GUILayout.Height(50));
+
+// Min/Max
+GUILayout.Button("Flex", GUILayout.MinWidth(100), GUILayout.MaxWidth(300));
+
+// Expand
+GUILayout.Button("Fill", GUILayout.ExpandWidth(true));
+```
+
+## Styling
+
+```csharp
+// Built-in styles
+GUILayout.Label("Bold", EditorStyles.boldLabel);
+GUILayout.Label("Large", EditorStyles.largeLabel);
+GUILayout.Label("Mini", EditorStyles.miniLabel);
+GUILayout.Label("Centered", EditorStyles.centeredGreyMiniLabel);
+
+// Custom style (cache this, don't create in OnGUI)
+private GUIStyle _headerStyle;
+private GUIStyle HeaderStyle => _headerStyle ??= new GUIStyle(EditorStyles.boldLabel)
+{
+    fontSize = 16,
+    alignment = TextAnchor.MiddleCenter
+};
+```
+
+## Spacing and Separators
+
+```csharp
+// Fixed space
+GUILayout.Space(10);
+
+// Flexible space (pushes elements apart)
+GUILayout.FlexibleSpace();
+
+// Horizontal line
+EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+
+// Editor separator
+EditorGUILayout.Separator();
+```
+
+## Disabled Groups
+
+```csharp
+EditorGUI.BeginDisabledGroup(someCondition);
+// ... disabled elements
+EditorGUI.EndDisabledGroup();
+
+// Or with using
+using (new EditorGUI.DisabledGroupScope(someCondition))
+{
+    // ... disabled elements
+}
+```
+
+## Change Check
+
+```csharp
+EditorGUI.BeginChangeCheck();
+value = EditorGUILayout.IntField("Value", value);
+if (EditorGUI.EndChangeCheck())
+{
+    // Value changed, do something
+}
+```

--- a/skills/ui-imgui/references/templates.md
+++ b/skills/ui-imgui/references/templates.md
@@ -1,0 +1,141 @@
+# IMGUI Templates
+
+## EditorWindow
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+public class MyToolWindow : EditorWindow
+{
+    [MenuItem("Tools/My Tool")]
+    public static void ShowWindow()
+    {
+        GetWindow<MyToolWindow>("My Tool");
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.Label("My Tool", EditorStyles.boldLabel);
+
+        // Your GUI here
+    }
+}
+```
+
+## Custom Inspector
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+[CustomEditor(typeof(MyComponent))]
+public class MyComponentEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        MyComponent component = (MyComponent)target;
+
+        if (GUILayout.Button("Do Something"))
+        {
+            component.DoSomething();
+        }
+    }
+}
+```
+
+## SerializedProperty Pattern (Undo Support)
+
+```csharp
+[CustomEditor(typeof(MyComponent))]
+public class MyComponentEditor : Editor
+{
+    private SerializedProperty myProperty;
+
+    private void OnEnable()
+    {
+        myProperty = serializedObject.FindProperty("myField");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+
+        EditorGUILayout.PropertyField(myProperty);
+
+        serializedObject.ApplyModifiedProperties();
+    }
+}
+```
+
+## PropertyDrawer
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(MyData))]
+public class MyDataDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditorGUI.BeginProperty(position, label, property);
+
+        position = EditorGUI.PrefixLabel(position, label);
+
+        var fieldProp = property.FindPropertyRelative("field");
+        EditorGUI.PropertyField(position, fieldProp, GUIContent.none);
+
+        EditorGUI.EndProperty();
+    }
+}
+```
+
+## ScriptableWizard
+
+```csharp
+using UnityEditor;
+using UnityEngine;
+
+public class MyWizard : ScriptableWizard
+{
+    public string objectName = "New Object";
+    public int count = 1;
+
+    [MenuItem("Tools/My Wizard")]
+    static void CreateWizard()
+    {
+        DisplayWizard<MyWizard>("Create Objects", "Create", "Cancel");
+    }
+
+    void OnWizardCreate()
+    {
+        // Execute when "Create" clicked
+    }
+
+    void OnWizardUpdate()
+    {
+        // Validate input
+        isValid = !string.IsNullOrEmpty(objectName) && count > 0;
+    }
+}
+```
+
+## Debug Overlay (Runtime)
+
+```csharp
+using UnityEngine;
+
+public class DebugOverlay : MonoBehaviour
+{
+    private void OnGUI()
+    {
+        GUILayout.BeginArea(new Rect(10, 10, 200, 100));
+        GUILayout.Label($"FPS: {1f / Time.deltaTime:F1}");
+        GUILayout.Label($"Time: {Time.time:F2}");
+        GUILayout.EndArea();
+    }
+}
+```

--- a/skills/ui-ugui/SKILL.md
+++ b/skills/ui-ugui/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: ui-ugui
+description: Unity uGUI (Canvas-based) UI expert. Understands, edits, and generates Canvas hierarchies, RectTransforms, Layout Groups, and prefab UI. Use for requests involving Canvas, uGUI, RectTransform, or .prefab UI files.
+---
+
+Understand existing Unity uGUI, make targeted edits, and generate new Canvas-based hierarchies.
+
+When working with ScrollRect/ScrollView, read the reference file:
+- `references/scrollview-setup.md` — Required hierarchy, setup rules, and common failures
+
+## Scope
+
+Determine what the user is asking for:
+
+| Request Type | Action |
+|--------------|--------|
+| Question about UI | **Understand** — analyze hierarchy, explain structure |
+| Change specific element | **Edit** — targeted modification only |
+| Create new UI | **Generate** — create new hierarchy |
+| Fix/improve existing UI | **Edit** — modify existing, don't rebuild |
+
+**Generate only what is requested:**
+
+| Request | Output |
+|---------|--------|
+| UI layout | Prefab or scene hierarchy only |
+| "with code" / "with logic" / "functional" | Hierarchy + scripts |
+
+**These do NOT imply scripts:**
+- "proper buttons" → well-configured Button components
+- "working UI" → valid hierarchy that renders
+- "menu screen" → visual layout only
+
+## Critical Rules
+
+**Namespace disambiguation:**
+- Always use fully qualified type names when creating or referencing UI components
+- `UnityEngine.UI.Image`, not `Image`
+- `UnityEngine.UI.Button`, not `Button`
+- Other namespaces in the project can cause ambiguous type errors
+
+**Verify before modifying:**
+- Always check what currently exists before making changes
+- Confirm parent objects exist before adding children
+- Verify components are present before modifying properties
+- Never assume hierarchy state — query it first
+
+**Incremental fixes over rebuilds:**
+- When fixing issues, make targeted corrections
+- Never destroy and recreate entire hierarchies to fix problems — destroyed objects cause null reference cascades
+- Prefer identifying the specific broken property and fixing only that over rewriting large sections
+- **When a fix fails, revert the change** before trying an alternative approach
+
+**One change at a time:**
+- Make a single change, then verify the result
+- Do not batch multiple unrelated modifications
+- Be careful not to inadvertently modify or remove adjacent elements when editing a specific one
+- If something fails, understand why before trying alternatives
+- Avoid "shotgun debugging" with multiple simultaneous changes
+
+**Color and visibility:**
+- **Ensure text is readable by default:** When choosing colors, ensure text contrasts with its background — but respect intentional low-contrast uses (disabled states, placeholder text, decorative elements)
+- **Check visibility for new elements:** After creating UI elements, verify they have non-zero size and are within parent bounds. Elements intentionally created hidden (for later toggling, animation, etc.) are fine
+
+**Specification adherence:**
+- **Honor user specifications exactly:** When the user provides pixel dimensions, hex colors, positions, spacing, or other exact values, apply them precisely — do not approximate or substitute
+- **Minimize unrelated changes:** When editing, avoid changing properties the user didn't ask about unless a related adjustment is necessary for the fix to work
+
+## Conventions
+
+**Follow project patterns first.** Search existing files before applying defaults.
+
+| Type | Convention | Good | Bad |
+|------|------------|------|-----|
+| GameObject names | PascalCase | `SubmitButton` | `submit-button` |
+| Prefab paths | Feature folders | `Assets/UI/Inventory/` | `Assets/Prefabs/UI/` |
+
+## Workflow
+
+1. **Verify state** — Check what exists in the scene/hierarchy before any action.
+2. **Analyze** — Determine exactly what's needed. No extras.
+3. **Search** — Find existing prefabs, canvases, assets. Don't assume paths.
+4. **Follow project patterns** — Match folder structure and naming.
+5. **Create or edit** — Build structure with proper anchoring, or make targeted edits.
+6. **Confirm result** — Verify the change worked before moving on.
+
+## Canvas Setup
+
+Every UI needs a Canvas:
+
+```
+Canvas (Screen Space - Overlay or Camera)
+├── CanvasScaler (Scale With Screen Size recommended)
+├── GraphicRaycaster
+└── [UI Content]
+```
+
+**CanvasScaler settings:**
+- Default to UI Scale Mode "Scale With Screen Size" unless the project has a specific reason for "Constant Pixel Size" (e.g., pixel-art, fixed-resolution targets)
+- Reference Resolution: Match project standards (e.g., 1920x1080)
+- When creating a Canvas with Screen Space - Camera, **read the camera's reference resolution** first
+- Match Width Or Height: 0.5 (balanced)
+- If an existing Canvas uses "Constant Pixel Size", flag it and ask the user before changing
+- Prefer anchors and Layout Groups over absolute pixel positions for layout
+
+## Layout Components
+
+**Layout Groups control child sizing:**
+- When a parent has a Layout Group, it manages child RectTransforms
+- Children's anchors and sizeDelta may be overridden by the parent
+- Understand whether the parent or child controls size before setting values
+
+**Vertical/Horizontal Layout Groups:**
+- Control Child Size: determines if parent sets child dimensions
+- Child Force Expand: determines if children stretch to fill space
+- If Control Child Size is off, children must have explicit sizes
+
+**Avoiding layout conflicts:**
+- Do not manually set child anchors/size when parent controls them
+- Do not add Layout Group to an element that should have fixed size
+- Nested Layout Groups require careful configuration of each level
+- When layout is wrong, check parent settings before modifying child
+- ContentSizeFitter on the **same** object as a Layout Group that has Control Child Size enabled = conflict
+- ContentSizeFitter on a child whose parent has Control Child Size enabled = ContentSizeFitter is overridden (wasted)
+- When using ContentSizeFitter with a Layout Group parent, disable Control Child Size on the parent for the relevant axis
+- Common pattern: ScrollView Content should have ContentSizeFitter + VerticalLayoutGroup where VLG controls children but ContentSizeFitter sizes the Content itself
+
+**Grid Layout Group:**
+- For inventory grids, card layouts
+- Cell Size must be set explicitly — children are sized to match
+- Constraint controls row/column limits
+
+**Content Size Fitter:**
+- Horizontal/Vertical Fit: Preferred Size
+- Use on containers that should size to their content
+- Requires a layout element or text component to provide preferred size
+
+## RectTransform Anchoring
+
+**Elements must have non-zero size to be visible:**
+- Set explicit width/height via sizeDelta, or
+- Use stretch anchors with proper offsets, or
+- Let a parent Layout Group control size (with Control Child Size enabled)
+
+**Anchor configuration order:**
+1. Set anchor preset first (corner, edge, or stretch)
+2. Then set position/offset values
+3. Verify the resulting size is non-zero
+
+**Common patterns:**
+- **Stretch anchors** — for responsive elements that fill available space
+- **Corner anchors** — for fixed-position, fixed-size elements
+- **Edge anchors** — for elements that stretch in one direction only
+
+**Positioning from natural language descriptions:**
+When the user describes a position (e.g., "top right", "bottom bar", "left side"):
+1. Determine if it's a **corner** (fixed point), an **edge** (stretch along one axis), or **fill** (stretch both axes)
+2. Set anchor min and anchor max — for corners these are the same point; for edges/fill they span a range
+3. **Set pivot to match the anchor point** — pivot must align with where the element is anchored, not left at the default (0.5, 0.5). A "top right" element needs pivot at the top-right corner; a "top bar" needs pivot at the top edge center
+4. Set position/offset values **after** anchors and pivot are configured
+
+**Visibility checklist:**
+- Width and height are both greater than zero
+- Element is within parent bounds
+- Element is not obscured by siblings (check hierarchy order)
+- Image component has a sprite or color with alpha > 0
+
+## Common Components
+
+| Component | Use Case |
+|-----------|----------|
+| `Image` | Backgrounds, icons |
+| `RawImage` | Render textures, videos |
+| `Text (TMP)` | All text (use TextMeshPro) |
+| `Button` | Clickable elements |
+| `Toggle` | Checkboxes, radio buttons |
+| `Slider` | Value ranges |
+| `ScrollRect` | Scrollable content |
+| `InputField (TMP)` | Text input |
+
+## Best Practices
+
+- Use TextMeshPro for all text (not legacy Text)
+- WorldSpace UI that have text should also use Text Mesh Pro, be sure to review the project and import the TMP essentials if they are not present in the project
+- If the TextMeshPro Essentials were imported be sure to close the TMP Importer Windows and the Import Unity Package Window once the assets are imported
+- Organize hierarchy logically (Header, Content, Footer)
+- Use Layout Groups instead of manual positioning where possible
+- Set Raycast Target = false on non-interactive images
+- Use sprite atlases for performance
+
+**Never use** `EditorApplication.ExecuteMenuItem("Window/TextMeshPro/Import TMP Essential Resources")`, unless the user asks for an interactive TMP Essentials installation. It opens a modal dialog that blocks whatever invoked it until a human dismisses it.
+
+**Do not use** `AssetDatabase.ImportPackage()` for TMP resources, instead `TMP_PackageResourceImporter.ImportResources()` is the canonical non-interactive API.
+
+## Interaction Readiness
+
+Before completing any UI that contains interactive elements, verify:
+
+1. **EventSystem** must exist in the scene (exactly one)
+2. **GraphicRaycaster** must be on the Canvas
+3. **Raycast Target = true** on interactive elements (and false on non-interactive ones to avoid blocking)
+4. **Button.onClick should be wired** (via inspector or script) — only when scripts or logic were requested
+
+If the first three are missing, interactive elements will exist visually but fail silently.
+
+## Understanding
+
+When the user asks questions about existing UI:
+
+**Read the hierarchy first.** Don't assume — always inspect the scene or prefab before answering.
+
+**Analyze structure:**
+- Identify the Canvas and its render mode
+- Map the parent-child relationships
+- Identify which Layout Groups control which children
+- Check RectTransform anchor configurations
+
+**Answer questions about:**
+- "What does this button do?" → Explain component, hierarchy position, event wiring
+- "How is this laid out?" → Describe Layout Groups, anchoring, hierarchy
+- "Why is this invisible?" → Check size, anchors, parent bounds, component state
+- "What controls this element's size?" → Trace Layout Group settings or anchors
+
+## Editing
+
+For targeted changes to existing UI:
+
+**Read before editing.** Always inspect the current state first.
+
+**Edit workflow:**
+1. Verify the target object exists
+2. Identify the specific property or component to change
+3. Make the minimal change required
+4. Verify the result before proceeding
+
+**Never destroy to fix:**
+- Destroying objects cascades to null references elsewhere
+- Fix properties in place rather than recreating
+- If an element must be removed, update all references first
+
+## C# (Only When Requested)
+
+- Use fully qualified UI types to avoid namespace conflicts
+- Use `[SerializeField]` for inspector references
+- Cache component references in Awake()
+- Use events/delegates for button callbacks
+- Place scripts in same folder as prefabs (follow project patterns)
+
+**Component references:**
+- Verify referenced objects exist before accessing them
+- Handle cases where serialized references may be null
+- When wiring up references, confirm the target component is present
+
+## Error Recovery
+
+When something goes wrong:
+
+**Stop and diagnose:**
+- Identify the exact error or symptom
+- Determine the root cause before attempting fixes
+- Do not make speculative changes
+
+**Fix incrementally:**
+- Address one issue at a time
+- Verify each fix before moving to the next
+- Keep track of what was changed
+
+**Avoid destructive patterns:**
+- "Start fresh" strategies destroy working elements along with broken ones
+- Rebuilding entire hierarchies creates more problems than it solves
+- Prefer surgical fixes to wholesale replacements
+
+**When stuck:**
+- Re-verify the current state of the hierarchy
+- Check if previous changes were actually applied
+- Consider if the approach itself is wrong rather than the implementation

--- a/skills/ui-ugui/SKILL.md
+++ b/skills/ui-ugui/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: ui-ugui
 description: Unity uGUI (Canvas-based) UI expert. Understands, edits, and generates Canvas hierarchies, RectTransforms, Layout Groups, and prefab UI. Use for requests involving Canvas, uGUI, RectTransform, or .prefab UI files.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 ---
 
 Understand existing Unity uGUI, make targeted edits, and generate new Canvas-based hierarchies.

--- a/skills/ui-ugui/references/scrollview-setup.md
+++ b/skills/ui-ugui/references/scrollview-setup.md
@@ -1,0 +1,29 @@
+# ScrollView Setup
+
+ScrollRect requires a specific hierarchy to function correctly. Missing or misordered components cause jitter, duplication, or non-scrollable content.
+
+**Required hierarchy:**
+```
+ScrollView (ScrollRect)
+├── Viewport (RectTransform + Mask + Image)
+│   └── Content (RectTransform + VerticalLayoutGroup + ContentSizeFitter)
+│       └── [Children — static or added at runtime]
+└── Scrollbar (optional)
+```
+
+**Setup rules:**
+- **ScrollRect** component goes on the root ScrollView object
+- **Viewport** must have a `Mask` component and an `Image` component (Mask requires Image)
+- **Content** must have `ContentSizeFitter` with Vertical Fit set to "Preferred Size" so the scroll area grows with children
+- ScrollRect references: assign Content to `Content`, Viewport to `Viewport`, and optionally assign a Scrollbar
+- Content can contain static children (settings lists, about pages) or be populated dynamically at runtime
+
+**Dynamic population (runtime items):**
+- **Clear existing children** before populating to prevent duplication on panel re-open
+- Instantiate item prefabs as children of the Content object
+- The ContentSizeFitter + VerticalLayoutGroup on Content will automatically size the scrollable area
+
+**Common failures:**
+- Items duplicated on every open → Content not cleared before populating
+- Content not scrollable → missing ContentSizeFitter on Content, or Viewport missing Mask
+- Jitter/flickering → ContentSizeFitter conflict with parent Layout Group (see "Avoiding layout conflicts" in the main skill)

--- a/skills/ui-uitk/SKILL.md
+++ b/skills/ui-uitk/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: ui-uitk
+description: Unity UI Toolkit expert for Unity 6.0+. Understands, edits, and generates UXML and USS files with flex-based layouts. Use for requests involving .uxml, .uss, UI Toolkit, UIElements, UIDocument, UI runtime binding, Custom UI Elements, Manipulators or PanelSettings.
+---
+
+Understand existing Unity UI Toolkit code, make targeted edits, generate new UXML/USS files, Manipulators, and handle UI runtime binding.
+
+## References
+
+Read these as needed:
+- `references/uss-guide.md` — USS patterns and examples
+- `references/svg-icons.md` — SVG icon generation (only when generating icons)
+- `references/common-issues.md` — Common mistakes to avoid
+- `references/ui-runtime-binding.md` — Patterns and guide to bind data to UI at runtime (only when requested or when bindings are involved)
+- `references/painter2d.md` — Painter2D API for custom visuals: gradients, shapes, arcs, procedural drawing (read this whenever gradients, custom shapes, progress rings, procedural drawing, or any visual beyond what USS can express is needed)
+- `references/pointermanipulator-guide.md` — Patterns and guide to create and use Manipulators (only when requested or when manipulators are involved). This helps with setting up drag and drop features or simple event handling for a Visual Element.
+- `references/custom-elements.md` — Custom UI Element patterns and guide to create reusable components with UXML, USS, and C#. This helps with creating complex UI components for reuse across the project.
+
+Paths are relative to this skill's folder — read `references/uss-guide.md` directly.
+
+## Understanding
+
+When explaining UI structure, use this format:
+```
+[ElementType] name="elementName" class="class1 class2"
+├── [ChildType] name="childName"
+│   └── [GrandchildType]
+└── [ChildType] class="another-class"
+```
+
+## Editing
+
+**Common edit requests:**
+
+| Request | Action |
+|---------|--------|
+| "Change button color" | Edit USS selector for that button |
+| "Add a label here" | Add element to UXML at specified location |
+| "Make this bigger" | Edit width/height in USS |
+| "Hide this element" | Add `display: none` to USS or remove from UXML |
+| "Rename this element" | Update `name` attribute in UXML |
+
+**Don't over-edit:**
+- Change only what's requested
+- Preserve formatting and structure
+- Don't "improve" unrelated code
+- Don't add comments unless asked
+- For targeted changes, prefer modifying specific elements or selectors over rewriting entire files — but use judgment; if a change touches most of the file, a rewrite may be cleaner
+- Be careful not to accidentally drop existing elements, styles, or references when making edits
+- **When editing USS**, focus on the properties and selectors relevant to the request — avoid unnecessary reorganization, but restructure if the change genuinely requires it
+
+## Validation
+
+There is no way to validate UXML or USS from outside the Editor — Unity parses these
+files on import and reports problems in the Console. Write the files, then have the
+user check the result.
+
+**Workflow:**
+
+1. Write the complete file to its target path in the project. Do not write partial or
+   draft content — a half-written UXML file is a parse error the moment the Editor
+   picks it up.
+2. Ask the user to focus the Unity Editor. That triggers a reimport of the changed
+   assets.
+3. Ask them to report anything in the Console. UXML parse errors name the file and
+   line; USS problems appear as warnings about unknown properties or selectors.
+4. Fix what they report and repeat from step 1.
+
+**Because feedback costs a user round-trip, get it right the first time:**
+
+- Finish all files before asking the user to check, so one reimport covers everything
+  rather than one per file.
+- Re-read `references/uss-guide.md` and `references/common-issues.md` before writing,
+  rather than after an error comes back.
+- Watch for the mistakes that survive a parse but render wrong — those will not appear
+  in the Console at all, so the user has to eyeball the UI. `references/common-issues.md`
+  lists them.
+
+## Generation
+
+When creating new UI:
+
+**Generate only what is requested:**
+
+| Request | Output |
+|---------|--------|
+| USS only | `.uss` file only |
+| UXML only | `.uxml` file only |
+| UI screen / menu / panel | `.uss` + `.uxml` only |
+| "with code" / "with logic" / "functional" | `.uss` + `.uxml` + `.cs` |
+
+**These do NOT imply C#:**
+- "proper buttons" → well-styled Button elements
+- "currency display" → a Label element
+- "working UI" → valid UXML/USS that renders
+- "inventory screen" → visual layout only
+- "inventory system" / "equipment system" / "crafting system" → Ask: "Should items be draggable?" If yes, see `references/pointermanipulator-guide.md` for patterns
+
+**Generation workflow:**
+1. **Analyze** — Determine exactly what files are needed. No extras.
+2. **Search** — Find existing USS, UXML, assets. Don't assume paths.
+3. **Follow project patterns** — Match folder structure and naming conventions.
+4. **Reuse** — Check for shared stylesheets. Reuse if appropriate.
+5. **Write USS first** — Verify against restrictions below.
+6. **Write UXML** — Reference the USS, verify structure.
+7. **Write the files out complete** — never partial content; see Validation above for
+   how errors come back and why one round of files beats several.
+8. **Scene setup** — Assign PanelSettings if adding UI to scene.
+9. **Data binding** — If requested, add C# script with runtime data binding patterns (see `references/ui-runtime-binding.md`). Generate the scriptable object asset if needed. Assign the asset to the UI element root in UXML or via datasource in C#.
+
+**Color, visibility, and specification rules:**
+- **Ensure text is readable by default:** When choosing colors, ensure text contrasts with its background — but respect intentional low-contrast uses (disabled states, placeholder text, decorative elements). When using design tokens, check that text and background variables provide adequate contrast.
+- **Honor exact values:** User-specified hex colors, pixel dimensions, spacing — use exactly as given. Do not approximate or substitute.
+
+**Styling / Theme**
+When styling UI or adjusting theme make sure to not only apply to the elements directly in the current UXML but also to the core elements of UI Toolkit which are composed of several child elements usually.
+
+## Conventions
+
+**Follow project patterns first.** Search existing files before applying defaults.
+
+| Type | Convention | Good | Bad |
+|------|------------|------|-----|
+| `name` attribute | camelCase | `submitButton` | `submit-button` |
+| `class` attribute / USS | kebab-case | `.submit-button` | `.submitButton` |
+| File paths | Feature folders | `Assets/UI/Inventory/` | `Assets/Scripts/UI/` |
+
+**Output format:**
+```uxml Filename.uxml
+<ui:UXML>...</ui:UXML>
+```
+```uss Filename.uss
+.class { ... }
+```
+
+## USS Restrictions
+
+Unity's USS is a subset of CSS. These properties do NOT exist — NEVER use them:
+
+| NEVER Use | Use Instead |
+|-----------|-------------|
+| `border` shorthand | `border-width`, `border-color` separately |
+| `gap` | `margin` on children |
+| `z-index` | DOM order or parent nesting |
+| `pointer-events` | `picking-mode` UXML attribute |
+| `filter` | Not supported |
+| `outline` | `border-*` properties |
+| `box-shadow` | Nested elements or background image |
+| `:first-child`, `:last-child`, `:nth-child` | Explicit classes |
+| `[attribute]` selectors | Explicit classes |
+| `transition-property: <value>` | Omit entirely, or `none`/`initial`/`inherit` only |
+| `linear-gradient()`, `radial-gradient()` | Custom `VisualElement` with Painter2D (see `references/painter2d.md`) |
+
+**Inline styles:** NEVER use `style="..."` in UXML. All styling in USS only.
+
+**External URLs:** NEVER use `url()` with external paths. Only `url("project://database/Assets/...")`.
+
+**Prefer flexible layouts over hardcoded sizes:**
+- Use `flex-grow`, `flex-shrink`, or `%` instead of fixed `width`/`height` values
+- Let elements flow naturally and be constrained by their parent container
+- Set explicit pixel sizes only on root containers or when a fixed size is truly required
+- Child elements should adapt to available space rather than define their own dimensions
+
+## USS Brevity
+
+- No default values (`flex-direction: column` is default)
+- No default fonts
+- No redundant constraints (`width: 100px` doesn't need `min-width`/`max-width`)
+- No overlapping properties (`flex: 1` already sets grow/shrink)
+- Simplest selector that works
+- Never duplicate selectors
+
+## UXML
+
+Every file must:
+1. Declare namespace: `<ui:UXML xmlns:ui="UnityEngine.UIElements">`
+2. Link stylesheet(s): `<ui:Style src="Screen.uss" />`
+3. Have exactly one top-level container
+4. **No `style="..."` attributes** — use USS only
+
+```uxml
+<ui:UXML xmlns:ui="UnityEngine.UIElements">
+  <ui:Style src="Panel.uss" />
+  <ui:VisualElement name="root" class="panel">
+    <!-- content -->
+  </ui:VisualElement>
+</ui:UXML>
+```
+
+## Events and Interactivity
+- Use Pointer Manipulators for event handling and interactivity on a VisualElement (see `references/pointermanipulator-guide.md`)
+- If drag and drop is requested then write a pointer Manipulator and attach it to the relevant Visual Element in UXML or via C#.
+- For simple click events, you can use the `clickable` manipulator in UXML
+- For more advanced interactions, create use more traditional event callbacks in C# and attach them to elements as needed
+
+**For inventory and crafting systems:**
+- When users request an "inventory system", "equipment system", or "crafting system", ask explicitly: "Should players be able to drag and drop items?"
+- If yes, read `references/pointermanipulator-guide.md` for inventory/crafting-specific patterns
+- If no or unclear, create static layout only
+
+## Assets
+
+**Do NOT reference `UnityDefaultRuntimeTheme.tss`** or Unity's built-in theme icons.
+
+**Icon priority:**
+1. Reuse existing project icons
+2. Generate SVG (see `references/svg-icons.md`)
+3. Image generators (last resort)
+
+**Reference format:**
+```uss
+background-image: url("project://database/Assets/UI/Textures/icon.png");
+```
+
+## Scene Setup
+
+**PanelSettings is required** — UI won't render without it.
+
+1. Search for existing PanelSettings asset
+2. If none, create generic: `Assets/UI/PanelSettings.asset`
+3. Assign to UIDocument's `Panel Settings` field
+
+Skip for Editor UI (EditorWindow, PropertyDrawer).
+
+## C# (Only When Requested)
+
+- Style via USS classes (`AddToClassList()`) — never use `element.style.*` as inline styles have higher specificity than USS selectors, making them impossible to override via stylesheets, and add per-element memory overhead
+- UITK uses TextCore text assets — use `FontAsset`, `TextStyleSheet`, and `TextSettings`, not their TextMeshPro equivalents (`TMP_FontAsset`, etc.)
+- Place scripts in same folder as UXML/USS

--- a/skills/ui-uitk/SKILL.md
+++ b/skills/ui-uitk/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: ui-uitk
 description: Unity UI Toolkit expert for Unity 6.0+. Understands, edits, and generates UXML and USS files with flex-based layouts. Use for requests involving .uxml, .uss, UI Toolkit, UIElements, UIDocument, UI runtime binding, Custom UI Elements, Manipulators or PanelSettings.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
 ---
 
 Understand existing Unity UI Toolkit code, make targeted edits, generate new UXML/USS files, Manipulators, and handle UI runtime binding.

--- a/skills/ui-uitk/references/common-issues.md
+++ b/skills/ui-uitk/references/common-issues.md
@@ -1,0 +1,74 @@
+# Common USS/UXML Issues
+
+## Transitions on :hover
+
+Transitions must be defined on the base class, not the hover state:
+
+```uss
+/* WRONG - won't animate on hover-out */
+.button:hover {
+  background-color: blue;
+  transition-duration: 0.2s;
+}
+
+/* CORRECT */
+.button {
+  background-color: white;
+  transition-duration: 0.2s;
+}
+.button:hover {
+  background-color: blue;
+}
+```
+
+## Hardcoded Percentage Widths
+
+Avoid hardcoded percentages for flexible layouts:
+
+```uss
+/* AVOID */
+.column {
+  width: 33%;
+}
+
+/* PREFER */
+.column {
+  flex-grow: 1;
+}
+```
+
+## Unclosed Brackets
+
+Always ensure brackets are properly closed:
+
+```uss
+/* WRONG - missing closing bracket */
+.panel {
+  padding: 16px;
+
+.button {
+  color: white;
+}
+
+/* CORRECT */
+.panel {
+  padding: 16px;
+}
+
+.button {
+  color: white;
+}
+```
+
+## Referencing Unity Theme
+
+**Do NOT reference `UnityDefaultRuntimeTheme.tss`** or built-in theme icons.
+
+Create custom styles or reuse project assets instead.
+
+## Performance Issues
+
+- **Inline styles** cause per-element memory overhead
+- **`:hover` on parents** with many children invalidates entire hierarchies
+- **Many classes per element** decreases selector performance linearly
+- **Large hierarchies** are the main performance factor

--- a/skills/ui-uitk/references/custom-elements.md
+++ b/skills/ui-uitk/references/custom-elements.md
@@ -1,0 +1,241 @@
+# Custom VisualElements in UI Toolkit
+
+Guide for creating custom VisualElements using Unity 6+ `[UxmlElement]` and `[UxmlAttribute]` attributes.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Requirements](#requirements)
+- [Supported Property Types](#supported-property-types)
+- [Advanced Patterns](#advanced-patterns)
+- [Best Practices](#best-practices)
+- [UXML Namespace Declaration](#uxml-namespace-declaration)
+- [UI Builder Integration](#ui-builder-integration)
+- [Summary](#summary)
+
+## Overview
+
+Unity 6+ uses attribute-based custom elements. The old factory pattern (`IUxmlFactory`, `UxmlTraits`) is **deprecated**.
+
+### ⚠️ CRITICAL: Namespace Declaration
+
+**Never include assembly names in UXML namespace declarations:**
+
+```xml
+❌ WRONG: xmlns:custom="Game.UI.Custom, Assembly-CSharp"
+✅ CORRECT: xmlns:custom="Game.UI.Custom"
+```
+
+**Format**: `xmlns:prefix="Namespace.Path"` (namespace only, no assembly)
+
+### Basic Pattern
+
+```csharp
+[UxmlElement]
+public partial class MyElement : VisualElement
+{
+    [UxmlAttribute]
+    public string myValue { get; set; }
+}
+```
+
+```xml
+<ui:UXML xmlns:ui="UnityEngine.UIElements"
+         xmlns:custom="Game.UI.Custom">
+    <custom:MyElement my-value="Hello" />
+</ui:UXML>
+```
+
+## Requirements
+
+1. **[UxmlElement]** attribute on the class
+2. **partial** keyword required
+3. Inherit from **VisualElement** or subclass
+4. **[UxmlAttribute]** on exposed properties
+
+### Property Naming
+
+C# camelCase → UXML kebab-case:
+- `myStringValue` → `my-string-value`
+- `maxHealth` → `max-health`
+
+### Example
+
+```csharp
+[UxmlElement]
+public partial class CustomLabel : Label
+{
+    [UxmlAttribute]
+    public Color textColor { get; set; } = Color.white;
+
+    [UxmlAttribute]
+    public int fontSize { get; set; } = 14;
+
+    public CustomLabel()
+    {
+        RegisterCallback<GeometryChangedEvent>(evt => {
+            style.color = textColor;
+            style.fontSize = fontSize;
+        });
+    }
+}
+```
+
+```xml
+<custom:CustomLabel text="Hello" text-color="rgb(255,215,0)" font-size="24" />
+```
+
+## Supported Property Types
+
+**Basic**: `string`, `int`, `float`, `bool`, `Color`
+**Unity**: `Texture2D`, `Sprite`, `Font`
+**Enums**: Any enum type
+**Collections**: `List<T>`, `T[]`
+
+### Image Handling
+
+**Static images** (don't change) → Use USS:
+```css
+.icon { background-image: url('project://Assets/UI/Icons/fireball.png'); }
+```
+
+**Dynamic images** (change per instance) → Use `[UxmlAttribute]`:
+```csharp
+[UxmlAttribute]
+public Sprite portrait { get; set; }  // Different per character
+```
+
+## Advanced Patterns
+
+### Validation Attributes
+
+```csharp
+[UxmlAttribute]
+[Range(0, 100)]
+[Tooltip("Current health value")]
+public float health { get; set; } = 100f;
+```
+
+Improves UI Builder inspector experience.
+
+### Custom Attribute Names
+
+```csharp
+[UxmlAttribute("hp")]
+public float health { get; set; }  // Use "hp" in UXML
+```
+
+### Custom Type Converters
+
+Use `UxmlAttributeConverter<T>` when a property's type is not natively supported by UXML (e.g. structs, complex data objects). An example below implements `FromString` to parse the UXML attribute string into the specified type, then register it with `[UxmlAttributeConverter]` on the property.
+
+```csharp
+public class HealthDataConverter : UxmlAttributeConverter<HealthData>
+{
+    public override HealthData FromString(string value)
+    {
+        var parts = value.Split(',');
+        return new HealthData { current = float.Parse(parts[0]), max = float.Parse(parts[1]) };
+    }
+}
+
+[UxmlAttribute]
+[UxmlAttributeConverter(typeof(HealthDataConverter))]
+public HealthData healthData { get; set; }
+```
+
+### Custom Property Drawers
+
+Create custom UI Builder inspector controls for your attributes:
+
+```csharp
+// 1. Custom attribute
+public class SliderDrawerAttribute : PropertyAttribute { }
+
+// 2. Property drawer
+[CustomPropertyDrawer(typeof(SliderDrawerAttribute))]
+public class SliderDrawerPropertyDrawer : PropertyDrawer
+{
+    public override VisualElement CreatePropertyGUI(SerializedProperty property)
+    {
+        var field = new SliderInt(0, 100) { label = property.displayName };
+        field.BindProperty(property);
+        return field;
+    }
+}
+
+// 3. Usage
+[UxmlElement]
+public partial class StyledButton : Button
+{
+    [UxmlAttribute]
+    [SliderDrawer]
+    public int intensity { get; set; } = 50;
+}
+```
+
+**Override existing properties** with custom drawers:
+
+```csharp
+[UxmlElement]
+public partial class CustomIntField : IntegerField
+{
+    // Override base 'value' property to use slider drawer in UI Builder
+    [UxmlAttribute("value"), SliderDrawer]
+    internal int myValue
+    {
+        get => this.value;
+        set => this.value = value;
+    }
+}
+```
+
+This customizes how properties appear in the UI Builder inspector.
+
+
+## Best Practices
+
+1. **Always use `partial`** - Required for [UxmlElement]
+2. **Provide defaults** - `public float radius { get; set; } = 30f;`
+3. **Update on changes** - Use property setters to call `UpdateVisuals()` or `MarkDirtyRepaint()`
+4. **Use backing fields** - When validation or change detection needed
+5. **USS for styling** - Add class names and style via USS, not inline styles
+6. **Static images → USS, Dynamic → C#** - Use USS `background-image` for fixed images
+7. **Document elements** - Add XML comments for better developer experience
+
+## UXML Namespace Declaration
+
+### Rules
+
+1. **Namespace only** - No assembly name, no commas
+2. **Exact match** - Must match C# namespace exactly (case-sensitive)
+3. **Format**: `xmlns:prefix="Namespace.Path"`
+
+### Examples
+
+```xml
+<!-- ✅ Single namespace -->
+<ui:UXML xmlns:ui="UnityEngine.UIElements"
+         xmlns:custom="Game.UI.Custom">
+    <custom:RadialProgress />
+</ui:UXML>
+
+<!-- ✅ Multiple namespaces -->
+<ui:UXML xmlns:ui="UnityEngine.UIElements"
+         xmlns:hud="Game.UI.HUD"
+         xmlns:menu="Game.UI.Menu">
+    <hud:HealthBar />
+    <menu:SettingsPanel />
+</ui:UXML>
+```
+
+### Common Mistakes
+
+```xml
+❌ xmlns:custom="Game.UI.Custom, Assembly-CSharp"  (assembly name)
+❌ xmlns:custom="game.ui.custom"                    (wrong case)
+❌ xmlns:custom="Custom"                            (incomplete)
+❌ xmlns:custom="Game.UI.Custom.RadialProgress"     (class name)
+
+✅ xmlns:custom="Game.UI.Custom"                    (correct)
+```

--- a/skills/ui-uitk/references/painter2d.md
+++ b/skills/ui-uitk/references/painter2d.md
@@ -1,0 +1,282 @@
+# Custom Visuals with Painter2D
+
+## Table of Contents
+
+- [The Pattern](#the-pattern)
+- [Canvas-to-Painter2D Mapping](#canvas-to-painter2d-mapping)
+- [Gradient Fills](#gradient-fills)
+- [GradientElement — Full Example](#gradientelement--full-example)
+- [Other Use Cases](#other-use-cases)
+- [Rules](#rules)
+
+USS cannot draw gradients, arbitrary shapes, arcs, or procedural patterns. For these, use the **Painter2D** API via the `generateVisualContent` callback.
+
+Painter2D is modeled on the **HTML Canvas 2D** context — `BeginPath`, `MoveTo`, `LineTo`, `Arc`, `BezierCurveTo`, `Fill`, `Stroke` all map directly. Key differences from Canvas: text is drawn via `ctx.DrawText()` on the `MeshGenerationContext` (not on Painter2D itself), no `drawImage()` (use `fillTexture` or child elements with USS `background-image`), angles use `Angle.Degrees()` / `Angle.Turns()` structs, arc direction is an enum (`ArcDirection.Clockwise` / `.CounterClockwise`), and coordinates are local to the element's content rect.
+
+**Drawing text:** Use `ctx.DrawText(string text, Vector2 pos, float fontSize, Color color, FontAsset font)` on the `MeshGenerationContext` directly. Pass `null` for `font` to use the element's USS font. This is useful when text must be positioned precisely within custom-drawn visuals — for simpler cases, child `Label` elements are easier.
+
+## The Pattern
+
+Every custom-drawn element: extend `VisualElement` directly (never `Label`, `Button`, etc. — Painter2D won't render correctly on those), subscribe to `generateVisualContent`, draw with `ctx.painter2D`, call `MarkDirtyRepaint()` when properties change. For animations, call `MarkDirtyRepaint()` every frame from an update loop.
+
+```csharp
+[UxmlElement]
+public partial class MyCustomVisual : VisualElement
+{
+    float m_Value = 0.5f;
+
+    [UxmlAttribute]
+    public float Value
+    {
+        get => m_Value;
+        set { m_Value = value; MarkDirtyRepaint(); }
+    }
+
+    public MyCustomVisual()
+    {
+        generateVisualContent += OnGenerateVisualContent;
+    }
+
+    void OnGenerateVisualContent(MeshGenerationContext ctx)
+    {
+        float w = contentRect.width;
+        float h = contentRect.height;
+        if (w < 1f || h < 1f) return;
+
+        var painter = ctx.painter2D;
+        // ... drawing commands
+    }
+}
+```
+
+Name classes to match their purpose — `GradientCard`, `RadialProgress`, `WaveformDisplay`, etc.
+
+## Canvas-to-Painter2D Mapping
+
+| HTML Canvas 2D | Unity Painter2D |
+|----------------|-----------------|
+| `beginPath()` | `BeginPath()` |
+| `moveTo(x, y)` | `MoveTo(new Vector2(x, y))` |
+| `lineTo(x, y)` | `LineTo(new Vector2(x, y))` |
+| `arc(cx, cy, r, start, end)` | `Arc(Vector2 center, float radius, Angle start, Angle end, ArcDirection dir)` |
+| `arcTo(x1, y1, x2, y2, r)` | `ArcTo(Vector2 p1, Vector2 p2, float radius)` |
+| `bezierCurveTo(...)` | `BezierCurveTo(Vector2 ctrl1, Vector2 ctrl2, Vector2 end)` |
+| `quadraticCurveTo(...)` | `QuadraticCurveTo(Vector2 ctrl, Vector2 end)` |
+| `closePath()` | `ClosePath()` |
+| `rect(x, y, w, h)` | **No equivalent** — trace manually with `MoveTo`/`LineTo`/`ClosePath` |
+| `fill()` | `Fill(FillRule rule = NonZero)` — use `OddEven` for holes/cutouts |
+| `stroke()` | `Stroke()` |
+| `lineWidth` | `lineWidth` |
+| `strokeStyle` | `strokeColor` / `strokeGradient` / `strokeFillGradient` |
+| `fillStyle` | `fillColor` / `fillGradient` / `fillTexture` |
+| `lineCap` | `lineCap` — `LineCap.Butt` (default), `.Round`, `.Square` |
+| `lineJoin` | `lineJoin` — `LineJoin.Miter` (default), `.Bevel`, `.Round` |
+| `setLineDash([...])` | `SetDashPattern(float[])` |
+| `lineDashOffset` | `dashOffset` |
+
+Both `Fill()` and `Stroke()` can be called on the same path.
+
+Angle helpers: `Angle.Degrees(float)`, `Angle.Radians(float)`, `Angle.Turns(float)`.
+
+## Gradient Fills
+
+USS has no `linear-gradient()` or `radial-gradient()`. Use `FillGradient`:
+
+```csharp
+// Linear — two-color shorthand
+FillGradient.MakeLinearGradient(Color startColor, Color endColor, Vector2 start, Vector2 end, AddressMode mode)
+// Linear — multi-stop via Gradient object
+FillGradient.MakeLinearGradient(Gradient gradient, Vector2 start, Vector2 end, AddressMode mode)
+
+// Radial — two-color shorthand
+FillGradient.MakeRadialGradient(Color startColor, Color endColor, Vector2 center, float radius, Vector2 focus, AddressMode mode)
+// Radial — multi-stop via Gradient object
+FillGradient.MakeRadialGradient(Gradient gradient, Vector2 center, float radius, Vector2 focus, AddressMode mode)
+```
+
+`AddressMode`: `Clamp` (extend edge color), `Repeat` (tile), `Mirror` (reflect).
+
+**Linear gradient direction** — controlled by start/end points:
+
+| Direction | Start | End |
+|-----------|-------|-----|
+| Top → Bottom | `(0, 0)` | `(0, height)` |
+| Left → Right | `(0, 0)` | `(width, 0)` |
+| Diagonal | `(0, 0)` | `(width, height)` |
+
+**Radial gradient** — set `focus` off-center to shift the bright spot.
+
+## GradientElement — Full Example
+
+A custom element rendering a linear gradient with rounded corners and optional border stroke. All properties exposed as UXML attributes.
+
+```csharp
+using UnityEngine;
+using UnityEngine.UIElements;
+
+[UxmlElement]
+public partial class GradientElement : VisualElement
+{
+    Color m_StartColor = new Color(0.13f, 0.59f, 0.95f);
+    Color m_EndColor = new Color(0.61f, 0.15f, 0.69f);
+    Color m_BorderColor = Color.white;
+    float m_BorderWidth = 2f;
+    float m_CornerRadius = 8f;
+    float m_GradientAlpha = 1f;
+
+    [UxmlAttribute]
+    public Color StartColor
+    {
+        get => m_StartColor;
+        set { m_StartColor = value; MarkDirtyRepaint(); }
+    }
+
+    [UxmlAttribute]
+    public Color EndColor
+    {
+        get => m_EndColor;
+        set { m_EndColor = value; MarkDirtyRepaint(); }
+    }
+
+    [UxmlAttribute]
+    public Color BorderColor
+    {
+        get => m_BorderColor;
+        set { m_BorderColor = value; MarkDirtyRepaint(); }
+    }
+
+    [UxmlAttribute]
+    public float BorderWidth
+    {
+        get => m_BorderWidth;
+        set { m_BorderWidth = value; MarkDirtyRepaint(); }
+    }
+
+    [UxmlAttribute]
+    public float CornerRadius
+    {
+        get => m_CornerRadius;
+        set { m_CornerRadius = value; MarkDirtyRepaint(); }
+    }
+
+    [UxmlAttribute]
+    public float GradientAlpha
+    {
+        get => m_GradientAlpha;
+        set { m_GradientAlpha = Mathf.Clamp01(value); MarkDirtyRepaint(); }
+    }
+
+    public GradientElement()
+    {
+        generateVisualContent += OnGenerateVisualContent;
+    }
+
+    void OnGenerateVisualContent(MeshGenerationContext ctx)
+    {
+        float w = contentRect.width;
+        float h = contentRect.height;
+        if (w < 1f || h < 1f)
+            return;
+
+        DrawGradientBackground(
+            ctx.painter2D, w, h,
+            m_StartColor, m_EndColor, m_GradientAlpha,
+            m_CornerRadius,
+            m_BorderColor, m_BorderWidth);
+    }
+
+    static void DrawGradientBackground(
+        Painter2D painter,
+        float width, float height,
+        Color startColor, Color endColor, float alpha,
+        float cornerRadius,
+        Color borderColor, float borderWidth)
+    {
+        float r = Mathf.Min(cornerRadius, Mathf.Min(width, height) * 0.5f);
+
+        var start = startColor;
+        var end = endColor;
+        start.a *= alpha;
+        end.a *= alpha;
+
+        painter.fillGradient = FillGradient.MakeLinearGradient(
+            BuildGradient(start, end),
+            new Vector2(0f, 0f),
+            new Vector2(0f, height),
+            AddressMode.Clamp);
+
+        painter.BeginPath();
+        TraceRoundedRect(painter, 0f, 0f, width, height, r);
+        painter.Fill();
+
+        if (borderWidth <= 0f)
+            return;
+
+        float half = borderWidth * 0.5f;
+        painter.strokeColor = borderColor;
+        painter.lineWidth = borderWidth;
+        painter.lineJoin = LineJoin.Round;
+
+        painter.BeginPath();
+        TraceRoundedRect(
+            painter, half, half,
+            width - borderWidth, height - borderWidth,
+            Mathf.Max(0f, r - half));
+        painter.Stroke();
+    }
+
+    static Gradient BuildGradient(Color start, Color end)
+    {
+        var gradient = new Gradient();
+        gradient.SetKeys(
+            new[] { new GradientColorKey(start, 0f), new GradientColorKey(end, 1f) },
+            new[] { new GradientAlphaKey(start.a, 0f), new GradientAlphaKey(end.a, 1f) });
+        return gradient;
+    }
+
+    static void TraceRoundedRect(Painter2D p, float x, float y, float w, float h, float r)
+    {
+        p.MoveTo(new Vector2(x + r, y));
+        p.LineTo(new Vector2(x + w - r, y));
+        p.ArcTo(new Vector2(x + w, y), new Vector2(x + w, y + r), r);
+        p.LineTo(new Vector2(x + w, y + h - r));
+        p.ArcTo(new Vector2(x + w, y + h), new Vector2(x + w - r, y + h), r);
+        p.LineTo(new Vector2(x + r, y + h));
+        p.ArcTo(new Vector2(x, y + h), new Vector2(x, y + h - r), r);
+        p.LineTo(new Vector2(x, y + r));
+        p.ArcTo(new Vector2(x, y), new Vector2(x + r, y), r);
+        p.ClosePath();
+    }
+}
+```
+
+### Usage in UXML
+
+```uxml
+<ui:UXML xmlns:ui="UnityEngine.UIElements">
+  <ui:Style src="Screen.uss" />
+  <GradientElement class="gradient-card"
+      start-color="#2196F3" end-color="#9C27B0"
+      gradient-alpha="0.9" corner-radius="12"
+      border-color="#FFFFFF" border-width="1">
+    <ui:Label text="Card Title" class="card-title" />
+    <ui:Label text="Description text goes here" class="card-desc" />
+  </GradientElement>
+</ui:UXML>
+```
+
+The element participates in flexbox, accepts children, and can be styled with USS for sizing, padding, and margin. The gradient draws behind child content.
+
+## Other Use Cases
+
+Painter2D handles any visual USS cannot express — progress rings (`Arc()` with dynamic `endAngle`), custom shapes (polygons, stars, badges), charts (bar fills, pie segments, sparklines), decorative elements (wave patterns, bezier flourishes), and animated visuals (drive properties from C#, call `MarkDirtyRepaint()` each frame).
+
+## Rules
+
+- **Extend `VisualElement` directly** — never `Label`, `Button`, etc.
+- **Guard zero dimensions** — `if (contentRect.width < 1f || contentRect.height < 1f) return;`
+- **`BeginPath()` before every path** — omitting it causes silent failures
+- **No `Rect()` method** — Painter2D has no rectangle convenience method. Trace rectangles manually with `MoveTo`/`LineTo`/`ClosePath` (see `TraceRoundedRect` in the gradient example)
+- **Set style properties before `BeginPath()`** — `lineWidth`, `strokeColor`, `fillColor`, etc.
+- **Never mutate the element inside `generateVisualContent`** — no style changes, no adding children, no `MarkDirtyRepaint()` from within the callback
+- **`LineCap.Butt` for precise arc endpoints** — `Round` extends past the endpoint by half the line width

--- a/skills/ui-uitk/references/pointermanipulator-guide.md
+++ b/skills/ui-uitk/references/pointermanipulator-guide.md
@@ -1,0 +1,94 @@
+# UI Toolkit Manipulator Reference
+
+Pointer Manipulators handle pointer interactions like drag and drop, click, hover, and gestures in Unity UI Toolkit.
+
+## What is a Manipulator?
+
+A `Manipulator` is an event handler class attached to `VisualElement`s to add interactive behavior. They encapsulate interaction logic and can be reused across multiple elements.
+
+## Base Pattern
+
+Pointer Manipulators inherit from `PointerManipulator` and override:
+- `RegisterCallbacksOnTarget()` — Subscribe to events when attached
+- `UnregisterCallbacksFromTarget()` — Unsubscribe when detached
+
+Attach with: `element.AddManipulator(new YourManipulator())`
+
+## Drag and Drop Approach
+
+### Drag and Drop Code Design
+1. **PointerDown** — Capture pointer, store pointer start position, store dragged element reference, mark as dragging, set to Aboslute positioning, and BringToFront
+
+```csharp
+_isDragging = true;
+target.style.position = Position.Absolute;
+target.BringToFront();
+target.usageHints = UsageHints.DynamicTransform;
+```
+
+2. **PointerMove** — Update dragged element position relative to the pointer, check if pointer is over valid drop target. ALWAYS use the StyleTranslate API for drag and drop and updating element position unless otherwise specified.
+
+Example of using StyleTranslate API:
+```csharp
+target.style.translate = new StyleTranslate(newWorldPosition);
+```
+
+3. **PointerUp** — If over drop target or find nearest overlapping target, execute drop logic (move element, trigger callback), release pointer
+4. **PointerCaptureOut** — Finalize drop and raise event
+
+### Drop Target Detection
+Use `VisualElement.panel.Pick(position)` or check bounds with `worldBound.Contains(position)` to find elements under the pointer.
+
+### Visual Feedback
+Add/remove USS classes on drag start/end for hover states, drag shadows, or drop zone highlights:
+```csharp
+target.AddToClassList("dragging");
+dropZone.AddToClassList("drop-zone-active");
+```
+
+## Best Practices
+- Use USS classes for visual states instead of inline `element.style.*` properties
+- Validate drop targets before executing drop logic
+- Use `evt.StopPropagation();` to prevent dragged items from behaving like buttons or interacting unexpectedly
+- To ensure dragged item is always on top use `BringToFront()`
+- Decide the `pickingMode` for the dragged item to ensure the slot underneath is detected and revert to proper state after dropping
+
+## Common Enhancements
+
+- **Constrain to bounds** — Clamp position to parent or screen bounds
+- **StyleTranslation API** - Use `target.style.translate = new StyleTranslate(newWorldPosition)` to avoid style pass updates
+- **Performance** - Use Usage Hints and `UsageHints.DynamicTransform;` for better performance
+- **Drop validation** — Check if drop target accepts this element type
+- **Revert on invalid drop** — Animate back to start position if dropped outside valid zone
+
+## Inventory and Crafting Systems
+
+When users request inventory or crafting systems, first determine requirements:
+
+### Ask Users First
+- "Should players be able to drag and drop items between slots?"
+- "Should items snap to grid positions or specific equipment slots?"
+- "Do items stack? Do they have quantities?"
+
+If drag-and-drop is NOT needed, create static visual layout only (UXML/USS).
+
+### When to Use Drag-Drop
+
+**Inventory systems need drag-drop when:**
+- Players move items between slots (inventory, equipment, hotbar)
+- Items can be equipped to specific slots (head, chest, weapon)
+- Players organize or sort their inventory
+
+**Crafting systems need drag-drop when:**
+- Players place ingredients into crafting slots
+- Players combine items by dragging them together
+- Recipe slots require specific item types
+
+**Implementation Checklist**
+When implementing drag-drop for inventory/crafting:
+- Created manipulator and callback methods for draggable UI element
+- Created UI element or slots as a drop zone
+- Added USS classes for dragging and drop states
+- Stored item data separately from visual elements (use data binding or C# dictionaries)
+- Validated drop targets before executing drop
+- Added visual feedback: drag shadows, slot highlighting, hover states

--- a/skills/ui-uitk/references/svg-icons.md
+++ b/skills/ui-uitk/references/svg-icons.md
@@ -1,0 +1,136 @@
+# SVG Icon Generation (Unity 6.3+)
+
+## Table of Contents
+
+- [When to Use SVG](#when-to-use-svg)
+- [Priority Order](#priority-order)
+- [SVG Format](#svg-format)
+- [Common Icon Examples](#common-icon-examples)
+- [Usage in Unity](#usage-in-unity)
+- [Tips](#tips)
+
+## When to Use SVG
+
+**Prefer SVG for:**
+- Simple icons (arrows, chevrons, checkmarks)
+- Geometric shapes
+- UI symbols (close, menu, settings)
+- Any icon that can be drawn with paths
+
+**Use image generators for:**
+- Complex illustrations
+- Photorealistic content
+- Detailed artwork
+- Gradients with many stops
+
+## Priority Order
+
+1. **Reuse existing project icons** — always search first
+2. **Generate SVG** — fast, resolution-independent, low cost
+3. **Image generators** — last resort, slower and higher cost
+
+## SVG Format
+
+Unity imports SVG as VectorImage assets. Use standard SVG markup:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="..." stroke="currentColor" stroke-width="2" fill="none"/>
+</svg>
+```
+
+## Common Icon Examples
+
+### Arrow Right
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M8 4l8 8-8 8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+```
+
+### Arrow Left
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M16 4l-8 8 8 8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+```
+
+### Chevron Down
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 8l8 8 8-8" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+```
+
+### Checkmark
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 12l6 6L20 6" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+```
+
+### Close (X)
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+### Plus
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 4v16M4 12h16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+### Minus
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 12h16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+### Menu (Hamburger)
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+### Settings (Gear)
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+### Search (Magnifying Glass)
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="10" cy="10" r="6" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M14.5 14.5L20 20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>
+```
+
+## Usage in Unity
+
+1. Save SVG file to project (e.g., `Assets/UI/Icons/arrow-right.svg`)
+2. Unity auto-imports as VectorImage
+3. Set "Generated Asset Type" to "UI Toolkit Vector Image" in Inspector
+4. Reference in USS:
+
+```uss
+.icon-arrow {
+  background-image: url("project://database/Assets/UI/Icons/arrow-right.svg");
+  width: 24px;
+  height: 24px;
+}
+```
+
+## Tips
+
+- Use `viewBox="0 0 24 24"` for consistent sizing
+- Use `stroke="currentColor"` for tintable icons
+- Use `fill="none"` for outline-style icons
+- Keep paths simple — complex SVGs may not render correctly

--- a/skills/ui-uitk/references/ui-runtime-binding.md
+++ b/skills/ui-uitk/references/ui-runtime-binding.md
@@ -1,0 +1,234 @@
+# Runtime Data Binding Reference
+
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [Data Source Setup](#data-source-setup)
+- [CRITICAL: Always Use nameof()](#critical-always-use-nameof)
+- [Explicit Binding Element](#explicit-binding-element)
+- [C# SetBinding (Programmatic)](#c-setbinding-programmatic)
+- [PanelRenderer with Bindings](#panelrenderer-with-bindings)
+
+Unity UI Toolkit runtime data binding for efficient UI updates.
+
+## Core Concepts
+
+**Use binding when:**
+- Connecting game state to UI (health, score, ammo)
+- Multiple UI elements display the same data
+- Data changes frequently but predictably
+
+**Avoid binding when:**
+- One-time UI updates
+- Per-frame updates (use direct property sets)
+- Simple direct property assignment is clearer
+
+## Data Source Setup
+
+### Required: [CreateProperty] Attribute
+
+```csharp
+using Unity.Properties;
+using UnityEngine;
+
+public class PlayerData
+{
+    [CreateProperty]
+    public int Health { get; set; }
+
+    // the private serialized field here helps the user see the property in the editor but do not create the property on the private member unless requested
+    [SerializeField, DontCreateProperty]
+    private float m_Speed;
+
+    // the public member gets a property created out of it so we bind to this property
+    [CreateProperty]
+    public float Speed
+    {
+        get => m_Speed;
+        set => m_Speed = value;
+    }
+}
+```
+
+
+## CRITICAL: Always Use nameof()
+```csharp
+element.SetBinding("value", new DataBinding
+{
+    dataSourcePath = new PropertyPath(nameof(HealthData.HealthPercentage))
+});
+```
+
+**Why nameof():**
+- Compile-time safety (no typos)
+- Refactoring support
+- IntelliSense/autocomplete
+- No capitalization errors
+
+**Nested properties:**
+```csharp
+dataSourcePath = new PropertyPath($"{nameof(PlayerData)}.{nameof(PlayerData.Health)}.{nameof(HealthData.Current)}")
+```
+
+### Explicit Binding Element
+
+```xml
+<UXML xmlns:ui="UnityEngine.UIElements" xmlns:engine="UnityEngine.UIElements">
+    <Slider name="volume-slider">
+        <Bindings>
+            <engine:DataBinding
+                property="value"
+                data-source-path="MasterVolume"
+                binding-mode="TwoWay"/>
+        </Bindings>
+    </Slider>
+</UXML>
+```
+
+The datasource can be set in the root VisualElement like:
+```xml
+    <ui:VisualElement name="root" data-source="project://database/Assets/Scripts/PlayerData.asset?fileID=11400000&amp;guid=976f7b99fc1424923aee5b5657723366&amp;type=2#PlayerData" class="root">
+```
+This is so that UIBuilder can also read the datasource and preview the binding and control.
+
+```csharp
+private void OnEnable()
+{
+    var root = GetComponent<UIDocument>().rootVisualElement;
+    root.dataSource = m_Settings;
+}
+```
+
+## C# SetBinding (Programmatic)
+
+### Basic Pattern
+
+```csharp
+using UnityEngine;
+using UnityEngine.UIElements;
+
+[RequireComponent(typeof(UIDocument))]
+public class HealthBarController : MonoBehaviour
+{
+    [SerializeField] private HealthData m_HealthData;
+    private Label m_HealthLabel;
+    private ProgressBar m_HealthBar;
+
+    private void OnEnable()
+    {
+        var root = GetComponent<UIDocument>().rootVisualElement;
+        m_HealthLabel = root.Q<Label>("health-label");
+        m_HealthBar = root.Q<ProgressBar>("health-bar");
+
+        m_HealthLabel.SetBinding("text", new DataBinding
+        {
+            dataSourcePath = new PropertyPath(nameof(HealthData.HealthText))
+        });
+
+        m_HealthBar.SetBinding("value", new DataBinding
+        {
+            dataSourcePath = new PropertyPath(nameof(HealthData.HealthPercentage))
+        });
+
+        m_HealthLabel.dataSource = m_HealthData;
+        m_HealthBar.dataSource = m_HealthData;
+    }
+
+    private void OnDisable()
+    {
+        if (m_HealthLabel?.HasBinding("text") == true)
+            m_HealthLabel.ClearBinding("text");
+        if (m_HealthBar?.HasBinding("value") == true)
+            m_HealthBar.ClearBinding("value");
+    }
+}
+```
+
+### Binding Modes
+
+```csharp
+element.SetBinding("text", new DataBinding
+{
+    dataSourcePath = new PropertyPath(nameof(Data.Score)),
+    bindingMode = BindingMode.ToTarget
+});
+
+slider.SetBinding("value", new DataBinding
+{
+    dataSourcePath = new PropertyPath(nameof(Settings.MasterVolume)),
+    bindingMode = BindingMode.TwoWay
+});
+```
+
+**Modes:**
+- `ToTarget` - Data → UI (read-only, default)
+- `ToSource` - UI → Data (write-only, rare)
+- `TwoWay` - Data ↔ UI (input fields)
+
+### Runtime-Created Elements
+
+```csharp
+var label = new Label();
+label.SetBinding("text", new DataBinding
+{
+    dataSourcePath = new PropertyPath(nameof(PlayerData.Name))
+});
+label.dataSource = m_PlayerData;
+parentElement.Add(label);
+```
+
+## PanelRenderer with Bindings
+
+**Unity 6.6+ only** - `PanelRenderer` is a new UI Toolkit runtime component.
+
+**Use `PanelRenderer` instead of `UIDocument` for runtime UI with bindings.**
+
+`PanelRenderer` provides `RegisterUIReloadCallback` which ensures bindings are properly re-established if the UI reloads.
+
+### PanelRenderer Controller
+
+```csharp
+using Unity.Properties;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+public class StatsController : MonoBehaviour
+{
+    [SerializeField] private MyStats m_Stats;
+    private ScriptableObject m_LoadedData;
+
+    private void Awake()
+    {
+        m_LoadedData = ScriptableObject.Instantiate(m_Stats);
+    }
+
+    private void OnEnable()
+    {
+        GetComponent<PanelRenderer>().RegisterUIReloadCallback(OnUIReload);
+    }
+
+    private void OnUIReload(PanelRenderer panelRenderer, VisualElement rootElement)
+    {
+        var hpLabel = rootElement.Q("hpLabel");
+        var mpLabel = rootElement.Q("mpLabel");
+
+        rootElement.dataSource = m_LoadedData;
+
+        hpLabel.SetBinding("text", new DataBinding
+        {
+            dataSourcePath = new PropertyPath(nameof(MyStats.HP))
+        });
+
+        mpLabel.SetBinding("text", new DataBinding
+        {
+            dataSourcePath = new PropertyPath(nameof(MyStats.MP))
+        });
+    }
+}
+```
+
+**Key benefits:**
+- Callback handles UI reload events automatically
+- Bindings re-established if UI is reloaded
+- Cleaner than manual OnEnable setup
+- Works with ScriptableObject data sources

--- a/skills/ui-uitk/references/uss-guide.md
+++ b/skills/ui-uitk/references/uss-guide.md
@@ -1,0 +1,138 @@
+# USS Patterns and Examples
+
+## Table of Contents
+
+- [Design Tokens](#design-tokens)
+- [Transitions](#transitions)
+- [Pseudo-State Tinting](#pseudo-state-tinting)
+- [Text Wrapping](#text-wrapping)
+- [9-Slice Backgrounds](#9-slice-backgrounds)
+- [Child vs Descendant Selectors](#child-vs-descendant-selectors)
+- [Specificity](#specificity)
+
+## Design Tokens
+
+Use `:root` variables for repeated values:
+
+```uss
+:root {
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --color-primary: #4da3ff;
+  --color-bg-dark: #1a1a1a;
+  --color-text: #ffffff;
+}
+
+.container {
+  padding: var(--spacing-md);
+  background-color: var(--color-bg-dark);
+  color: var(--color-text);
+}
+
+.button {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-primary);
+}
+```
+
+## Transitions
+
+Define transition properties on the **base class**, not on `:hover`. Otherwise hover-out won't animate.
+
+```uss
+/* CORRECT */
+.button {
+  background-color: #4da3ff;
+  transition-duration: 0.2s;
+}
+.button:hover {
+  background-color: #6db3ff;
+}
+
+/* WRONG - transition on :hover won't animate out */
+.button {
+  background-color: #4da3ff;
+}
+.button:hover {
+  background-color: #6db3ff;
+  transition-duration: 0.2s;
+}
+```
+
+## Pseudo-State Tinting
+
+Prefer tinting one image instead of creating multiple image variants:
+
+```uss
+.button {
+  background-image: url("project://database/Assets/UI/Textures/button-bg.png");
+}
+
+.button:hover {
+  -unity-background-image-tint-color: rgba(255, 255, 255, 0.15);
+}
+
+.button:active {
+  -unity-background-image-tint-color: rgba(0, 0, 0, 0.2);
+}
+
+.button:disabled {
+  -unity-background-image-tint-color: rgba(128, 128, 128, 0.5);
+}
+```
+
+## Text Wrapping
+
+Labels don't wrap by default. Enable wrapping explicitly:
+
+```uss
+.description-text {
+  white-space: normal;
+  overflow: visible;
+}
+```
+
+## 9-Slice Backgrounds
+
+For scalable backgrounds that stretch without distorting edges:
+
+```uss
+.panel-background {
+  background-image: url("project://database/Assets/UI/Textures/panel-bg.png");
+  -unity-slice-left: 12;
+  -unity-slice-top: 12;
+  -unity-slice-right: 12;
+  -unity-slice-bottom: 12;
+  -unity-slice-scale: 1;
+}
+```
+
+Slice values define the non-stretched border regions in pixels.
+
+## Child vs Descendant Selectors
+
+Prefer child selectors for performance:
+
+```uss
+/* BETTER - child selector */
+.panel > .header > .title { }
+
+/* AVOID - descendant selector (slower) */
+.panel .header .title { }
+```
+
+## Specificity
+
+More specific selectors override less specific ones. If your styles aren't applying, check for conflicting selectors:
+
+```uss
+/* Less specific */
+.button { color: white; }
+
+/* More specific - wins */
+.panel .button { color: black; }
+
+/* Even more specific - wins */
+.panel > .content > .button { color: red; }
+```

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui
-description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Supports importing design data from Figma projects as part of the UI creation pipeline. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
+description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
 ---
 
 Determine the appropriate UI system for the project and route to the correct specialized skill.
@@ -89,7 +89,7 @@ Route all types to the appropriate specialized skill based on the UI system.
 - **Understands**, **edits**, and **generates** EditorWindow, inspectors, PropertyDrawers built with OnGUI
 - Not for runtime game UI — for new editor tools, use UI Toolkit unless the project already uses IMGUI exclusively
 
-### Figma design import — not available in this plugin
+### Figma design import — not available here
 
 Importing a Figma design requires Unity's Figma integration service, which only exists
 inside Unity AI Assistant. There is no client-side equivalent, so do not promise it.

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ui
+description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Supports importing design data from Figma projects as part of the UI creation pipeline. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
+---
+
+Determine the appropriate UI system for the project and route to the correct specialized skill.
+
+## When to Route vs Answer Directly
+
+**Route to a specialized skill when:**
+- User wants to understand, edit, or generate specific UI elements
+- User references specific files or UI objects
+- User asks for UI changes or creation
+
+**Answer directly (without routing) when:**
+- User asks comparative/educational questions ("What's the difference between UI Toolkit and uGUI?")
+- User asks about UI system capabilities or recommendations ("Should I use UITK or uGUI for mobile?")
+- User needs conceptual explanation of Unity UI architecture
+
+## Routing Logic
+
+**Step 1: Check for explicit file references or keywords:**
+
+| User mentions | Route to |
+|---------------|----------|
+| `.uxml` or `.uss` files (including in `/Editor/`) | `ui-uitk` |
+| "UI Toolkit", "UITK", "UIElements", "CreateGUI" | `ui-uitk` |
+| Canvas prefabs/objects, `.prefab` with UI | `ui-ugui` |
+| "uGUI", "Canvas", "RectTransform", "legacy UI" | `ui-ugui` |
+| "IMGUI", "OnGUI", "OnInspectorGUI", "immediate mode" | `ui-imgui` |
+| Figma URL (`figma.com/design/...`), "Figma", "import from Figma" | Not available — see below |
+
+**For editor-related requests (EditorWindow, custom inspector, PropertyDrawer):**
+- If no explicit UI system mentioned → **Go to Step 2** to detect project's editor UI system
+- If no existing pattern is detected, default to `ui-uitk` for new editor UI
+- Only use `ui-imgui` if project exclusively uses IMGUI or user explicitly requests it
+
+If explicit file or keywords found, activate the corresponding skill immediately.
+
+**Step 2: If ambiguous, detect from project:**
+
+Search the project to determine which UI system is in use:
+
+| Look for | Indicates |
+|----------|-----------|
+| `.uxml` or `.uss` files (including in `/Editor/`) | UI Toolkit (runtime or editor) |
+| `UIDocument` components in scenes | UI Toolkit (runtime) |
+| Editor scripts with `CreateGUI()` method | UI Toolkit (editor) |
+| `Canvas` in scenes/prefabs | uGUI |
+| `RectTransform` heavy usage | uGUI |
+| Editor scripts with `OnGUI()` or `OnInspectorGUI()` | IMGUI (legacy editor) |
+
+**Step 3: If still unclear, ask or default:**
+
+- For existing projects: detect and follow whichever framework is already in use (Step 2)
+- For new projects with no UI yet: ask the user which framework they prefer (UI Toolkit vs uGUI), briefly explaining that UI Toolkit is modern/CSS-like while uGUI is Canvas-based/mature
+- For new runtime/game UI where the user has no preference: default to uGUI (`ui-ugui`)
+- When the user mentions mobile/performance constraints or older Unity versions (pre-6.0): bias toward uGUI (`ui-ugui`)
+
+## Request Types
+
+Specialized skills handle three types of requests:
+
+| Type | Examples |
+|------|----------|
+| **Understanding** | "What does this button do?", "How is this laid out?", "Explain this UI" |
+| **Editing** | "Change this color", "Add a label here", "Fix this layout" |
+| **Generation** | "Create a menu", "Make an inventory screen", "Build a settings panel" |
+
+Route all types to the appropriate specialized skill based on the UI system.
+
+## Available Sub-Skills
+
+### UI Toolkit — `ui-uitk`
+- For Unity 6.0+ projects using UI Toolkit (runtime game UI and editor tools)
+- **Understands**, **edits**, and **generates** `.uxml` and `.uss` files
+- Modern, CSS-like styling approach
+- Preferred for new editor windows (CreateGUI) and existing UI Toolkit projects
+
+### uGUI — `ui-ugui`
+- For projects using Unity's Canvas-based UI system
+- **Understands**, **edits**, and **generates** Canvas hierarchies
+- Uses Layout Groups for responsive design
+- Default for new runtime/game UI when the user has no framework preference
+
+### IMGUI — `ui-imgui`
+- For legacy editor tools using OnGUI/immediate mode
+- Only use when project has existing IMGUI editor code or user explicitly requests IMGUI
+- **Understands**, **edits**, and **generates** EditorWindow, inspectors, PropertyDrawers built with OnGUI
+- Not for runtime game UI — for new editor tools, use UI Toolkit unless the project already uses IMGUI exclusively
+
+### Figma design import — not available in this plugin
+
+Importing a Figma design requires Unity's Figma integration service, which only exists
+inside Unity AI Assistant. There is no client-side equivalent, so do not promise it.
+
+If the user brings a Figma URL, say the automated import is not available here and offer
+the alternative: ask them to describe or screenshot the screen, then build it with the
+appropriate framework skill above.
+
+## Common Guidelines (All UI Systems)
+
+### Scope Discipline
+
+**Do only what is requested:**
+- Question → answer without making changes
+- Targeted edit → modify only what's specified
+- Generation → create only requested files
+- Don't proactively add scripts unless explicitly asked
+
+**These do NOT imply scripts:**
+- "proper buttons" → well-styled buttons
+- "working UI" → valid UI that renders
+- "menu screen" → visual layout only
+
+### Conventions
+
+**Follow project patterns first.** Search existing files before applying defaults.
+
+| Type | Convention |
+|------|------------|
+| Element names | Follow project patterns, or camelCase |
+| File organization | Match existing project structure |
+
+### Workflow
+
+1. **Determine UI system** — Use routing logic above
+   - For Figma requests, tell the user the automated import is not available here, then
+     work from their description or screenshot and continue with framework detection
+2. **Activate specialized skill** — Route to `ui-uitk`, `ui-ugui`, or `ui-imgui`
+3. **Skill handles request** — Understanding, editing, or generation as appropriate
+
+## Handling Mixed Projects
+
+Many Unity projects use multiple UI systems simultaneously (e.g., UI Toolkit for runtime game UI plus editor tools). When you detect multiple systems:
+
+- **For runtime UI requests** (menus, HUDs, game screens) → Route to whichever runtime system (UITK or uGUI) is already in use
+- **For editor tool requests** (custom inspectors, editor windows):
+  - **Prefer UI Toolkit** (CreateGUI) for new editor UI — it's the modern approach
+  - Only use IMGUI if the project's existing editor tools use IMGUI exclusively, or user explicitly requests IMGUI
+  - Check for existing editor `.uxml` files to confirm UITK usage
+- **If creating new runtime UI in a mixed project** → Match the pattern used by similar existing UI; if there is no similar existing UI and the user has no preference, use uGUI


### PR DESCRIPTION
Adds Unity's UI skills — a router plus one skill per UI system. First of several batches. Grouped by domain rather than one skill per PR, so each batch lands with a natural reviewer — per the relaxation in #40.

## What this adds

| Skill | Covers |
|---|---|
| `ui` | Entry point — detects which UI system a project uses and routes to one of the three below |
| `ui-uitk` | UI Toolkit — UXML and USS authoring, flex layout, custom elements, Painter2D, runtime binding |
| `ui-ugui` | uGUI — Canvas hierarchies, RectTransform anchoring, Layout Groups, prefab UI |
| `ui-imgui` | IMGUI editor tooling — EditorWindows, custom Inspectors, PropertyDrawers |

## Changes made to the original content

These skills were written for an agent host that has its own Editor-side tooling and its own command namespace. Everything depending on either has been rewritten so the skills work on any host. Per skill:

| Skill | What changed |
|---|---|
| `ui` | 15 references to skills written as host-specific slash commands (`/<plugin>:<skill>`) now reference the skills by name. The routing table and section headings read `ui-uitk` rather than a command form, so the skill doesn't assume the host exposes skills as commands at all — some don't. |
| `ui-uitk` | Removed a call to a host-only UXML/USS validator; the skill now writes the files and asks the user to check the Unity Console, which is where import errors surface. Also fixed two reference links that pointed at `references/pointermanipulator-guide` without the `.md` and never resolved. |
| `ui-ugui` | Two mentions of host-specific tooling rewritten — a `ReadSkillResource` call became a plain instruction to read the reference file, and a warning about a modal dialog no longer names the tool it blocks. One `scripts/logic` changed to `scripts or logic` so it doesn't read as a path. |
| `ui-imgui` | **Body unchanged.** |

**Frontmatter,** all four: added `name` per `CONTRIBUTING.md`, matching the folder. Removed keys that are only meaningful to one host (`tools`, `modes`, `enabled`) and a `metadata` block whose contents no host reads.

**Descriptions are unchanged.** They're already tuned as triggers against real usage, and per the guidance added in #40 I haven't rewritten them to match the `Use when …` shape.

## Verification

- Every relative `references/` path in all four skills resolves to a file in the same skill folder
- No host-specific tool names remain in any body
- No slash-command references remain, so nothing assumes a particular host's command syntax
- `name` matches the folder name in all four
- Each skill was exercised against a real Unity 6 project and triggers from a plain description of the task
