### PR TITLE
fix(ui-uitk): strip hidden U+FE0F and link orphaned reference files

### DIFF
--- a/skills/ui-ugui/SKILL.md
+++ b/skills/ui-ugui/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
 Understand existing Unity uGUI, make targeted edits, and generate new Canvas-based hierarchies.
 
 When working with ScrollRect/ScrollView, read the reference file:
-- `references/scrollview-setup.md` — Required hierarchy, setup rules, and common failures
+- [references/scrollview-setup.md](references/scrollview-setup.md) — Required hierarchy, setup rules, and common failures
 
 ## Scope
 

--- a/skills/ui-uitk/SKILL.md
+++ b/skills/ui-uitk/SKILL.md
@@ -14,13 +14,13 @@ Understand existing Unity UI Toolkit code, make targeted edits, generate new UXM
 ## References
 
 Read these as needed:
-- `references/uss-guide.md` — USS patterns and examples
-- `references/svg-icons.md` — SVG icon generation (only when generating icons)
-- `references/common-issues.md` — Common mistakes to avoid
-- `references/ui-runtime-binding.md` — Patterns and guide to bind data to UI at runtime (only when requested or when bindings are involved)
-- `references/painter2d.md` — Painter2D API for custom visuals: gradients, shapes, arcs, procedural drawing (read this whenever gradients, custom shapes, progress rings, procedural drawing, or any visual beyond what USS can express is needed)
-- `references/pointermanipulator-guide.md` — Patterns and guide to create and use Manipulators (only when requested or when manipulators are involved). This helps with setting up drag and drop features or simple event handling for a Visual Element.
-- `references/custom-elements.md` — Custom UI Element patterns and guide to create reusable components with UXML, USS, and C#. This helps with creating complex UI components for reuse across the project.
+- [references/uss-guide.md](references/uss-guide.md) — USS patterns and examples
+- [references/svg-icons.md](references/svg-icons.md) — SVG icon generation (only when generating icons)
+- [references/common-issues.md](references/common-issues.md) — Common mistakes to avoid
+- [references/ui-runtime-binding.md](references/ui-runtime-binding.md) — Patterns and guide to bind data to UI at runtime (only when requested or when bindings are involved)
+- [references/painter2d.md](references/painter2d.md) — Painter2D API for custom visuals: gradients, shapes, arcs, procedural drawing (read this whenever gradients, custom shapes, progress rings, procedural drawing, or any visual beyond what USS can express is needed)
+- [references/pointermanipulator-guide.md](references/pointermanipulator-guide.md) — Patterns and guide to create and use Manipulators (only when requested or when manipulators are involved). This helps with setting up drag and drop features or simple event handling for a Visual Element.
+- [references/custom-elements.md](references/custom-elements.md) — Custom UI Element patterns and guide to create reusable components with UXML, USS, and C#. This helps with creating complex UI components for reuse across the project.
 
 Paths are relative to this skill's folder — read `references/uss-guide.md` directly.
 

--- a/skills/ui-uitk/references/custom-elements.md
+++ b/skills/ui-uitk/references/custom-elements.md
@@ -17,7 +17,7 @@ Guide for creating custom VisualElements using Unity 6+ `[UxmlElement]` and `[Ux
 
 Unity 6+ uses attribute-based custom elements. The old factory pattern (`IUxmlFactory`, `UxmlTraits`) is **deprecated**.
 
-### ⚠️ CRITICAL: Namespace Declaration
+### ⚠ CRITICAL: Namespace Declaration
 
 **Never include assembly names in UXML namespace declarations:**
 


### PR DESCRIPTION
## What

Two related documentation-hygiene fixes in the UI skills. Grouped into one PR since both are validator findings from the same run and the diff is nine lines; CONTRIBUTING allows batching related skills when noted.

### 1. Hidden Unicode (the error)

The skills.sh Snyk W021 audit flagged `SEC_HIDDEN_UNICODE` in `ui-uitk`:

```
✗ ui-uitk
  ERROR [SEC_HIDDEN_UNICODE] references/custom-elements.md:20 — hidden/invisible character U+FE0F
```

A `U+FE0F` variation selector trailed the warning glyph in the heading on line 20. It is stripped; the visible `U+26A0` glyph is kept, so the heading still renders as `### ⚠ CRITICAL: Namespace Declaration`. That bare form is already how the rest of the repo writes the glyph (see `levelplay-unity-integration/references/best-practices.md`).

A scan of every `.md`/`.json`/`.yaml`/`.txt` file in the repo for variation selectors, BOM, zero-width, bidi-control and soft-hyphen characters confirms this was the only occurrence, and that the tree is now clean.

### 2. Orphaned reference files (the warnings)

The same run reported eight `REF_ORPHAN` warnings — seven in `ui-uitk`, one in `ui-ugui`.

The files were not actually undocumented: both SKILL.md files listed them, but as backticked paths rather than markdown links. The validator strips inline code before collecting link targets, so a backticked path never counts as a link and the reference reads as unreachable.

Converted the reference-list entries to markdown links. This matches `ui-imgui`, which already uses the linked form, and mirrors the same conversion made for `levelplay-unity-integration` in #38. Inline prose mentions elsewhere in the body are left as backticks, also matching `ui-imgui`.

**No reference files were added, removed, or renamed.**

## Verification

```
node scripts/checks/validate-skills.mjs skills --profile hub
```

Before → after for the two affected skills:

| Skill | Before | After |
|---|---|---|
| `ui-uitk` | 1 error, 7 warnings | ✓ clean |
| `ui-ugui` | 0 errors, 1 warning | ✓ clean |

## Note for reviewers

The same validator run reports a pre-existing `HUB_LEAK` error in `unity-cli/SECURITY.md:21` on `main`. It is unrelated to this change and is already addressed on the in-flight `unity-cli/safe-mode-recovery-and-install-accuracy` branch, so it is deliberately untouched here.