### PR TITLE
fix: strip XML-like tags from two skill descriptions

### DIFF
--- a/skills/new-unity-project/SKILL.md
+++ b/skills/new-unity-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-unity-project
-description: Use when starting a brand-new Unity game or project from scratch — "make/start/create a new game", "bootstrap a Unity project", "I want to build a <genre> game", "scaffold/prototype a game", game jam, greenfield, blank project, project setup. A guided flow that gathers the concept, target platforms, and monetization, installs the Editor in the background while it asks, then creates the project and source control and installs packages — delegating the mechanics to the unity-cli and unity-package-management skills and handing off monetization to the dedicated skills. Does not scaffold gameplay code.
+description: Use when starting a brand-new Unity game or project from scratch — "make/start/create a new game", "bootstrap a Unity project", "I want to build a [genre] game", "scaffold/prototype a game", game jam, greenfield, blank project, project setup. A guided flow that gathers the concept, target platforms, and monetization, installs the Editor in the background while it asks, then creates the project and source control and installs packages — delegating the mechanics to the unity-cli and unity-package-management skills and handing off monetization to the dedicated skills. Does not scaffold gameplay code.
 allowed-tools:
   - Bash
   - Read

--- a/skills/unity-package-management/SKILL.md
+++ b/skills/unity-package-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-package-management
-description: Use when adding, removing, upgrading, or discovering Unity (UPM) packages programmatically from outside the Editor — headless or CI package installs via the C# UnityEditor.PackageManager.Client API, verifying package ids/versions against the Unity registry, or choosing which packages a game needs by genre, platform, and monetization. The Unity CLI does not manage UPM packages, so this skill covers that gap. Triggers on "install a Unity package", "add com.unity.*", "set up packages headless/CI", "which packages for a <genre> game".
+description: Use when adding, removing, upgrading, or discovering Unity (UPM) packages programmatically from outside the Editor — headless or CI package installs via the C# UnityEditor.PackageManager.Client API, verifying package ids/versions against the Unity registry, or choosing which packages a game needs by genre, platform, and monetization. The Unity CLI does not manage UPM packages, so this skill covers that gap. Triggers on "install a Unity package", "add com.unity.*", "set up packages headless/CI", "which packages for a [genre] game".
 allowed-tools:
   - Bash
   - Read


### PR DESCRIPTION
## What

Replaces `<genre>` with `[genre]` in the `description:` lines of the `new-unity-project` and `unity-package-management` skills.

## Why

The Claude Desktop plugin catalog rejects SKILL.md descriptions that contain XML tags (`plugin_upload_skill_md_description_contains_xml`), which blocked these two skills from syncing in the plugin's last update. The plugin copies are fixed in Unity-Technologies/unity-agent-plugin#32; this keeps the source copies here in sync so the tag doesn't reappear on the next mirror.

These are the only two `SKILL.md` descriptions in the repo containing a `<...>` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)