### PR TITLE
fix: scope AssetDatabase.FindAssets, and persist scene edits in the URP templates

### DIFF
--- a/skills/audio-setup-mixers/references/api.md
+++ b/skills/audio-setup-mixers/references/api.md
@@ -33,8 +33,13 @@ All snippets below are written for `unity command eval --code '<snippet>'`: full
 ## Inventory the project's mixers and their groups
 
 ```csharp
-var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
-if (guids.Length == 0) { return "no AudioMixer assets in this project"; }
+// Scope the search to Assets. Unscoped, FindAssets also walks read-only packages, so the
+// inventory fills up with mixers the user did not author and cannot edit. Measured on one
+// project: t:Material returned 81 unscoped against 9 under Assets, t:Shader 204 against 22.
+// The only overloads are (string) and (string, string[] searchInFolders) — there is no
+// SearchMode parameter.
+var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer", new[] { "Assets" });
+if (guids.Length == 0) { return "no AudioMixer assets under Assets/"; }
 
 var rows = new System.Collections.Generic.List<string>();
 foreach (var guid in guids)

--- a/skills/manage-sprite-atlas/references/common-errors.md
+++ b/skills/manage-sprite-atlas/references/common-errors.md
@@ -10,7 +10,7 @@ This document covers invalid V2 patterns, API corrections, and common mistakes t
   - [❌ SetMasterAtlasPath() - Method Does Not Exist](#-setmasteratlaspath---method-does-not-exist)
   - [⚠️ Platform-Specific Format Limitations](#️-platform-specific-format-limitations)
   - [⚠️ PackAtlases() Requires Runtime SpriteAtlas[]](#️-packatlases-requires-runtime-spriteatlas)
-  - [⚠️ AssetDatabase.FindAssets() Requires 2 Arguments](#️-assetdatabasefindassets-requires-2-arguments)
+  - [⚠️ Always scope AssetDatabase.FindAssets to the folders you mean](#️-always-scope-assetdatabasefindassets-to-the-folders-you-mean)
   - [⚠️ AssetImporter.GetAtPath() Takes Single Argument](#️-assetimportergetatpath-takes-single-argument)
 
 ## Invalid V2 Patterns (Do Not Use)
@@ -84,22 +84,33 @@ variant.SetMasterAtlas(masterRuntime);
 SpriteAtlasUtility.PackAtlases(atlasAssets, ...);
 
 // ✅ CORRECT - Load runtime SpriteAtlases first
-SpriteAtlas[] atlases = AssetDatabase.FindAssets("t:SpriteAtlas", SearchMode.AllAssets)
+SpriteAtlas[] atlases = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { "Assets" })
     .Select(g => AssetDatabase.LoadAssetAtPath<SpriteAtlas>(AssetDatabase.GUIDToAssetPath(g)))
     .Where(a => a != null)
     .ToArray();
 SpriteAtlasUtility.PackAtlases(atlases, EditorUserBuildSettings.activeBuildTarget, false);
 ```
 
-### ⚠️ AssetDatabase.FindAssets() Requires 2 Arguments
+### ⚠️ Always scope AssetDatabase.FindAssets to the folders you mean
 
 ```csharp
-// ❌ WRONG - Missing SearchMode argument
+// ❌ WRONG - does not compile. There is no SearchMode overload.
+string[] guids = AssetDatabase.FindAssets("t:SpriteAtlas", SearchMode.AllAssets);
+
+// ❌ RISKY - compiles, but searches the WHOLE project including read-only packages
 string[] guids = AssetDatabase.FindAssets("t:SpriteAtlas");
 
-// ✅ CORRECT - Two arguments only
-string[] guids = AssetDatabase.FindAssets("t:SpriteAtlas", SearchMode.AllAssets);
+// ✅ CORRECT - the second parameter is string[] searchInFolders
+string[] guids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { "Assets" });
 ```
+
+`AssetDatabase.FindAssets` has exactly two overloads, `FindAssets(string filter)` and
+`FindAssets(string filter, string[] searchInFolders)`. Verified on Unity 6000.5.8f1.
+
+Scoping matters because an unscoped search reaches into `Packages/`, and those assets are usually
+read-only. Measured on a real project: an unscoped `t:Scene` search returned 20 scenes where the
+project itself has 1, and all 19 extras were package test fixtures. A batch operation that then
+writes to what it found will fail, or worse, target assets it must not modify.
 
 ### ⚠️ AssetImporter.GetAtPath() Takes Single Argument
 

