### PR TITLE
chore: align six skills with the plugin copy

### DIFF
--- a/skills/build-live-game/SKILL.md
+++ b/skills/build-live-game/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: build-live-game
 description: Build and operate a live game using Unity Services. Use when the user needs to implement, connect, or debug backend-driven features — battle passes, achievements, player progression, cloud saves, leaderboards, matchmaking, virtual economies, server-authoritative logic, anti-cheat, player accounts and authentication, remote configuration, feature flags, A/B testing, analytics, or cloud resource deployment. Triggers on live-ops, live service, backend, server authority, cloud code, cloud save, remote config, player data, retention, monetization loop, season pass, ranking, multiplayer sessions, lobbies, or any Unity Services integration.
-enabled: true
 ---
 
 # Build a Live Game With Unity Gaming Services

--- a/skills/setup-multiplayer-services/SKILL.md
+++ b/skills/setup-multiplayer-services/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Guides the development of online multiplayer experiences where players connect, group, and interact in real-time using Unity Multiplayer Services.
   Use when the user asks for topology choice, player grouping, hosting, matchmaking, discovery, network setup,
   and session-based play (rooms, parties, lobbies) using the Unity Multiplayer Services APIs.
+  Not for leaderboards, cloud saves, or backend features that involve no real-time connection
+  between players; those belong to the build-live-game skill.
 ---
 
 # Multiplayer SDK (Unity Multiplayer Services)

--- a/skills/ui-imgui/SKILL.md
+++ b/skills/ui-imgui/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: ui-imgui
-description: Unity IMGUI (Immediate Mode GUI) expert for legacy editor tools using OnGUI/immediate mode. Generates and modifies IMGUI EditorWindows, custom Inspectors, PropertyDrawers, and scripts with IMGUI code (OnGUI, OnInspectorGUI). Use when maintaining existing IMGUI editor code or when user explicitly requests IMGUI/OnGUI.
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
+description: Unity IMGUI (Immediate Mode GUI) expert for legacy editor tools using OnGUI/immediate mode. Generates and modifies IMGUI EditorWindows, custom Inspectors, PropertyDrawers, and scripts with IMGUI code (OnGUI, OnInspectorGUI). Use when maintaining existing IMGUI editor code or when user explicitly requests IMGUI/OnGUI. Do not use for NEW editor windows or tools: new editor UI defaults to UI Toolkit (ui-uitk) unless the project already uses IMGUI exclusively or the user asks for OnGUI by name.
 ---
 
 **Before proceeding:** If the user is asking about creating a **new** editor window, custom inspector, or PropertyDrawer without explicitly mentioning IMGUI/OnGUI, recommend using UI Toolkit (CreateGUI) instead, as it's the modern approach. Only proceed with IMGUI if:

--- a/skills/ui-ugui/SKILL.md
+++ b/skills/ui-ugui/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: ui-ugui
 description: Unity uGUI (Canvas-based) UI expert. Understands, edits, and generates Canvas hierarchies, RectTransforms, Layout Groups, and prefab UI. Use for requests involving Canvas, uGUI, RectTransform, or .prefab UI files.
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
 ---
 
 Understand existing Unity uGUI, make targeted edits, and generate new Canvas-based hierarchies.

--- a/skills/ui-uitk/SKILL.md
+++ b/skills/ui-uitk/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: ui-uitk
 description: Unity UI Toolkit expert for Unity 6.0+. Understands, edits, and generates UXML and USS files with flex-based layouts. Use for requests involving .uxml, .uss, UI Toolkit, UIElements, UIDocument, UI runtime binding, Custom UI Elements, Manipulators or PanelSettings.
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Glob
-  - Grep
 ---
 
 Understand existing Unity UI Toolkit code, make targeted edits, generate new UXML/USS files, Manipulators, and handle UI runtime binding.

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui
-description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Routes to UI Toolkit, uGUI, or IMGUI based on project context.
+description: Unity UI expert for menus, HUDs, screens, panels, buttons, labels, and all visual interface elements. Handles questions about UI in scenes or prefabs (how many elements, what exists, structure analysis), styling changes (colors, borders, backgrounds, fonts, spacing, rounded corners), layout adjustments, and UI generation. Routes to UI Toolkit, uGUI, or IMGUI based on project context. Use for ANY request to build, edit, or understand game UI (menus, HUDs, settings or pause screens) when no framework is named: consult this skill to detect which UI system the project uses before writing any UI code, even for a request that looks simple enough to build directly.
 ---
 
 Determine the appropriate UI system for the project and route to the correct specialized skill.


### PR DESCRIPTION
## What

Brings six `SKILL.md` files into agreement with the copy that ships in the plugin. After this, all six are byte-identical between the two repos.

| Skill | Change |
|---|---|
| `build-live-game` | drops `enabled: true` from the frontmatter |
| `setup-multiplayer-services` | adds two lines scoping the skill away from leaderboards and cloud saves, pointing at `build-live-game` instead |
| `ui` | adopts the longer description, which tells the model to consult the router even for a request that looks simple enough to build directly |
| `ui-imgui` | adopts the longer description, which says new editor UI defaults to UI Toolkit; also drops `allowed-tools` |
| `ui-ugui` | drops `allowed-tools` |
| `ui-uitk` | drops `allowed-tools` |

## Why

**The description and scoping changes** came out of a round of trigger tuning and were applied to the plugin's copies but never here. They are the difference between a skill firing on the right prompts and a UI request landing on the wrong framework.

**`enabled: true`** is read by the internal assistant, not by any agent consuming this repo. It has no meaning here.

**`allowed-tools`** withholds every tool not on its list, including Bash, for the whole duration of the skill. That is not what these three skills want: a UI task frequently needs to drive the Editor, and there is no reason to take that away. Two further points against keeping it as written: the field is specified as a space-separated string rather than a YAML list, so this form may not be doing anything at all; and the plugin has shipped all three without it, so the restriction is not load-bearing.

## How To Test/Validate

The diff is six files. To confirm the two copies now agree, compare against the plugin repo:

```
for s in build-live-game setup-multiplayer-services ui ui-imgui ui-ugui ui-uitk; do
  diff <(curl -sL "https://raw.githubusercontent.com/Unity-Technologies/unity-agent-plugin/main/skills/$s/SKILL.md") \
       "skills/$s/SKILL.md" && echo "identical: $s"
done
```

## Scope

Frontmatter and description only. No procedural content, no reference files, no code samples changed.
