### PR TITLE
fix: adopt the plugin's copies of optimize-web, localization and IAP

### DIFF
--- a/skills/implement-in-app-purchases/SKILL.md
+++ b/skills/implement-in-app-purchases/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: implement-in-app-purchases
 description: Implement, configure, and debug Unity In-App Purchases (IAP) — store connection, product catalog, consumable/non-consumable/subscription purchases, two-step pending-confirm flow, receipt validation, entitlement checking, restore transactions, Apple extensions (promotional purchases, Ask-to-Buy, code redemption), and Google Play extensions (subscription upgrade/downgrade), D2C Capabilities(direct to customer), 3rd party payment provider (Stripe/Coda) via Unity IAP/Unity Cloud. Use when the user needs to add, modify, debug, or migrate from native Android/iOS billing, 3rd party packages(RevenueCat/Adapty/Essential Kit/Unipay supported) to IAP. Triggers on microtransactions (MTX), monetization, real-money purchases, store purchases, buying items, support D2C, purchase via Stripe/Coda, migrate from native billing(Google's BillingClient or Apple's StoreKit/SKPaymentQueue/SKProduct)/RevenueCat/Adapty/EssentialKit/Unipay.
-modes: [agent, ask]
 ---
 
 # Unity In-App Purchasing

--- a/skills/implement-in-app-purchases/references/api-notes.md
+++ b/skills/implement-in-app-purchases/references/api-notes.md
@@ -22,7 +22,7 @@
 - [Failure Description Property Names](#failure-description-property-names)
 - [CrossPlatformValidator](#crossplatformvalidator)
 - [Interface Hierarchy](#interface-hierarchy)
-- [IRunCommand Template: Fetch Products](#iruncommand-template-fetch-products)
+- [Template: Fetch Products](#template-fetch-products)
 
 ## Anti-Hallucination: v5 vs Legacy API
 
@@ -222,7 +222,7 @@ Product coinsPack = store.GetProductById("com.mygame.coins100");
 
 ### CatalogListings and uSku (v5.4+)
 
-In v5.4, `Product` exposes two new members. Prefer these for new code — `product.definition.id` remains backwards compatible but points new users toward `CatalogListings`:
+In v5.4, `Product` exposes two new members. Prefer these for new code — `product.definition.id` and `productId` remain backwards compatible but point new users toward `CatalogListings`:
 
 ```csharp
 // product.uSku — the Unity-side identifier for the product (cross-platform canonical ID)
@@ -518,45 +518,42 @@ StoreController implements:
   IPurchaseService   - PurchaseProduct(), ConfirmPurchase(), FetchPurchases(), Apple/Google purchase extensions
 ```
 
-## IRunCommand Template: Fetch Products
+## Template: Fetch Products
 
 ```csharp
 using UnityEngine;
 using UnityEngine.Purchasing;
 using System.Collections.Generic;
 
-namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor
+public static class FetchProductsExample
 {
-    internal class CommandScript : IRunCommand
+    // Store callbacks arrive after Connect() returns, so this reports through the
+    // Editor console rather than a return value.
+    public static async void Run()
     {
-        public string Title => "Fetch IAP products";
-        public string Description => "Connects to the store and fetches product information.";
-        public async void Execute(ExecutionResult result)
+        var store = UnityIAPServices.StoreController();
+
+        // Subscribe to events BEFORE Connect
+        store.OnStoreConnected += () =>
         {
-            var store = UnityIAPServices.StoreController();
-
-            // Subscribe to events BEFORE Connect
-            store.OnStoreConnected += () =>
+            var products = new List<ProductDefinition>
             {
-                var products = new List<ProductDefinition>
-                {
-                    new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
-                    new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
-                };
-
-                store.OnProductsFetched += (fetched) =>
-                {
-                    foreach (var p in fetched)
-                        result.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
-                };
-                store.OnProductsFetchFailed += (failure) => result.LogError($"Product fetch failed: {failure.FailureReason}");
-
-                store.FetchProducts(products);
+                new ProductDefinition("com.mygame.coins100", ProductType.Consumable),
+                new ProductDefinition("com.mygame.removeads", ProductType.NonConsumable)
             };
-            store.OnStoreDisconnected += (failure) => result.LogError($"Store disconnected: {failure.Message}");
 
-            await store.Connect();
-        }
+            store.OnProductsFetched += (fetched) =>
+            {
+                foreach (var p in fetched)
+                    Debug.Log($"{p.definition.id}: {p.metadata.localizedPriceString}");
+            };
+            store.OnProductsFetchFailed += (failure) => Debug.LogError($"Product fetch failed: {failure.FailureReason}");
+
+            store.FetchProducts(products);
+        };
+        store.OnStoreDisconnected += (failure) => Debug.LogError($"Store disconnected: {failure.Message}");
+
+        await store.Connect();
     }
 }
 ```

--- a/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
+++ b/skills/implement-in-app-purchases/references/path-convert-native-google-billing.md
@@ -115,7 +115,7 @@ Generate all 18 sections. Do not skip any.
 9. **Non-consumable acknowledgement behavior mapping** — native `acknowledgePurchase` → Unity IAP `ConfirmPurchase` (only after grant)
 10. **Subscription behavior mapping** — detected subscription products, restore path, renewal handling
 11. **Google-specific features detected** — list each (see Blocker Detection below)
-12. **Unity IAP 5.2 migration blockers** — features that cannot be cleanly mapped
+12. **Unity IAP 5.x migration blockers** — features that cannot be cleanly mapped
 13. **Proposed new Unity IAP architecture** — new files and their roles
 14. **Code files to create** — with paths
 15. **Code files to modify** — with nature of each change

--- a/skills/implement-in-app-purchases/references/path-implement-iap-d2c.md
+++ b/skills/implement-in-app-purchases/references/path-implement-iap-d2c.md
@@ -273,6 +273,17 @@ Do not call `StoreController(PaymentProvider.Name)` before the player is authent
 
 **Anonymous sign-in warning:** Do not use anonymous sign-in as the authentication method for D2C purchases. Anonymous sign-in does not persist purchases after the session token is lost — if the player reinstalls the app or clears app data, their purchase history becomes unrecoverable. Use a persistent identity method (e.g., Unity Authentication with a linked account, or your own identity provider).
 
+### Payment provider services on the StoreController
+
+The `StoreController` (scoped to `PaymentProvider.Name`) exposes the payment-provider APIs through **two** properties. Use the exact property names below — do not substitute the interface name for the property name, and do not use `PurchaseService.PaymentProviders` (that is a different entry point that returns the purchase-extended interface). Both properties are typed as nullable, but on a `PaymentProvider.Name`-scoped `StoreController` the factory always populates them — they are only `null` when reached from a `StoreController` scoped to another store (Apple / Google), where the payment-provider extensions do not apply. Guard with `?.` if the same code path could see either kind of controller.
+
+| StoreController property | Returns interface | Members used in this doc |
+| --- | --- | --- |
+| `store.PaymentProviderStoreExtendedService` | `IPaymentProvidersExtendedService` | `GetEligiblePaymentProviders`, `GetPaymentOptionProviderUGUI`, `GetPaymentOptionProviderUITK`, `SetCheckoutPresentationMode`, `SetWebshopPresentationMode`, `SetDeepLinkScheme` |
+| `store.PaymentProvidersExtendedPurchaseService` | `IPaymentProvidersExtendedPurchaseService` | `PurchaseProduct`, `RedirectToWebshop`, `GenerateURL`, `SetComplianceCheck`, `SetPaymentProviderOverride` |
+
+Note the naming asymmetry: the presentation-service property is singular (`PaymentProvider`**Store**`ExtendedService`) while the purchase-service property is plural (`PaymentProviders`**ExtendedPurchase**`Service`). This mirrors the Apple/Google split (`...ExtendedService` + `...ExtendedPurchaseService`).
+
 ### Coexistence with existing Apple / Google StoreController
 
 If the project already has a `StoreController` for Apple App Store or Google Play (standard IAP 5):
@@ -293,7 +304,14 @@ If the project already has a `StoreController` for Apple App Store or Google Pla
 Before initiating purchase, use `GetEligiblePaymentProviders()` to confirm that at least one payment provider is available for the current user and region. Call this after `Connect()` and `FetchProducts()` succeed:
 
 ```csharp
-var eligible = await store.PaymentProviderStoreExtendedService?.GetEligiblePaymentProviders();
+var svc = store.PaymentProviderStoreExtendedService;
+if (svc == null)
+{
+    // No payment provider service — hide purchase UI or show an error
+    return;
+}
+
+var eligible = await svc.GetEligiblePaymentProviders();
 if (eligible == null || eligible.Providers.Count == 0)
 {
     // No payment providers available — hide purchase UI or show an error
@@ -328,7 +346,8 @@ Then initiate purchase with the `catalogListingId`:
 ```csharp
 public async void Buy(string catalogListingId)
 {
-    var eligibility = await store.PaymentProviderStoreExtendedService?.GetEligiblePaymentProviders();
+    var svc = store.PaymentProviderStoreExtendedService;
+    var eligibility = svc != null ? await svc.GetEligiblePaymentProviders() : null;
     if (eligibility?.Providers.Count > 0)
     {
         // Show the Purchase Options UI — lets the player pick native, D2C, or webshop
@@ -476,8 +495,14 @@ Returns `null` when the product wasn't fetched through the PaymentProvider store
 Skip the picker entirely and open the webshop for a specific listing (or the generic Unity webshop when `catalogListingId` is null):
 
 ```csharp
-await store.PaymentProvidersExtendedPurchaseService?
-    .RedirectToWebshop("coins_100_offer_usd");
+var svc = store.PaymentProvidersExtendedPurchaseService;
+if (svc == null)
+{
+    // No payment provider purchase service — surface an error or hide the entry point
+    return;
+}
+
+await svc.RedirectToWebshop("coins_100_offer_usd");
 ```
 
 The SDK fetches the webshop URL, runs the registered compliance callback (`SetComplianceCheck`), and opens the URL on approval. Network failures propagate as exceptions on the returned `Task`; compliance rejection routes through the standard `OnPurchaseFailed` path.
@@ -575,7 +600,7 @@ Purchase handling follows the same save-before-confirm contract as standard IAP 
 
 IAP D2C Capabilities-specific notes:
 
-- **Checkout presentation mode:** By default, the payment flow opens in the device's external browser. Unity IAP 5.4 also supports an in-app WebView via `CheckoutPresentationMode`. Set the mode on `IPaymentProvidersExtendedService` before purchase:
+- **Checkout presentation mode:** By default, the payment flow opens in the device's external browser. Unity IAP 5.4 also supports an in-app WebView via `CheckoutPresentationMode`. Set the mode before purchase via `store.PaymentProviderStoreExtendedService` (the `IPaymentProvidersExtendedService` accessor — see "Payment provider services on the StoreController" above):
 
   ```csharp
   // External browser (default)
@@ -586,6 +611,16 @@ IAP D2C Capabilities-specific notes:
   ```
 
   When using `ExternalBrowser`, the game is suspended during payment and resumes via the deep link redirect. When using `WebView`, the game remains active and the WebView is dismissed on completion. `OnPurchasePending` fires in both cases after the payment is processed.
+
+- **Webshop presentation mode:** `RedirectToWebshop` uses a **separate** `SetWebshopPresentationMode` setter — it is independent of `SetCheckoutPresentationMode` (verified by `PaymentProviderImplTests.TestWebshopModeIsIndependentOfCheckoutMode`). Setting the checkout mode to `WebView` does **not** move the webshop flow into the in-app WebView; without an explicit webshop-mode call, `RedirectToWebshop` opens the external browser. Set it before invoking `RedirectToWebshop`:
+
+  ```csharp
+  // External browser (default)
+  store.PaymentProviderStoreExtendedService?.SetWebshopPresentationMode(CheckoutPresentationMode.ExternalBrowser);
+
+  // In-app WebView
+  store.PaymentProviderStoreExtendedService?.SetWebshopPresentationMode(CheckoutPresentationMode.WebView);
+  ```
 
 - `OnPurchaseDeferred` fires if the payment is not immediately completed. Do not grant — show pending UI.
 - Always confirm (`ConfirmPurchase`) only after entitlement is granted and saved. For consumables, Unity IAP D2C Capabilities prevents re-purchase until the previous order is confirmed.

--- a/skills/localization/SKILL.md
+++ b/skills/localization/SKILL.md
@@ -6,14 +6,35 @@ description: "Sets up and configures Unity Localization, including locales, Stri
 This guide covers setting up and configuring Unity Localization, including locales, String and Asset Tables, Addressables integration, and CJK font support via Asset Tables.
 
 ## 0. Package Installation Check
-Before doing anything else, verify that the Localization packages is installed. Many APIs in this skill will fail silently or throw confusing errors if the package isn't present.
-1. **Check:** Use `UnityEditor.PackageManager.Client.List(true)` to check for `com.unity.localization`.
-2. **Install:** If missing, use `Client.Add("com.unity.localization")`.
-3. **Wait:** Do not proceed until `Client.List` confirms installation.
+Before doing anything else, verify that the Localization package is installed. Many APIs in this skill
+will fail silently or throw confusing errors if the package isn't present.
+
+1. **Check by reading the project, not by asking the Package Manager.** Look for
+   `com.unity.localization` in **`Packages/packages-lock.json`**. That file records what Unity
+   actually resolved, it is plain JSON, and reading it needs no Editor and no async call.
+   (`Packages/manifest.json` only records what was *requested*, so check the lock file.)
+2. **Install if missing:** `UnityEditor.PackageManager.Client.Add("com.unity.localization")`.
+3. **Wait properly.** `Client.Add` and `Client.List` are **asynchronous**: they return a request that
+   is still `InProgress` when the call returns, so reading the result in the same statement tells you
+   nothing. Do not busy-wait on `IsCompleted` either; that blocks the main thread you are running on.
+   Instead, return after firing the install, then **poll `packages-lock.json` in a later call** until
+   the id appears. Installation also triggers a domain reload, so expect the first poll or two to
+   fail; a fresh install typically resolves in a few seconds.
+4. **Confirm the types are actually loaded** before using them, since the lock file can be written
+   before the assemblies are ready:
+   ```csharp
+   var t = System.Type.GetType(
+       "UnityEngine.Localization.Settings.LocalizationSettings, Unity.Localization");
+   return t != null ? "ready" : "not loaded yet";
+   ```
+   Only proceed once that returns `ready`.
 
 ## 1. Localization Settings & Locales
 If `LocalizationEditorSettings.ActiveLocalizationSettings` is null, you must find or create it:
-1. **Find:** Use `AssetDatabase.FindAssets("t:LocalizationSettings")`. If found, load the first one and assign it to `LocalizationEditorSettings.ActiveLocalizationSettings`.
+1. **Find:** Use `AssetDatabase.FindAssets("t:LocalizationSettings", new[] { "Assets" })`. If found, load the first one and assign it to `LocalizationEditorSettings.ActiveLocalizationSettings`.
+   - **Always pass the search folders.** An unscoped `FindAssets` searches the whole project including
+     read-only packages, so it can return an asset from a package and you end up pointing the project
+     at something you cannot edit. This applies to every `FindAssets` call in this skill.
 2. **Create:** If not found, create a new instance and save it to `Assets/Localization/LocalizationSettings.asset`. Use `ScriptableObject.CreateInstance<LocalizationSettings>()` followed by `AssetDatabase.CreateAsset()`.
 3. **Activate:** Set `LocalizationEditorSettings.ActiveLocalizationSettings = settings`.
 4. **Locales:** Ensure locales (en, fr, de, etc.) exist. Create them if missing and add them to settings using `LocalizationEditorSettings.AddLocale(locale)`.
@@ -37,7 +58,20 @@ After any modification (adding keys, updating values), notify the Editor so it c
 - **Always qualify names:** Use `UnityEngine.UI.Image`, `UnityEngine.UI.VerticalLayoutGroup`, `UnityEngine.UI.ScrollRect`, `UnityEngine.UI.Mask`, `UnityEngine.UI.CanvasScaler`, `UnityEngine.UI.GraphicRaycaster`, `UnityEngine.UI.ContentSizeFitter`, `UnityEngine.UI.LayoutRebuilder`, etc. 
 - `UnityEngine.UI` is both a namespace and a class container, so unqualified names produce `CS0118` (namespace used like a type). Full qualification avoids this entirely.
 - **Single Instance:** Always check `GameObject.Find("YourCanvasName")` and destroy the old one before creating a new one.
-- **No Debug Dropdown:** NEVER create a manual UI dropdown or debug menu to change the locale. The Localization package has a built-in way to do this properly (e.g., via the "Localization Scene Controls" window for previews).
+- **Locale switching: use the package, and keep preview and runtime separate.** These are two
+  different mechanisms, and conflating them is why locale switching often ends up hand-rolled.
+  - **To preview a locale while authoring**, use the **Localization Scene Controls** window
+    (`Window > Asset Management > Localization Scene Controls`). This is Editor-only. It is not a
+    runtime feature, so it is not the answer when the game itself needs a language setting.
+  - **To switch locale at runtime**, assign `LocalizationSettings.SelectedLocale`. That is the
+    supported entry point, and everything bound through `LocalizeStringEvent` updates from it.
+  - **To pin which locale the game starts in**, configure a startup locale selector on the
+    Localization Settings asset. `SpecificLocaleSelector` is the one that forces a chosen locale;
+    the default chain otherwise picks up the system language.
+  - **NEVER hand-roll locale state.** A real in-game language menu is fine and expected, as long as
+    it sets `SelectedLocale` and lets the package propagate the change. What is forbidden is a debug
+    dropdown or menu that tracks its own "current language" variable, swaps strings itself, or
+    reaches around the package, because nothing else in the project will follow it.
 
 ### **Localized String Events (Robust Binding)**
 - **Check Component Type:** Identify if the target is `TextMeshPro` or legacy `UnityEngine.UI.Text`.
@@ -56,6 +90,41 @@ After any modification (adding keys, updating values), notify the Editor so it c
 ## 4. Asian Language Font Support (CJK)
 Avoid TMP Fallback Fonts for CJK locales. Use **Asset Table Font Swapping** for each specific locale instead — fallbacks are unreliable and hard to debug when glyphs are missing.
 
+### Prerequisite: TMP Essential Resources must be imported
+
+**Check this before touching any TMP API.** In a project that has never imported them,
+`TMP_Settings.instance` is `null` and TMP calls fail with a bare
+`NullReferenceException` that names nothing useful. `TMP_FontAsset.CreateFontAsset` is one of them, so
+font creation dies on the first line with an error that looks like a bug in your code.
+
+```csharp
+// The check.
+var ready = TMPro.TMP_Settings.instance != null;
+```
+
+If it is not ready, import them **non-interactively**:
+
+```csharp
+// Do NOT use EditorApplication.ExecuteMenuItem("Window/TextMeshPro/Import TMP Essential Resources").
+// It returns true and then opens a dialog that waits for a human, so nothing gets imported and the
+// run appears to hang. Import the package directly instead.
+string package = null;
+var cache = System.IO.Path.GetFullPath(System.IO.Path.Combine(
+    UnityEngine.Application.dataPath, "..", "Library", "PackageCache"));
+foreach (var dir in System.IO.Directory.GetDirectories(cache))
+{
+    // TMP ships inside com.unity.ugui in Unity 6, and the folder name carries a version hash,
+    // so search for the file rather than hardcoding a path.
+    var candidate = System.IO.Path.Combine(dir, "Package Resources", "TMP Essential Resources.unitypackage");
+    if (System.IO.File.Exists(candidate)) { package = candidate; break; }
+}
+UnityEditor.AssetDatabase.ImportPackage(package, false);   // false = non-interactive
+```
+
+Then poll `TMP_Settings.instance != null` in a **later** call, the same way as the package check in
+Step 0, and only continue once it is non-null. Verified on Unity 6000.5.8f1: the non-interactive
+import completes in a few seconds and the assets land in `Assets/TextMesh Pro`.
+
 1. **Use locale-specific fonts:** Western fonts like Arial or Liberation Sans don't contain CJK glyphs, which results in "tofu" (square blocks). Always use a font designed for the target language:
    - For **Simplified Chinese (zh-Hans)**: Use `msyh.ttc` (Microsoft YaHei) or equivalent.
    - For **Japanese (ja)**: Use `msgothic.ttc` (MS Gothic) or equivalent.
@@ -65,8 +134,30 @@ Avoid TMP Fallback Fonts for CJK locales. Use **Asset Table Font Swapping** for 
 3. **Multi-Atlas & Dynamic:** CJK character sets are too large for static atlases; a single atlas will run out of space immediately.
    - `fontAsset.atlasPopulationMode = AtlasPopulationMode.Dynamic;`
    - `fontAsset.isMultiAtlasTexturesEnabled = true;`
-4. **Sub-Assets:** Save atlas and material as sub-assets, or they'll be lost on reimport: `AssetDatabase.AddObjectToAsset(fontAsset.atlasTexture, fontAsset);`. 
-    - Explicitly link the material's texture: `fontAsset.material.mainTexture = fontAsset.atlasTexture;` and set both as dirty before saving.
+4. **Sub-Assets:** add the atlas textures **and the material**. Adding only the texture is the usual
+   mistake, and the material then never reaches the file at all: measured on Unity 6000.5.8f1, a font
+   asset saved without the second call contains **zero** `Material` objects on disk, and one with it.
+   A material that exists only in memory is not part of the asset, so anything that loads the asset
+   fresh gets whatever TMP reconstructs rather than the material you configured, and any setting you
+   applied to it is silently gone.
+    ```csharp
+    // Every atlas texture, not just the first. Step 3 enabled multi-atlas, so there may be several.
+    foreach (var atlas in fontAsset.atlasTextures)
+    {
+        UnityEditor.AssetDatabase.AddObjectToAsset(atlas, fontAsset);
+    }
+    // The material too. Without this line it is not written into the asset.
+    UnityEditor.AssetDatabase.AddObjectToAsset(fontAsset.material, fontAsset);
+    ```
+    - Explicitly link the material's texture: `fontAsset.material.mainTexture = fontAsset.atlasTexture;`
+      and set the font asset, its material, and its textures dirty before saving. (`atlasTexture` is
+      the first entry of `atlasTextures`, which is what the primary material draws from, so this is
+      consistent with adding every texture above.)
+    - **Verify against the file, not against the object you are holding.** After
+      `AssetDatabase.SaveAssets()`, call `AssetDatabase.LoadAllAssetsAtPath(path)` and confirm a
+      `Material` is among the returned objects. Do not settle for `fontAsset.material != null`: that
+      stays true whether or not the material was saved, because TMP will hand back an in-memory one,
+      so it cannot tell a saved material from an unsaved one.
 5. **Addressables:** Every asset referenced in an Asset Table must be marked as Addressable. 
     - Do not reference assets inside a `Resources/` folder in an Asset Table. This causes `OperationException: Failed to load sub-asset` errors. If an asset is in `Resources/`, copy it to `Assets/Fonts/` or similar before making it Addressable.
     - If a font asset is deleted and recreated, the new GUID must be manually updated in the Asset Table and re-added to Addressables.
@@ -87,21 +178,134 @@ Before concluding any CJK localization task:
 ### Notes when translating an existing project
 - **Minimal Code Changes**: Never modify code unrelated to localization. Use a static helper class (e.g., `L10n`) to wrap `LocalizationSettings.StringDatabase.GetLocalizedString` for easy injection into existing scripts.
 - **Robust Mapping Strategy**: When mapping existing UI text to keys, sort keys by string length (descending) and match longest strings first. This prevents short strings (like "NO") from matching parts of longer sentences. Use case-insensitive matching where appropriate.
-- **Component Event Listeners**: When setting up `LocalizeStringEvent` via script, avoid `UnityEventTools.AddPersistentListener` as it often fails to set the dynamic mode (Mode 0) correctly. 
-Instead, use the **SerializedObject Pattern** described in Section 3 to explicitly set `m_MethodName` to `set_text` and `m_Mode` to `0`. Persistent listeners **MUST** point to a method on a `UnityEngine.Object`; lambdas will fail.
+- **Component Event Listeners**: wire `LocalizeStringEvent.OnUpdateString` with
+`UnityEventTools.AddPersistentListener`, passing a delegate built over the text component's public
+`text` setter. The setter has no C# method-group name, so build the delegate by name:
+`(UnityAction<string>)Delegate.CreateDelegate(typeof(UnityAction<string>), text, "set_text")`.
+That is reflection over a **public** member, which is fine. See
+[resources/L10nBatchProcessor.cs](resources/L10nBatchProcessor.cs) for the working version, including
+clearing any existing persistent listeners first so repeated runs don't stack duplicates.
+  - Do **not** write the persistent-call fields directly through `SerializedObject` (`m_MethodName`,
+    `m_Mode`, `m_PersistentCalls`). Those are private serialized names with no compatibility
+    guarantee, and it isn't necessary: `AddPersistentListener` with the delegate above produces the
+    same serialized call (target = the text component, method = `set_text`, mode = `EventDefined`).
+  - **You must then set the call state, or the label will not update in the Editor.**
+    `AddPersistentListener` leaves the call at `UnityEventCallState.RuntimeOnly`, so the binding is
+    correct but dormant outside Play mode: switching locale in the Editor changes nothing, and it
+    stays that way through a save and reload. Fix it with the public
+    `UnityEventBase.SetPersistentListenerState`:
+    ```csharp
+    UnityEventTools.AddPersistentListener(lse.OnUpdateString, setText);
+    var index = lse.OnUpdateString.GetPersistentEventCount() - 1;
+    lse.OnUpdateString.SetPersistentListenerState(
+        index, UnityEngine.Events.UnityEventCallState.EditorAndRuntime);
+    ```
+    Verified on Unity 6000.5.8f1: without the second call the listener does not fire in Edit mode
+    even after a prefab save and reload; with it the call state becomes `EditorAndRuntime` and the
+    text updates immediately.
+  - Persistent listeners **MUST** point to a method on a `UnityEngine.Object`; lambdas will fail.
+  - **Then confirm the binding is live, don't assume it.** Wiring that looks right in the Inspector
+    but does nothing is the characteristic failure of this step. All of the read-back you need is
+    public API on the event, so none of this requires touching serialized fields:
+
+    | Check | Call | Expect |
+    |---|---|---|
+    | Something was wired | `GetPersistentEventCount()` | `> 0` |
+    | It points at the text component | `GetPersistentTarget(i)`, `GetPersistentMethodName(i)` | the component, `set_text` |
+    | It will fire while authoring | `GetPersistentListenerState(i)` | `EditorAndRuntime` |
+    | It actually updates the label | `lEvent.RefreshString()` | the text value changes |
+
+    Do all four. A count above zero only proves something was wired, and a `RuntimeOnly` call fails
+    the last check while being perfectly correct for a build, so reading the state is what tells a
+    dormant binding apart from a broken one. A component that was added and configured but never
+    fires is worse than an unlocalized label, because it reads as done.
 - **Initialization & Refresh**: 
     - `LocalizationEditorSettings.CreateStringTableCollection` expects a **directory path** (e.g., `Assets/Localization`), not a full asset path.
     - Always call `lEvent.RefreshString()` after assigning a `LocalizedString` reference programmatically to update the UI immediately.
-    - Ensure keys are added to **all** tables in a collection (en, de, ja, etc.) to avoid "No translation found" errors.
+    - Keys must exist with a **non-empty value in every table** of a collection (en, de, ja, …). A key
+      that exists with an empty value is the common gap, and it is not silent: the package prints its
+      own "No translation found for …" text **into the game UI**, so the shipped screen shows a
+      developer message. Do not eyeball this. Run the completeness check below.
 - **Namespaces & Linq**: Always include `using System.Linq;` when searching collections and `using UnityEngine.Localization;` when working with locales or tables.
 - **Verification**: After modifying tables or addressables, run `AddressableAssetSettings.BuildPlayerContent()` and switch the Editor locale to verify changes. Check `LocalizationSettings.Instance` status after activation.
+
+### Table completeness check (run this before declaring the work done)
+
+Enumerating the tables answers "did every key get a value in every locale" mechanically, so a missing
+entry is found before anyone plays the game. Run it and report the output.
+
+```csharp
+var gaps = new System.Collections.Generic.List<string>();
+var checkedCount = 0;
+
+foreach (var col in UnityEditor.Localization.LocalizationEditorSettings.GetStringTableCollections())
+{
+    foreach (var key in col.SharedData.Entries)
+    {
+        foreach (var table in col.StringTables)
+        {
+            checkedCount++;
+            var entry = table.GetEntry(key.Id);
+            // A missing entry and a present-but-empty entry both show as untranslated in game.
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Value))
+            {
+                gaps.Add($"{col.TableCollectionName} / {table.LocaleIdentifier.Code} / {key.Key}");
+            }
+        }
+    }
+}
+
+// Zero entries is not a pass. It means no collections or no locales were found, so the check
+// examined nothing: report that distinctly instead of letting it read as success.
+if (checkedCount == 0)
+{
+    return "INCONCLUSIVE: no table entries found. Either no String Table Collection exists yet, "
+         + "or the collection has no locale tables. Fix that before trusting this check.";
+}
+
+return gaps.Count == 0
+    ? $"COMPLETE: {checkedCount} entries checked, no gaps"
+    : $"GAPS ({gaps.Count} of {checkedCount} checked):\n  " + string.Join("\n  ", gaps);
+```
+
+Verified on Unity 6000.5.8f1 against a table with one deliberately emptied `ja` value: it reports
+`GAPS 1 of 4` naming exactly that entry, `COMPLETE (4 checked)` once the value is filled, and
+`INCONCLUSIVE` in a project with no tables.
+
+**Report the gap list rather than resolving it silently.** Some gaps are decisions, not mistakes: a
+locale you were not asked to translate, or a key that is intentionally identical across languages.
+Filling those with the English text hides the decision. List them and let the user say which are
+intentional.
 - **Smart Strings**: Set up smart strings where needed. Inspect the context of each string by taking the entire UI it is on, and any scripts that affect it, into account. Set the context on the string table to ensure translations make sense.
 
 ## 6. Recommended Translation Strategy
 To efficiently translate an existing project, follow this multi-step workflow:
 
 1. **Extraction & Component Setup:**
-   - **Find all occurrences:** Scan all scenes and prefabs for strings in code and UI components (Legacy `UnityEngine.UI.Text`, `TextMeshPro`, buttons, etc.).
+   - **Find all occurrences. There are two separate hiding places, and scanning one misses the other.**
+     - **Authored text** sits on components in scenes and prefabs: legacy `UnityEngine.UI.Text` and
+       TextMeshPro (`TMP_Text`, the base of `TextMeshProUGUI` and `TextMeshPro`). Walk **both**
+       families. Measured on a real project: `FindObjectsByType<Text>` found 1 component while
+       `FindObjectsByType<TMP_Text>` found 13, so a legacy-only pass reports success having done
+       almost nothing.
+     - **Text composed in code** never appears on a component at edit time, so no scene walk can see
+       it. `scoreLabel.text = $"EXP {value}"` is invisible to every component-based scan and is the
+       string that survives a "finished" localization pass. Find it in the C# instead:
+       ```bash
+       # Assignments and SetText calls that carry a string literal.
+       grep -rnE '\.text\s*(=|\+=)\s*\$?"|SetText\(\s*\$?"' --include='*.cs' Assets/
+       ```
+       That pattern catches plain, interpolated, concatenated and `+=` forms plus `SetText`, and
+       deliberately does not match `label.text = someVariable` or `label.text = Localize("KEY")`
+       (nothing to extract at the first, already routed at the second). Its blind spot is a literal
+       held in a variable or const declared elsewhere; if the count looks low for the project, grep
+       that file's string literals too.
+   - **Report what you did not convert.** A composed string usually needs a smart string or a format
+     argument, which is a judgment call, and some are genuinely not worth localizing. Whichever you
+     choose, list every site the scan found alongside whether it was converted, and why not if it
+     wasn't. Reporting "localized 24 strings" while nine found sites went untouched is the failure
+     mode this list exists to prevent: the work looks finished and the gap only surfaces in a
+     screenshot from another locale.
    - **Shared Table:** Create a central String Table (e.g., `UIStrings`) with the base language and a "Context" column for each key to guide translators.
    - **Attach Components:** For every UI element found, attach a `LocalizeStringEvent` (for text) and a `LocalizedFont` helper (for font swapping).
    - **Validation:** Ensure these components are set up with persistent listeners (`EditorAndRuntime`) so they update in the Editor immediately when the locale changes.
@@ -127,6 +331,12 @@ To localize an entire project efficiently, use a batch processing script that ha
 > "This will open every scene in the project, attach `LocalizeStringEvent` components, and save all modified scenes. This cannot be undone automatically. Shall I proceed?"
 
 Only proceed once the user has confirmed. The batch processor template is in [resources/L10nBatchProcessor.cs](resources/L10nBatchProcessor.cs).
+
+It walks **both** `Text` and `TMP_Text`, and `LocalizeAll` **returns the labels it could not match**
+(as `scene :: object :: "text"`). Print that list. It is the whole point of the return value: a run
+that wires 20 labels and silently leaves 9 alone looks identical to a complete one otherwise. The
+list covers authored text only, so pair it with the code scan in Section 6 and the table completeness
+check in Section 5.
 
 ### **Technical Tips for Speed**
 - **Table References:** Use `TableReference` names (strings) instead of GUIDs — they are easier to read and maintain.

--- a/skills/localization/references/api-notes.md
+++ b/skills/localization/references/api-notes.md
@@ -18,6 +18,10 @@ string guid = AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(myAsset))
 var entry = table.GetEntry(sharedEntryId) ?? table.AddEntry(sharedEntryId, guid);
 entry.Guid = guid;
 EditorUtility.SetDirty(table);
+// SetDirty only marks the table. Without a save the entry reads back correctly for the rest of
+// the session and is gone when the Editor closes. See the save sequence in SKILL.md: dirty the
+// collection and its SharedData too, then save once at the end.
+AssetDatabase.SaveAssets();
 ```
 
 ## Common Namespace Conflicts (CS0118)

--- a/skills/localization/resources/L10nBatchProcessor.cs
+++ b/skills/localization/resources/L10nBatchProcessor.cs
@@ -6,54 +6,89 @@ using UnityEditor.Events;
 using UnityEngine.Events;
 using UnityEngine.Localization.Components;
 using System.Collections.Generic;
+using TMPro;
 
 /// <summary>
 /// Batch-processes all scenes in the project, attaching LocalizeStringEvent components
-/// to every Text element whose content matches a key in the provided mapping.
+/// to every text element whose content matches a key in the provided mapping.
+///
+/// Covers BOTH legacy UnityEngine.UI.Text and TextMeshPro (TMP_Text, which is the base of
+/// TextMeshProUGUI and TextMeshPro). Walking only one of the two is the usual mistake and it
+/// fails silently: measured on a real project, FindObjectsByType&lt;Text&gt; found 1 component
+/// while FindObjectsByType&lt;TMP_Text&gt; found 13, so a Text-only pass reports success having
+/// localized almost nothing.
 ///
 /// Only call LocalizeAll() after confirming with the user — it modifies and saves every scene.
+/// It also reports what it did NOT convert; see the return value of LocalizeHierarchy.
 /// </summary>
 public static class L10nBatchProcessor
 {
-    public static void LocalizeAll(Dictionary<string, string> mapping, string table)
+    /// <summary>Localizes every scene. Returns the labels that matched no mapping entry.</summary>
+    public static List<string> LocalizeAll(Dictionary<string, string> mapping, string table)
     {
-        string[] scenes = AssetDatabase.FindAssets("t:Scene");
+        var unmatched = new List<string>();
+
+        // Scope the search to Assets/. An unscoped FindAssets searches the whole project INCLUDING
+        // read-only packages, so it returns package test scenes and this loop then tries to open,
+        // dirty and save assets it must not touch. Measured on a real project: unscoped found 20
+        // scenes where the project has 1, and all 19 extras were inside read-only packages
+        // (com.unity.addressables test fixtures).
+        string[] scenes = AssetDatabase.FindAssets("t:Scene", new[] { "Assets" });
         foreach (var guid in scenes)
         {
             var path = AssetDatabase.GUIDToAssetPath(guid);
             var scene = EditorSceneManager.OpenScene(path, OpenSceneMode.Single);
-            LocalizeHierarchy(mapping, table);
+            unmatched.AddRange(LocalizeHierarchy(mapping, table, path));
             EditorSceneManager.MarkSceneDirty(scene);
             EditorSceneManager.SaveScene(scene);
         }
+        return unmatched;
     }
 
-    static void LocalizeHierarchy(Dictionary<string, string> mapping, string table)
+    /// <summary>
+    /// Wires the open scene. Returns "scene :: object :: text" for every label that was found
+    /// but matched no mapping entry, so partial coverage is reported rather than silent.
+    /// </summary>
+    static List<string> LocalizeHierarchy(
+        Dictionary<string, string> mapping, string table, string scenePath)
     {
-        var allText = Object.FindObjectsByType<Text>(FindObjectsInactive.Include, FindObjectsSortMode.None);
-        foreach (var text in allText)
+        var unmatched = new List<string>();
+
+        // Both component families. TMP_Text is abstract and covers TextMeshProUGUI and TextMeshPro.
+        var labels = new List<Component>();
+        labels.AddRange(Object.FindObjectsByType<Text>(
+            FindObjectsInactive.Include, FindObjectsSortMode.None));
+        labels.AddRange(Object.FindObjectsByType<TMP_Text>(
+            FindObjectsInactive.Include, FindObjectsSortMode.None));
+
+        foreach (var label in labels)
         {
+            // Read the current string from whichever family this component belongs to.
+            var current = label is Text legacy ? legacy.text : ((TMP_Text)label).text;
+            if (string.IsNullOrEmpty(current)) continue;
+
+            var matched = false;
             foreach (var kvp in mapping)
             {
-                if (!text.text.Contains(kvp.Key)) continue;
+                if (!current.Contains(kvp.Key)) continue;
 
-                var lse = text.gameObject.GetComponent<LocalizeStringEvent>()
-                    ?? text.gameObject.AddComponent<LocalizeStringEvent>();
+                var lse = label.gameObject.GetComponent<LocalizeStringEvent>()
+                    ?? label.gameObject.AddComponent<LocalizeStringEvent>();
                 lse.StringReference = new UnityEngine.Localization.LocalizedString(table, kvp.Value);
 
                 // Wire the listener through the public UnityEventTools API. The persistent-call
                 // fields could be written directly through SerializedObject instead, but those
-                // are private serialized names with no compatibility guarantee — and it isn't
-                // necessary. A delegate to Text's public `text` setter, handed to
-                // AddPersistentListener, serializes to exactly the same thing: target = the Text
-                // component, method = set_text, mode = EventDefined (dynamic), call state =
-                // EditorAndRuntime. Measured on Unity 6000.5.7f1.
+                // are private serialized names with no compatibility guarantee, and it isn't
+                // necessary. A delegate to the component's public `text` setter, handed to
+                // AddPersistentListener, produces the same serialized call: target = the
+                // component, method = set_text, mode = EventDefined (dynamic).
                 //
                 // The setter has no C# method-group name, so the delegate is built by name.
                 // That is reflection over a *public* member, which is fine; reaching for the
-                // private m_* fields would not be.
+                // private m_* fields would not be. `set_text` is public on both Text and
+                // TMP_Text, so the same call works for either target.
                 var setText = (UnityAction<string>)System.Delegate.CreateDelegate(
-                    typeof(UnityAction<string>), text, "set_text");
+                    typeof(UnityAction<string>), label, "set_text");
 
                 for (int i = lse.OnUpdateString.GetPersistentEventCount() - 1; i >= 0; i--)
                 {
@@ -61,9 +96,29 @@ public static class L10nBatchProcessor
                 }
                 UnityEventTools.AddPersistentListener(lse.OnUpdateString, setText);
 
+                // AddPersistentListener leaves the call at RuntimeOnly, which means the label does
+                // NOT update when the locale changes in the Editor: correct in a build, dormant
+                // while authoring, and it stays dormant through a save and reload. Set the state
+                // explicitly. SetPersistentListenerState is public API on UnityEventBase.
+                // Verified on Unity 6000.5.8f1: without this the listener never fires in Edit mode.
+                var callIndex = lse.OnUpdateString.GetPersistentEventCount() - 1;
+                lse.OnUpdateString.SetPersistentListenerState(
+                    callIndex, UnityEventCallState.EditorAndRuntime);
+
                 EditorUtility.SetDirty(lse);
+                matched = true;
                 break;
             }
+
+            // A label the mapping never covered is a coverage gap the caller has to see.
+            // Reporting "localized 12" while silently leaving 9 untouched is the failure mode
+            // this return value exists to prevent.
+            if (!matched)
+            {
+                unmatched.Add($"{scenePath} :: {label.gameObject.name} :: \"{current}\"");
+            }
         }
+
+        return unmatched;
     }
 }

--- a/skills/optimize-web/SKILL.md
+++ b/skills/optimize-web/SKILL.md
@@ -75,6 +75,14 @@ return string.Join("\n", w);
 installed. Read it in a separate call from the rest, and treat a resolution failure as "the Web
 module isn't installed" rather than as a bad snippet.
 
+**`codeOptimization` is the one setting here that does not live in the project file.** It persists to
+`Library/EditorUserBuildSettings.asset`, and `Library/` is gitignored by every standard Unity
+`.gitignore`, so this value is per-machine and does not travel: teammates and CI do not inherit it.
+Two consequences. Read it back through the API and do not look for it in
+`ProjectSettings/ProjectSettings.asset` — it is absent there even on a successful apply, so its
+absence is not a failure. And if the release build runs in CI, apply it there as a build step rather
+than assuming the repository carries it.
+
 ### Applying the settings
 
 Most of the writes in this skill are a single batch, and
@@ -89,6 +97,34 @@ UnityEditor.EditorApplication.ExecuteMenuItem("Tools/Apply Web Release Settings"
 
 Keep its `using` directives; they are correct in a file. For one-off changes — a single quality
 level, a frame-rate flip — an inline `eval` statement is fine.
+
+### Verify from disk, not from the objects you just wrote
+
+**Applying a setting and reading it back in the same session proves nothing.** Player Settings are
+in-memory objects until something saves them, so every read-back returns the value you just
+assigned whether or not it ever reached
+`ProjectSettings/ProjectSettings.asset`. A run that skips the save reports success, and when the
+Editor session ends the whole change is gone. This was observed, not theorised: a run applied
+everything, read back Brotli / High / None, said it was done, and the file on disk never changed.
+
+So after any write:
+
+1. **Save.** `UnityEditor.AssetDatabase.SaveAssets()`. `WebOptimizer.cs` now does this itself; an
+   inline `eval` write has to do it explicitly.
+2. **Read the values back and report them.** Not "applied successfully" but the actual values, so the
+   user can see what is stored. `WebOptimizer.cs` logs all nine.
+3. **For anything per-build-target, name the target you read.** Several of these settings exist once
+   per target, so a value can be correct for one target and unset for the one being built.
+
+The same trap exists on the file-editing route in reverse: a hand-edited
+`ProjectSettings.asset` reads back fine while the running Editor and the build still use the old
+value. Verifying after a save and a reimport is what catches both.
+
+**Do not try to reproduce this in batch mode.** A batch Editor invoked with `-quit` saves settings on
+exit, so an unsaved write persists anyway and the run looks correct. Both a saving and a non-saving
+version of the script pass under `-quit`. The bug only appears in a live Editor session, which is
+where it was found. Concluding from a green batch run that the save is unnecessary is the wrong
+conclusion from a test that cannot see the defect.
 
 ## 0. Pre-Flight
 

--- a/skills/optimize-web/resources/WebOptimizer.cs
+++ b/skills/optimize-web/resources/WebOptimizer.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEditor.Build;
+using UnityEngine;
 
 public class WebOptimizer
 {
@@ -17,5 +18,29 @@ public class WebOptimizer
         PlayerSettings.WebGL.wasm2023 = true;
         UnityEditor.WebGL.UserBuildSettings.codeOptimization =
             UnityEditor.WebGL.WasmCodeOptimization.DiskSizeLTO;
+
+        // Persist. Without this the settings are applied to the in-memory objects only: every
+        // read-back below returns the new value, the run reports success, and nothing reaches
+        // ProjectSettings/ProjectSettings.asset. When the Editor session ends the whole change
+        // is gone. Observed in testing, so it is not theoretical.
+        AssetDatabase.SaveAssets();
+
+        // Read back from the settings after saving and report what was actually stored. Assigning
+        // a property and assuming it took is the failure this method exists to demonstrate.
+        // Eight of the nine land in ProjectSettings/ProjectSettings.asset. codeOptimization is the
+        // exception: it persists to Library/EditorUserBuildSettings.asset, which is gitignored, so
+        // it is per-machine and absent from the project file even on success. Verify that one
+        // through this log, not by grepping ProjectSettings.asset, and re-apply it in CI.
+        Debug.Log(
+            "Web release settings applied and saved:\n"
+            + $"  il2cppCodeGeneration = {PlayerSettings.GetIl2CppCodeGeneration(target)}\n"
+            + $"  managedStrippingLevel = {PlayerSettings.GetManagedStrippingLevel(target)}\n"
+            + $"  stripUnusedMeshComponents = {PlayerSettings.stripUnusedMeshComponents}\n"
+            + $"  dataCaching = {PlayerSettings.WebGL.dataCaching}\n"
+            + $"  compressionFormat = {PlayerSettings.WebGL.compressionFormat}\n"
+            + $"  exceptionSupport = {PlayerSettings.WebGL.exceptionSupport}\n"
+            + $"  debugSymbolMode = {PlayerSettings.WebGL.debugSymbolMode}\n"
+            + $"  wasm2023 = {PlayerSettings.WebGL.wasm2023}\n"
+            + $"  codeOptimization = {UnityEditor.WebGL.UserBuildSettings.codeOptimization}");
     }
 }


### PR DESCRIPTION
## What

Adopts the plugin repo's version of nine files across `optimize-web`, `localization` and `implement-in-app-purchases`. After this, the first two are byte-identical between the two repos and the third differs only by its `README.md`, which is deliberately kept here.

## Why

Three classes of change.

**Edits reported as done and then lost.** `WebOptimizer.cs` applies nine Player Settings and never calls `AssetDatabase.SaveAssets()`. Every read-back in the same session returns the new value, the run reports success, and nothing reaches `ProjectSettings.asset`; when the Editor session ends the whole change is gone. Same shape in `localization/references/api-notes.md`, where a String Table entry is marked dirty without a save. `optimize-web/SKILL.md` also gains the note that `codeOptimization` is the one setting that persists to `Library/EditorUserBuildSettings.asset`, which is gitignored, so it is per-machine and its absence from the project file is not a failure.

**Silent failures.** `L10nBatchProcessor.cs` walked only `UnityEngine.UI.Text` and skipped TextMeshPro entirely. Measured on a real project: `FindObjectsByType<Text>` found 1 component while `FindObjectsByType<TMP_Text>` found 13, so the pass reported success having localized almost nothing. And `localization/SKILL.md`'s package check asked the Package Manager rather than reading `Packages/packages-lock.json`, which is what Unity actually resolved, is plain JSON, and needs no Editor and no async call.

**Internal-assistant leftovers that do not work outside it.** `implement-in-app-purchases/SKILL.md` carries a `modes: [agent, ask]` frontmatter field only the internal assistant reads. More seriously, its `references/api-notes.md` ships the Fetch Products template as an `IRunCommand` inside `namespace Unity.AI.Assistant.Agent.Dynamic.Extension.Editor`, logging through an `ExecutionResult`. None of those types exist for anyone consuming this repo, so the template cannot compile for its own audience. It becomes a plain `static class` using `Debug.Log`.

## How To Test/Validate

The `WebOptimizer.cs` one is the clearest to see, because it looks like it works. Run the old version in an Editor, read every setting back (all nine report the new value), then restart the Editor and read again — all nine are back to their previous values. Run the new version and they persist.

## Scope

No skill's trigger or description changes. `implement-in-app-purchases/README.md` is left alone.