--- a/skills/manage-sprite-atlas/resources/dontpackinruntimebuilds.cs
+++ b/skills/manage-sprite-atlas/resources/dontpackinruntimebuilds.cs
@@ -63,7 +63,7 @@ public static class DontPackInRuntimeBuildsDocumentation
             public void OnPreprocessBuild(BuildTarget target, string path)
             {
                 // Find and pack all atlases before build
-                string[] guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset");
+                string[] guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset", new[] { "Assets" });
                 var atlases = new SpriteAtlasAsset[guids.Length];
 
                 for (int i = 0; i < guids.Length; i++)

--- a/skills/manage-sprite-atlas/resources/migratev1tov2.cs
+++ b/skills/manage-sprite-atlas/resources/migratev1tov2.cs
@@ -256,7 +256,7 @@ public static class BuildScriptMigrationExample
         public static void BuildGame()
         {
             // Step 1: Generate/update atlases (V2)
-            string[] guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset");
+            string[] guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset", new[] { "Assets" });
             foreach (string guid in guids)
             {
                 string path = AssetDatabase.GUIDToAssetPath(guid);

--- a/skills/manage-sprite-atlas/resources/updatebuildscripts.cs
+++ b/skills/manage-sprite-atlas/resources/updatebuildscripts.cs
@@ -35,7 +35,7 @@ public static class UpdateBuildScriptsDocumentation
         public static void BuildGame()
         {
             // Manually pack atlases
-            var guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset");
+            var guids = AssetDatabase.FindAssets("t:SpriteAtlasAsset", new[] { "Assets" });
             var atlases = new SpriteAtlas[guids.Length];
             for (int i = 0; i < guids.Length; i++)
             {

--- a/skills/optimize-audio/resources/audio-import-api.md
+++ b/skills/optimize-audio/resources/audio-import-api.md
@@ -140,7 +140,10 @@ An `AudioMixer` is a project asset, not a scene object, so it is found through t
 rather than a scene query.
 
 ```csharp
-var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer");
+// Scope to Assets. Unscoped, FindAssets also walks read-only packages and reports mixers the
+// user did not author. The second parameter is string[] searchInFolders; there is no SearchMode
+// overload. Measured on one project: t:Material returned 81 unscoped against 9 under Assets.
+var guids = UnityEditor.AssetDatabase.FindAssets("t:AudioMixer", new[] { "Assets" });
 var paths = System.Linq.Enumerable.Select(guids, UnityEditor.AssetDatabase.GUIDToAssetPath);
 return $"count={guids.Length}: {string.Join(", ", paths)}";
 ```

--- a/skills/urp-postprocessing/references/code-templates.md
+++ b/skills/urp-postprocessing/references/code-templates.md
@@ -56,21 +56,47 @@ if (!cam.TryGetComponent<UnityEngine.Rendering.Universal.UniversalAdditionalCame
 UnityEditor.Undo.RecordObject(data, "Enable Post-Processing");
 data.renderPostProcessing = true;
 UnityEditor.EditorUtility.SetDirty(data);
-return $"Post-processing enabled on '{cam.name}'.";
+
+// This edits a component, which lives in the scene rather than in an asset, so
+// AssetDatabase.SaveAssets() does not persist it. SetDirty only marks; nothing is written until
+// the scene is saved. Mark the scene and say it is unsaved, rather than reporting the change as
+// done: if the session ends without a scene save, the edit is gone.
+var scene = data.gameObject.scene;
+UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(scene);
+return $"Post-processing enabled on '{cam.name}'. Scene '{scene.name}' is modified but NOT saved. "
+     + "Save it, or the change is lost when the Editor session ends.";
 ```
+
+The right choice depends on whether anyone is watching:
+
+- **Interactive run** (the user is at the Editor): report and let them save. A save from here also
+  commits whatever else they had in progress in that scene, which is not yours to decide.
+- **Non-interactive run** (batch, CI, or a session that is about to end): call
+  `UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scene)` and say that you saved it.
+  Nobody is there to act on a "scene is unsaved" report, so leaving it unsaved just loses the work.
 
 ### Modifying an Existing Volume Profile
 
+**Use `sharedProfile`, not `profile`.** `profile` auto-clones the asset into a runtime instance, so
+`SetDirty` on it marks a clone that is not an asset at all and the edit can never reach disk. Merely
+reading `volume.profile` is enough to trigger the clone, so the null check has to use `sharedProfile`
+too. `sharedProfile` returns the asset itself, which is what an Editor-time edit needs.
+
 ```csharp
 var volumeObj = UnityEngine.GameObject.Find("Global Volume");
-if (volumeObj != null && volumeObj.TryGetComponent<UnityEngine.Rendering.Volume>(out var volume) && volume.profile != null)
+if (volumeObj != null && volumeObj.TryGetComponent<UnityEngine.Rendering.Volume>(out var volume)
+    && volume.sharedProfile != null)
 {
-    if (volume.profile.TryGet<UnityEngine.Rendering.Universal.Bloom>(out var bloom))
+    var profile = volume.sharedProfile;
+    if (profile.TryGet<UnityEngine.Rendering.Universal.Bloom>(out var bloom))
     {
         bloom.intensity.overrideState = true;
         bloom.intensity.value = 2f;
     }
-    UnityEditor.EditorUtility.SetDirty(volume.profile);
+    UnityEditor.EditorUtility.SetDirty(profile);
+    // SetDirty only marks the asset. Without this the edit is in memory only: it reads back
+    // correctly for the rest of the session and is lost when the session ends.
+    UnityEditor.AssetDatabase.SaveAssets();
 }
 ```
 
@@ -94,6 +120,11 @@ UnityEditor.Undo.RegisterCompleteObjectUndo(target, "Set up post-processing");  
 // UnityEditor.Undo.RegisterCreatedObjectUndo(newObject, "Set up post-processing");
 UnityEditor.EditorUtility.SetDirty(target);
 
+// SetDirty marks; it does not write. Persist according to what `target` is, or the change is
+// lost at session end even though every read-back looks correct:
+//   an asset (Volume Profile, URP Asset)  -> UnityEditor.AssetDatabase.SaveAssets();
+//   a component in a scene                -> MarkSceneDirty(target.gameObject.scene) and tell
+//                                            the user the scene needs saving
 UnityEditor.Undo.FlushUndoRecordObjects();         // force the snapshot out now
 UnityEditor.Undo.CollapseUndoOperations(group);    // one entry, not several
 


### PR DESCRIPTION
## What

Adopts the plugin repo's version of seven reference and resource files, across four skills. After this, all four are byte-identical between the two repos.

## Why

**Six files search too widely.** `AssetDatabase.FindAssets("t:X")` with no folder argument walks read-only packages as well as the project, so an inventory fills up with assets the user did not author and cannot edit. Measured on one project: `t:Material` returned 81 unscoped against 9 under `Assets`, `t:Shader` 204 against 22. All six now pass `new[] { "Assets" }`.

**One of them documents an API that does not exist.** `manage-sprite-atlas/references/common-errors.md` has a section headed "AssetDatabase.FindAssets() Requires 2 Arguments" whose sample passes `SearchMode.AllAssets` and whose ❌ example is labelled "Missing SearchMode argument". There is no `SearchMode` overload — the second parameter is `string[] searchInFolders` — so the sample does not compile, and a page of common errors is teaching one. The section is retitled and corrected.

**The seventh fixes two ways a URP edit is reported as done and then lost.**

- Enabling post-processing writes to a component, which lives in the scene rather than in an asset, so `AssetDatabase.SaveAssets()` does not persist it. The template now marks the scene dirty and says the scene is unsaved, instead of reporting success, with separate guidance for an interactive run and a batch one.
- Editing an existing Volume Profile through `volume.profile` auto-clones the asset into a runtime instance, so `SetDirty` marks a clone that is not an asset and the edit can never reach disk. Merely *reading* `profile` triggers the clone, so the null check has to change too. The template now uses `sharedProfile` throughout.

## How To Test/Validate

The Volume Profile one is the most worth seeing, because it fails silently. In an Editor, edit a profile through `volume.profile`, read the value back in the same session (it looks correct), then restart the Editor and read again — the change is gone. Repeat with `sharedProfile` and it persists.

## Scope

Reference and resource files only. No `SKILL.md`, no frontmatter, no change to any skill's trigger or description.
